### PR TITLE
Update FileJobManagement to store param passed in from System properties and environment variables

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
@@ -1,5 +1,8 @@
 package javaposse.jobdsl.dsl;
 
+import com.google.common.collect.Maps;
+
+import java.util.Map;
 
 class FileJobManagement extends AbstractJobManagement {
     /**
@@ -11,6 +14,12 @@ class FileJobManagement extends AbstractJobManagement {
      * Extension to append to job name when looking at the filesystem
      */
     String ext
+
+    /**
+     * map to store job parameters from System properties and
+     * Environment variables.
+     */
+    protected Map params =  Maps.newHashMap();
 
     public FileJobManagement(File root, String ext = null, PrintStream out = System.out) {
         super(out)
@@ -41,6 +50,11 @@ class FileJobManagement extends AbstractJobManagement {
 
         new File(jobName + ext).write(config)
         return true
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return params;
     }
 
     @Override


### PR DESCRIPTION
- This enables command line testing of DSL jobs that use build parameters.

Below is a bash script that create a job dsl file named simple.job  It is parameterized to use String build parameter named JOB_NAME_PARAM.  The final line of the script sets an environment variable on the command line and invokes gradle wrapper to run the job from the command line

**SCRIPT_BELOW**
 #!/bin/bash
OUTFILE=simple.job
(
cat <<'EOF'
def jobName="${JOB_NAME_PARAM}"
job {
    name "${jobName}"
    scm {
        git('git://github.com/jgritman/aws-sdk-test.git')
    }
    triggers {
        scm('*/15 \* \* \* *')
    }
    steps {
        maven('-e clean test')
    }
}

EOF
) > $OUTFILE

JOB_NAME_PARAM="DSL-Tutorial-1-Test-param" ./gradlew :job-dsl-core:run  -Pargs=$PWD/simple.job
