### PR TITLE
Added a batchFile step for Windows-based jobs

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/StepContextHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/StepContextHelper.groovy
@@ -31,6 +31,18 @@ class StepContextHelper extends AbstractContextHelper<StepContext> {
         }
 
         /**
+         <hudson.tasks.BatchFile>
+             <command>echo Hello from Windows</command>
+         </hudson.tasks.BatchFile>
+         */
+        def batchFile(String commandStr) {
+            def nodeBuilder = new NodeBuilder()
+            stepNodes << nodeBuilder.'hudson.tasks.BatchFile' {
+                'command' commandStr
+            }
+        }
+
+        /**
          <hudson.plugins.gradle.Gradle>
              <description/>
              <switches>-Dtiming-multiple=5 -P${Status}=true -I ${WORKSPACE}/netflix-oss.gradle ${Option}</switches>

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/StepHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/StepHelperSpec.groovy
@@ -23,6 +23,18 @@ public class StepHelperSpec extends Specification {
         shellStep.command[0].value() == 'echo "Hello"'
     }
 
+    def 'call batchFile method'() {
+        when:
+        context.batchFile('echo "Hello from Windows"')
+
+        then:
+        context.stepNodes != null
+        context.stepNodes.size() == 1
+        def shellStep = context.stepNodes[0]
+        shellStep.name() == 'hudson.tasks.BatchFile'
+        shellStep.command[0].value() == 'echo "Hello from Windows"'
+    }
+
     def 'call gradle methods'() {
         when:
         context.gradle('build')


### PR DESCRIPTION
Pretty much as in the title. I wrote a test for it, which passes, and I made sure I could create a test job from this DSL:

``` groovy
job {
  name "batchFile-test"
  steps {
    batchFile("echo hello world")
  }
}
```

As an aside, the project structure you guys have for this with Gradle was an absolute joy to use. I cloned the repo, and had my new function working within an hour, despite having extremely minimal Groovy experience, and never having used Gradle before.
