### PR TITLE
fixed JENKINS-16931 for Maven jobs

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
@@ -191,7 +191,7 @@ public class Job {
   <keepDependencies>false</keepDependencies>
   <properties/>
   <scm class="hudson.scm.NullSCM"/>
-  <canRoam>false</canRoam>
+  <canRoam>true</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslSampleTest.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslSampleTest.groovy
@@ -137,7 +137,7 @@ class DslSampleTest extends Specification {
     <description></description>
     <keepDependencies>false</keepDependencies>
     <properties/>
-    <canRoam>false</canRoam>
+    <canRoam>true</canRoam>
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
@@ -296,7 +296,7 @@ job(type: maven) {
     <description></description>
     <keepDependencies>false</keepDependencies>
     <properties/>
-    <canRoam>false</canRoam>
+    <canRoam>true</canRoam>
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
@@ -349,7 +349,7 @@ job(type: maven) {
     <description></description>
     <keepDependencies>false</keepDependencies>
     <properties/>
-    <canRoam>false</canRoam>
+    <canRoam>true</canRoam>
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobTest.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobTest.groovy
@@ -249,7 +249,7 @@ class JobTest extends Specification {
     <keepDependencies>false</keepDependencies>
     <properties/>
     <scm class="hudson.scm.NullSCM"/>
-    <canRoam>false</canRoam>
+    <canRoam>true</canRoam>
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>


### PR DESCRIPTION
It's probably not ideal to have two separate job templates for free-style jobs and for maven jobs.
