### PR TITLE
Update the default values and provide convenience methods for build stat...

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/TriggerContextHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/TriggerContextHelper.groovy
@@ -70,6 +70,82 @@ class GerritContext implements Context {
     Closure configureClosure
     def projects = []
 
+    int startedCodeReview =0
+    int startedVerified =0
+
+    int successfulCodeReview =0
+    int successfulVerified =1
+
+    int failedCodeReview =0
+    int failedVerified = -1
+
+    int unstableCodeReview =0
+    int unstableVerified =0
+
+    int notBuiltCodeReview =0
+    int notBuiltVerified =0
+
+    def buildStarted(int verified, int codeReview){
+        startedVerified = verified
+        startedCodeReview = codeReview
+    }
+
+    def buildStarted(Object verified, Object codeReview){
+        buildStarted(
+            Integer.parseInt(verified.toString()),
+            Integer.parseInt(codeReview.toString())
+        )
+    }
+
+
+    def buildSuccessful(int verified, int codeReview){
+        successfulVerified = verified
+        successfulCodeReview = codeReview
+    }
+
+    def buildSuccessful(Object verified, Object codeReview){
+        buildSuccessful(
+            Integer.parseInt(verified.toString()),
+            Integer.parseInt(codeReview.toString())
+        )
+    }
+
+    def buildFailed(int verified, int codeReview){
+        failedVerified = verified
+        failedCodeReview = codeReview
+    }
+
+    def buildFailed(Object verified, Object codeReview){
+        buildFailed(
+            Integer.parseInt(verified.toString()),
+            Integer.parseInt(codeReview.toString())
+        )
+    }
+
+    def buildUnstable(int verified, int codeReview){
+        unstableVerified = verified
+        unstableCodeReview = codeReview
+    }
+
+    def buildUnstable(Object verified, Object codeReview){
+        buildUnstable(
+            Integer.parseInt(verified.toString()),
+            Integer.parseInt(codeReview.toString())
+        )
+    }
+
+    def buildNotBuilt(int verified, int codeReview){
+        notBuiltVerified = verified
+        notBuiltCodeReview = codeReview
+    }
+
+    def buildNotBuilt(Object verified, Object codeReview){
+        buildNotBuilt(
+            Integer.parseInt(verified.toString()),
+            Integer.parseInt(codeReview.toString())
+        )
+    }
+
     def configure(Closure configureClosure) {
         // save for later
         this.configureClosure = configureClosure
@@ -201,16 +277,16 @@ class TriggerContext implements Context {
                     }
                 }
             }
-            gerritBuildStartedVerifiedValue 0
-            gerritBuildStartedCodeReviewValue 0
-            gerritBuildSuccessfulVerifiedValue 1
-            gerritBuildSuccessfulCodeReviewValue 2
-            gerritBuildFailedVerifiedValue '-2'
-            gerritBuildFailedCodeReviewValue '-2'
-            gerritBuildUnstableVerifiedValue '-1'
-            gerritBuildUnstableCodeReviewValue '-1'
-            gerritBuildNotBuiltVerifiedValue 0
-            gerritBuildNotBuiltCodeReviewValue 0
+            gerritBuildStartedVerifiedValue Integer.toString(gerritContext.startedVerified)
+            gerritBuildStartedCodeReviewValue Integer.toString(gerritContext.startedCodeReview)
+            gerritBuildSuccessfulVerifiedValue Integer.toString(gerritContext.successfulVerified)
+            gerritBuildSuccessfulCodeReviewValue Integer.toString(gerritContext.successfulCodeReview)
+            gerritBuildFailedVerifiedValue Integer.toString(gerritContext.failedVerified)
+            gerritBuildFailedCodeReviewValue Integer.toString(gerritContext.failedCodeReview)
+            gerritBuildUnstableVerifiedValue Integer.toString(gerritContext.unstableVerified)
+            gerritBuildUnstableCodeReviewValue Integer.toString(gerritContext.unstableCodeReview)
+            gerritBuildNotBuiltVerifiedValue Integer.toString(gerritContext.notBuiltVerified)
+            gerritBuildNotBuiltCodeReviewValue Integer.toString(gerritContext.notBuiltCodeReview)
             dynamicTriggerConfiguration false
             triggerConfigURL ''
             triggerInformationAction ''

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/TriggerHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/TriggerHelperSpec.groovy
@@ -85,7 +85,7 @@ public class TriggerHelperSpec extends Specification {
         gerritTrigger.gerritBuildSuccessfulVerifiedValue[0].value() as String == '10'
 
         gerritTrigger.gerritBuildFailedCodeReviewValue.size() == 1
-        gerritTrigger.gerritBuildFailedCodeReviewValue[0].value() == '-2'
+        gerritTrigger.gerritBuildFailedCodeReviewValue[0].value() == '0'
 
         Node gerritEvents = gerritTrigger.triggerOnEvents[0]
         gerritEvents.children().size() == 2
@@ -110,6 +110,89 @@ public class TriggerHelperSpec extends Specification {
         gerritProjectSimple.pattern[0].value() == 'test-project'
         gerritProjectSimple.branches[0].children().size() == 1
         // Assume branch is fine
+    }
+
+
+    def 'call gerrit trigger and verify build status value settings'() {
+      when:
+        context.gerrit {
+            events {
+                PatchsetCreated
+                DraftPublished
+            }
+
+            project('test-project', '**')
+        }
+      then:
+        def gerritTrigger = context.triggerNodes[0]
+        gerritTrigger.gerritBuildSuccessfulCodeReviewValue.size() == 1
+        gerritTrigger.gerritBuildSuccessfulCodeReviewValue[0].value() == '0'
+
+        gerritTrigger.gerritBuildSuccessfulVerifiedValue.size() == 1
+        gerritTrigger.gerritBuildSuccessfulVerifiedValue[0].value() as String == '1'
+
+        gerritTrigger.gerritBuildFailedVerifiedValue.size() == 1
+        gerritTrigger.gerritBuildFailedVerifiedValue[0].value() as String == '-1'
+
+        gerritTrigger.gerritBuildFailedCodeReviewValue.size() == 1
+        gerritTrigger.gerritBuildFailedCodeReviewValue[0].value() as String == '0'
+
+        gerritTrigger.gerritBuildUnstableVerifiedValue.size() == 1
+        gerritTrigger.gerritBuildUnstableVerifiedValue[0].value() as String == '0'
+
+        gerritTrigger.gerritBuildUnstableCodeReviewValue.size() == 1
+        gerritTrigger.gerritBuildUnstableCodeReviewValue[0].value() == '0'
+    }
+
+
+    def 'call gerrit trigger and verify build status value methods'() {
+      when:
+        context.gerrit {
+            events {
+                PatchsetCreated
+                DraftPublished
+            }
+
+            project('test-project', '**')
+
+            buildSuccessful(11,10)
+            buildFailed('-21',20)
+            buildUnstable(30,'32')
+            buildNotBuilt('40','42')
+            buildStarted('50','55')
+        }
+      then:
+        def gerritTrigger = context.triggerNodes[0]
+        gerritTrigger.gerritBuildSuccessfulCodeReviewValue.size() == 1
+        gerritTrigger.gerritBuildSuccessfulCodeReviewValue[0].value() == '10'
+
+        gerritTrigger.gerritBuildSuccessfulVerifiedValue.size() == 1
+        gerritTrigger.gerritBuildSuccessfulVerifiedValue[0].value() as String == '11'
+
+        gerritTrigger.gerritBuildFailedVerifiedValue.size() == 1
+        gerritTrigger.gerritBuildFailedVerifiedValue[0].value() as String == '-21'
+
+        gerritTrigger.gerritBuildFailedCodeReviewValue.size() == 1
+        gerritTrigger.gerritBuildFailedCodeReviewValue[0].value() as String == '20'
+
+        gerritTrigger.gerritBuildUnstableVerifiedValue.size() == 1
+        gerritTrigger.gerritBuildUnstableVerifiedValue[0].value() as String == '30'
+
+        gerritTrigger.gerritBuildUnstableCodeReviewValue.size() == 1
+        gerritTrigger.gerritBuildUnstableCodeReviewValue[0].value() == '32'
+
+        gerritTrigger.gerritBuildNotBuiltVerifiedValue.size() == 1
+        gerritTrigger.gerritBuildNotBuiltVerifiedValue[0].value() as String == '40'
+
+        gerritTrigger.gerritBuildNotBuiltCodeReviewValue.size() == 1
+        gerritTrigger.gerritBuildNotBuiltCodeReviewValue[0].value() == '42'
+
+        gerritTrigger.gerritBuildStartedVerifiedValue.size() == 1
+        gerritTrigger.gerritBuildStartedVerifiedValue[0].value() as String == '50'
+
+        gerritTrigger.gerritBuildStartedCodeReviewValue.size() == 1
+        gerritTrigger.gerritBuildStartedCodeReviewValue[0].value() == '55'
+
     }
 
     def 'execute withXml Action'() {


### PR DESCRIPTION
...us values in the gerrit trigger.
- Create integer typed properties in the gerrit trigger
  - Update defaults for certain build status values to match defaults from gerrit trigger
  - Update the gerrit method to use the propertieds when setting build status values
  - Provide convenience methods for setting gerrit status values in gerritTrigger.
  - Add new test methods in test specification.
  - Update the GerritContext with convenience methods.
    
    def buildStarted(int verified, int codeReview);
    def buildSuccessful(int verified, int codeReview);
    def buildFailed(int verified, int codeReview);
    def buildUnstable(int verified, int codeReview);
    def buildNotBuilt(int verified, int codeReview);
  - Add another set of methods with signature
    build<Foo>(Object,Object) with code to coerce it arguments to int
    and call the corresponding build<Foo>(int,int) method.
