### PR TITLE
Adding junit archiving

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/PublisherContextHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/PublisherContextHelper.groovy
@@ -147,6 +147,37 @@ class PublisherContextHelper extends AbstractContextHelper<PublisherContext> {
         }
 
         /**
+         * Everything checked:
+         <hudson.tasks.junit.JUnitResultArchiver>
+             <testResults>build/test/*.xml</testResults> // Can be empty
+             <keepLongStdio>true</keepLongStdio>
+             <testDataPublishers> // Empty if no extra publishers
+                 <hudson.plugins.claim.ClaimTestDataPublisher/> // Allow claiming of failed tests
+                 <hudson.plugins.junitattachments.AttachmentPublisher/> // Publish test attachments
+             </testDataPublishers>
+         </hudson.tasks.junit.JUnitResultArchiver>
+         */
+        def archiveJunit(String glob, boolean retainLongStdout = false, boolean allowClaimingOfFailedTests = false, boolean publishTestAttachments = false) {
+            def nodeBuilder = new NodeBuilder()
+
+            Node archiverNode = nodeBuilder.'hudson.tasks.junit.JUnitResultArchiver' {
+                testResults glob
+                keepLongStdio retainLongStdout?'true':'false'
+                testDataPublishers {
+                    if (allowClaimingOfFailedTests) {
+                        'hudson.plugins.claim.ClaimTestDataPublisher' ''
+                    }
+                    if (publishTestAttachments) {
+                        'hudson.plugins.junitattachments.AttachmentPublisher' ''
+                    }
+                }
+            }
+
+            publisherNodes << archiverNode
+
+        }
+
+        /**
         <htmlpublisher.HtmlPublisher>
           <reportTargets>
             <htmlpublisher.HtmlPublisherTarget>

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/ScmContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/ScmContext.groovy
@@ -5,7 +5,6 @@ import groovy.transform.PackageScope
 import javaposse.jobdsl.dsl.WithXmlAction
 import hudson.plugins.perforce.PerforcePasswordEncryptor
 
-@PackageScope
 class ScmContext implements Context {
     boolean multiEnabled
     List<Node> scmNodes = []

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/PublisherHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/PublisherHelperSpec.groovy
@@ -98,6 +98,34 @@ public class PublisherHelperSpec extends Specification {
 
     }
 
+    def 'call junit archive with all args'() {
+        when:
+        context.archiveJunit('include/*', true, true, true)
+
+        then:
+        Node archiveNode = context.publisherNodes[0]
+        archiveNode.name() == 'hudson.tasks.junit.JUnitResultArchiver'
+        archiveNode.testResults[0].value() == 'include/*'
+        archiveNode.keepLongStdio[0].value() == 'true'
+        archiveNode.testDataPublishers[0].'hudson.plugins.claim.ClaimTestDataPublisher'[0] != null
+        archiveNode.testDataPublishers[0].'hudson.plugins.junitattachments.AttachmentPublisher'[0] != null
+    }
+
+
+    def 'call junit archive with minimal args'() {
+        when:
+        context.archiveJunit('include/*')
+
+        then:
+        Node archiveNode = context.publisherNodes[0]
+        archiveNode.name() == 'hudson.tasks.junit.JUnitResultArchiver'
+        archiveNode.testResults[0].value() == 'include/*'
+        archiveNode.keepLongStdio[0].value() == 'false'
+        archiveNode.testDataPublishers[0] != null
+        !archiveNode.testDataPublishers[0].children().any { it.name() == 'hudson.plugins.claim.ClaimTestDataPublisher' }
+        !archiveNode.testDataPublishers[0].children().any { it.name() == 'hudson.plugins.junitattachments.AttachmentPublisher' }
+    }
+
     def 'calling minimal html publisher'() {
         when:
         context.publishHtml {


### PR DESCRIPTION
Allows archiving of junit results.

(This is an interesting example of merging and pull requests. Once the ant pull request is accepted, this one will no longer be able to be merged cleaning from the UI, because it's stems from upstream/master which won't be the same once the ant request is merged.)
