### PR TITLE
Reduce onChange logging level

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/MonitorTemplateJobs.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/MonitorTemplateJobs.java
@@ -34,7 +34,7 @@ public class MonitorTemplateJobs extends SaveableListener {
     @SuppressWarnings("rawtypes")
     @Override
     public void onChange(Saveable saveable, XmlFile file) {
-        LOGGER.info("onChange");
+        LOGGER.finest("onChange");
 
         if (!AbstractProject.class.isAssignableFrom(saveable.getClass())) {
             LOGGER.finest(String.format("%s is not a Project", saveable.getClass()));


### PR DESCRIPTION
Hi,

Here is a small change in order to reduce this verbose and frequent logging:

_Dec 2, 2012 6:25:42 AM javaposse.jobdsl.plugin.MonitorTemplateJobs onChange_
_INFO: onChange_

This is making my Jenkins huge file quite big, and those log entries are not very helpful.

I've switched the log level to finest, maybe we should consider completely removing it.

Best regards,
Reynald
