### PR TITLE
Support for Priority Sorter Plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/TopLevelHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/TopLevelHelper.groovy
@@ -159,4 +159,21 @@ class TopLevelHelper extends AbstractHelper {
         }
     }
 
+    /**
+     * Priority of this job.
+     * Requires the <a href="https://wiki.jenkins-ci.org/display/JENKINS/Priority+Sorter+Plugin">Priority Sorter Plugin</a>.
+     * Default value is 100.
+     *
+     * <properties>
+     *   <hudson.queueSorter.PrioritySorterJobProperty plugin="PrioritySorter@1.3">
+     *     <priority>100</priority>
+     *   </hudson.queueSorter.PrioritySorterJobProperty>
+     * </properties>
+     */
+    def priority(int value) {
+        execute {
+            def node = new Node(it / 'properties', 'hudson.queueSorter.PrioritySorterJobProperty')
+            node.appendNode('priority', value)
+        }
+    }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/TopLevelHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/TopLevelHelperSpec.groovy
@@ -175,4 +175,12 @@ public class TopLevelHelperSpec extends Specification {
         root.jdk[0].value() == "JDK1.6.0_17"
     }
 
+    def 'priority constructs xml'() {
+        when:
+        def action = helper.priority(99)
+        action.execute(root)
+
+        then:
+        root.properties.'hudson.queueSorter.PrioritySorterJobProperty'.priority[0].value() == 99
+    }
 }

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -42,6 +42,11 @@ jenkinsPlugin {
             name 'Emil Sit'
             email 'sit@hadapt.com'
         }
+        developer {
+            id 'daspilker'
+            name 'Daniel Spilker'
+            email 'mail@daniel-spilker.com'
+        }
     }
 }
 


### PR DESCRIPTION
I added support for the [Priority Sorter Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Priority+Sorter+Plugin). The new syntax is simple:

``` groovy
job {
  name 'foo'
  priority 50
}
```

I will adapt the documentation if you merge this.
