### PR TITLE
Fix issue 39: NPE when job is externally deleted

### DIFF
--- a/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
+++ b/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
@@ -271,7 +271,9 @@ public class ExecuteDslScripts extends Builder {
         for(GeneratedJob removedJob: removed) {
             AbstractProject removedProject = (AbstractProject) Jenkins.getInstance().getItem(removedJob.getJobName());
             // TODO Let user choose what to do
-            removedProject.disable(); // TODO deleteJob which is protected
+            if (removedProject != null) {
+                removedProject.disable(); // TODO deleteJob which is protected
+            }
         }
 
         // BuildAction is created with the result, we'll look at an aggregation of builds to know figure out our generated jobs


### PR DESCRIPTION
Hi,

Here is a fix for https://github.com/JavaPosseRoundup/job-dsl-plugin/issues/39 , it's a NPE that happens whenever we delete a created job from Jenkins screens and then re-run the job-dsl-plugin.

Reynald
