### PR TITLE
Support for GitHub Plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/MultiScmContextHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/MultiScmContextHelper.groovy
@@ -21,7 +21,7 @@ class MultiScmContextHelper extends AbstractContextHelper<ScmContext> {
      * @return
      */
     def multiscm(Closure closure) {
-        execute(closure, new ScmContext(true))
+        execute(closure, new ScmContext(true, withXmlActions))
     }
 
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/ScmContextHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/ScmContextHelper.groovy
@@ -33,7 +33,7 @@ class ScmContextHelper extends AbstractContextHelper<ScmContext> {
      * @return
      */
     def scm(Closure closure) {
-        execute(closure, new ScmContext())
+        execute(closure, new ScmContext(false, withXmlActions))
     }
 
     Closure generateWithXmlClosure(ScmContext context) {


### PR DESCRIPTION
I added support for the [GitHub plugin](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Plugin) to enable links between Jenkins job pages and GitHub. The new syntax looks like this:

``` groovy
job {
  name 'test'
  gitHubProject 'jenkinsci/job-dsl-plugin'
}
```

As always, I will adapt the wiki if you merge this.
