### PR TITLE
Make it possible to forget generated jobs

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/Run.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/Run.java
@@ -18,7 +18,7 @@ public class Run {
         String scriptName = args[0];
 
         File cwd = new File(".");
-        ScriptRequest request = new ScriptRequest(scriptName, null, cwd.toURL());
+        ScriptRequest request = new ScriptRequest(scriptName, null, cwd.toURL(), false);
         FileJobManagement jm = new FileJobManagement(cwd);
         jm.getParameters().putAll(System.getenv());
         Set<GeneratedJob> generatedJobs = DslScriptLoader.runDslEngine(request, jm);

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -68,7 +68,7 @@ public class DslScriptLoader {
 
         LOGGER.log(Level.FINE, String.format("Ran script and got back %s", jp));
 
-        Set<GeneratedJob> generatedJobs = extractGeneratedJobs(jp);
+        Set<GeneratedJob> generatedJobs = extractGeneratedJobs(jp, scriptRequest.ignoreExisting);
         return generatedJobs;
 
     }
@@ -98,12 +98,12 @@ public class DslScriptLoader {
         LOGGER.log(Level.FINE, String.format("Ran script and got back %s", result));
         JobParent jp =  (JobParent) script;
 
-        Set<GeneratedJob> generatedJobs = extractGeneratedJobs(jp);
+        Set<GeneratedJob> generatedJobs = extractGeneratedJobs(jp, false);
 
         return generatedJobs;
     }
 
-    private static Set<GeneratedJob> extractGeneratedJobs(JobParent jp) {
+    private static Set<GeneratedJob> extractGeneratedJobs(JobParent jp, boolean ignoreExisting) {
         // Iterate jobs which were setup, save them, and convert to a serializable form
         Set<GeneratedJob> generatedJobs = Sets.newLinkedHashSet();
         if (jp != null) {
@@ -111,7 +111,7 @@ public class DslScriptLoader {
                 try {
                     String xml = job.getXml();
                     LOGGER.log(Level.FINE, String.format("Saving job %s as %s", job.getName(), xml));
-                    boolean created = jp.getJm().createOrUpdateConfig(job.getName(), xml);
+                    boolean created = jp.getJm().createOrUpdateConfig(job.getName(), xml, ignoreExisting);
                     GeneratedJob gj = new GeneratedJob(job.getTemplateName(), job.getName(), created);
                     generatedJobs.add(gj);
                 } catch( Exception e) {  // org.xml.sax.SAXException, java.io.IOException

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
@@ -34,7 +34,8 @@ class FileJobManagement extends AbstractJobManagement {
         }
     }
 
-    boolean createOrUpdateConfig(String jobName, String config) throws JobNameNotProvidedException, JobConfigurationMissingException {
+    boolean createOrUpdateConfig(String jobName, String config, boolean ignoreExisting)
+		throws JobNameNotProvidedException, JobConfigurationMissingException {
         validateUpdateArgs(jobName, config);
 
         new File(jobName + ext).write(config)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
@@ -20,10 +20,11 @@ public interface JobManagement {
      * Creates or updates the job config for the named Jenkins job with the config provided.
      * @param jobName the name of the new / updated job
      * @param config the new / updated job config
+	 * @param ignoreExisting do not update existing jobs
      * @throws JobNameNotProvidedException if the jobName is null or blank
      * @throws JobConfigurationMissingException if the config xml is null or blank
      */
-    boolean createOrUpdateConfig(String jobName, String config) throws JobNameNotProvidedException, JobConfigurationMissingException;
+    boolean createOrUpdateConfig(String jobName, String config, boolean ignoreExisting) throws JobNameNotProvidedException, JobConfigurationMissingException;
 
     /**
      * Stream to write to, for stdout.

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ScriptRequest.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ScriptRequest.java
@@ -3,10 +3,11 @@ package javaposse.jobdsl.dsl;
 import java.net.URL;
 
 public class ScriptRequest {
-    public ScriptRequest(String location, String body, URL urlRoot) {
+    public ScriptRequest(String location, String body, URL urlRoot, boolean ignoreExisting) {
         this.location = location;
         this.body = body;
         this.urlRoot = urlRoot;
+        this.ignoreExisting = ignoreExisting;
     }
 
     // Starting Object
@@ -18,4 +19,7 @@ public class ScriptRequest {
     // Where can we load objects from
     //ResourceConnector resourceConnector; // OR
     URL urlRoot; // file://. or http://server/ or workspace://JOBNAME/
+
+    // Ignore existing jobs
+    boolean ignoreExisting;
 }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -67,7 +67,8 @@ public final class JenkinsJobManagement extends AbstractJobManagement {
      * TODO cache the <jobName,config> and then let the calling method collect the tuples, so they can be saved at once. Maybe even connect to their template
      */
     @Override
-    public boolean createOrUpdateConfig(String jobName, String config) throws JobNameNotProvidedException, JobConfigurationMissingException {
+    public boolean createOrUpdateConfig(String jobName, String config, boolean ignoreExisting)
+            throws JobNameNotProvidedException, JobConfigurationMissingException {
 
         LOGGER.log(Level.INFO, String.format("createOrUpdateConfig for %s", jobName));
         boolean created = false;
@@ -79,7 +80,7 @@ public final class JenkinsJobManagement extends AbstractJobManagement {
 
         if (project == null) {
             created = createNewJob(jobName, config);
-        } else {
+        } else if (!ignoreExisting) {
             created = updateExistingJob(project, config);
         }
         return created;

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/RemovedJobAction.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/RemovedJobAction.java
@@ -1,0 +1,7 @@
+package javaposse.jobdsl.plugin;
+
+public enum RemovedJobAction {
+    IGNORE,
+    DISABLE,
+    DELETE
+}

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/config.groovy
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/config.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.plugin.ExecuteDslScripts
 
+import javaposse.jobdsl.plugin.RemovedJobAction;
 import javaposse.jobdsl.plugin.ExecuteDslScripts;
 
 def f=namespace(lib.FormTagLib)
@@ -19,6 +20,16 @@ f.radioBlock(name: 'scriptLocation', value: 'false', title: 'Look on Filesystem'
     }
 }
 
-f.entry(field: 'manageJobs') {
-    f.checkbox(name: 'manageJobs', title: 'Manage jobs', checked: instance.manageJobs)
+f.entry(field: 'ignoreExisting') {
+    f.checkbox(name: 'ignoreExisting', title: 'Ignore changes to existing jobs', checked: instance.ignoreExisting,
+		description: "What to do with previously generated jobs when generated config is not the same?")
+}
+
+f.entry(title: "Action for removed jobs:", field:"removedJobAction",
+	description: "What to do when a previously generated job is not referenced anymore?") {
+	select(name:"removedJobAction") {
+		f.option(value:"IGNORE",  selected:instance.removedJobAction==RemovedJobAction.IGNORE,  "Ignore")
+		f.option(value:"DISABLE", selected:instance.removedJobAction==RemovedJobAction.DISABLE, "Disable")
+		f.option(value:"DELETE", selected:instance.removedJobAction==RemovedJobAction.DELETE, "Delete")
+	}
 }

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-ignoreExisting.html
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-ignoreExisting.html
@@ -1,0 +1,1 @@
+<div>Ignore previously generated jobs. By default, this plugin will always regenerate all jobs, thus updating previously generated jobs. Check this box if you wish to leave previous jobs as is.</div>

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-manageJobs.html
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-manageJobs.html
@@ -1,1 +1,0 @@
-<div>Manage previously generated jobs at each build invocation. Active by default, uncheck if you don't want to alter generated jobs.</div>

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-scriptText.html
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-scriptText.html
@@ -1,3 +1,3 @@
 <div>
-  Job DSL Script, which is groovy code. Look at <a href="https://github.com/JavaPosseRoundup/job-dsl-plugin">documentation</a> for details on the syntax.
+  Job DSL Script, which is groovy code. Look at <a href="https://github.com/jenkinsci/job-dsl-plugin">documentation</a> for details on the syntax.
 </div>


### PR DESCRIPTION
By default, the job-dsl-plugin will delete all previously created jobs that are not generated by the current build execution. Unchecking the new box "Manage jobs" disable this behavior, leaving previously generated jobs as is.

Let me know what you think of my patch.
Reynald
