### PR TITLE
move chucknorris to publisher context

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/TopLevelHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/TopLevelHelper.groovy
@@ -58,16 +58,6 @@ class TopLevelHelper extends AbstractHelper {
             pluginNode / failBuild(shoudFailBuild?'true':'false')
         }
     }
-    /*
-    <hudson.plugins.chucknorris.CordellWalkerRecorder>
-      <factGenerator/>
-    </hudson.plugins.chucknorris.CordellWalkerRecorder>
-     */
-    def chucknorris() {
-        execute {
-            it / 'hudson.plugins.chucknorris.CordellWalkerRecorder' / factGenerator
-        }
-    }
 
     /*
     <disabled>true</disabled>

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextHelper.groovy
@@ -499,6 +499,18 @@ class PublisherContextHelper extends AbstractContextHelper<PublisherContextHelpe
             publisherNodes << publishNode
         }
 
+        /*
+        <hudson.plugins.chucknorris.CordellWalkerRecorder>
+          <factGenerator/>
+        </hudson.plugins.chucknorris.CordellWalkerRecorder>
+         */
+        def chucknorris() {
+            def nodeBuilder = NodeBuilder.newInstance()
+            def publishNode = nodeBuilder.'hudson.plugins.chucknorris.CordellWalkerRecorder' {
+                'factGenerator' ''
+            }
+            publisherNodes << publishNode
+        }
     }
 }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/TopLevelHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/TopLevelHelperSpec.groovy
@@ -28,23 +28,6 @@ public class TopLevelHelperSpec extends Specification {
 
     }
 
-    def 'can run cordell walker'() {
-        when:
-        helper.chucknorris()
-
-        then:
-        1 * mockActions.add(_)
-    }
-
-    def 'cordell walker constructs xml'() {
-        when:
-        def action = helper.chucknorris()
-        action.execute(root)
-
-        then:
-        root.'hudson.plugins.chucknorris.CordellWalkerRecorder'[0].factGenerator[0] != null
-    }
-
     def 'can run timeout'() {
         when:
         helper.timeout(15)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
@@ -514,4 +514,25 @@ public class PublisherHelperSpec extends Specification {
         then:
         1 * mockActions.add(_)
     }
+
+    def 'can run cordell walker'() {
+        when:
+        helper.publishers {
+            chucknorris()
+        }
+
+        then:
+        1 * mockActions.add(_)
+    }
+
+    def 'cordell walker constructs xml'() {
+        when:
+        context.chucknorris()
+
+        then:
+        Node publisherNode = context.publisherNodes[0]
+        publisherNode.name() == 'hudson.plugins.chucknorris.CordellWalkerRecorder'
+        publisherNode.value()[0].name() == "factGenerator"
+        publisherNode.value()[0].value() == ""
+    }
 }


### PR DESCRIPTION
chucknorris() didn't work, because it generated the tag under <project>. I've moved it to the publisher context, since it's a publisher, and now it's generated correctly under the <publishers> tag
