### PR TITLE
use other defaults for perModuleEmail and snapshotDependencies

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
@@ -199,8 +199,8 @@ public class Job {
   <concurrentBuild>false</concurrentBuild>
   <aggregatorStyleBuild>true</aggregatorStyleBuild>
   <incrementalBuild>false</incrementalBuild>
-  <perModuleEmail>true</perModuleEmail>
-  <ignoreUpstremChanges>false</ignoreUpstremChanges>
+  <perModuleEmail>false</perModuleEmail>
+  <ignoreUpstremChanges>true</ignoreUpstremChanges>
   <archivingDisabled>false</archivingDisabled>
   <resolveDependencies>false</resolveDependencies>
   <processPlugins>false</processPlugins>

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/MavenHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/MavenHelper.groovy
@@ -70,8 +70,8 @@ class MavenHelper extends AbstractHelper {
     }
 
     /**
-     * If set, Jenkins will send an e-mail notifications for each module, defaults to <code>true</code>.
-     * @param perModuleEmail set to <code>false</code> to disable per module e-mail notifications
+     * If set, Jenkins will send an e-mail notifications for each module, defaults to <code>false</code>.
+     * @param perModuleEmail set to <code>true</code> to enable per module e-mail notifications
      */
     def perModuleEmail(boolean perModuleEmail) {
         checkState jobArguments['type'] == maven, "perModuleEmail can only be applied for Maven jobs"

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/TriggerContextHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/TriggerContextHelper.groovy
@@ -234,8 +234,8 @@ class TriggerContext implements Context {
      * If set to <code>true</code>, Jenkins will parse the POMs of this project, and see if any of its snapshot
      * dependencies are built on this Jenkins as well. If so, Jenkins will set up build dependency relationship so that
      * whenever the dependency job is built and a new SNAPSHOT jar is created, Jenkins will schedule a build of this
-     * project. Defaults to <code>true</code>.
-     * @param checkSnapshotDependencies set to <code>false</code> to ignore snapshot dependencies
+     * project. Defaults to <code>false</code>.
+     * @param checkSnapshotDependencies set to <code>true</code> to check snapshot dependencies
      */
     def snapshotDependencies(boolean checkSnapshotDependencies) {
         Preconditions.checkState(jobArguments['type'] == maven, "snapshotDependencies can only be applied for Maven jobs")

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslSampleTest.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslSampleTest.groovy
@@ -266,14 +266,14 @@ job(type: maven) {
     rootPOM 'my_module/pom.xml'
     goals 'clean verify'
     mavenOpts '-Xmx1024m'
-    perModuleEmail false
+    perModuleEmail true
     archivingDisabled true
     runHeadless true
     scm {
         git(gitUrl)
     }
     triggers {
-        snapshotDependencies false
+        snapshotDependencies true
     }
 }
 
@@ -304,8 +304,8 @@ job(type: maven) {
     <concurrentBuild>false</concurrentBuild>
     <aggregatorStyleBuild>true</aggregatorStyleBuild>
     <incrementalBuild>false</incrementalBuild>
-    <perModuleEmail>false</perModuleEmail>
-    <ignoreUpstremChanges>true</ignoreUpstremChanges>
+    <perModuleEmail>true</perModuleEmail>
+    <ignoreUpstremChanges>false</ignoreUpstremChanges>
     <archivingDisabled>true</archivingDisabled>
     <resolveDependencies>false</resolveDependencies>
     <processPlugins>false</processPlugins>

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobTest.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobTest.groovy
@@ -257,8 +257,8 @@ class JobTest extends Specification {
     <concurrentBuild>false</concurrentBuild>
     <aggregatorStyleBuild>true</aggregatorStyleBuild>
     <incrementalBuild>false</incrementalBuild>
-    <perModuleEmail>true</perModuleEmail>
-    <ignoreUpstremChanges>false</ignoreUpstremChanges>
+    <perModuleEmail>false</perModuleEmail>
+    <ignoreUpstremChanges>true</ignoreUpstremChanges>
     <archivingDisabled>false</archivingDisabled>
     <resolveDependencies>false</resolveDependencies>
     <processPlugins>false</processPlugins>


### PR DESCRIPTION
I think perModuleEmail and snapshotDependencies should have other defaults. They are currently enabled by default, which are the defaults set by the Maven plugin when creating a new job. But in the context of the DSL it is strange to specify an element to remove some feature. So I changed the defaults, so that both elements need to be specified to enable these features. I will change the wiki in case you merge this.
