### PR TITLE
Support For SSH Agent Plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.java
@@ -35,6 +35,11 @@ public abstract class AbstractJobManagement implements JobManagement {
     }
 
     @Override
+    public String getCredentialsId(String credentialsDescription) {
+        return null;
+    }
+
+    @Override
     public void queueJob(String jobName) throws JobNameNotProvidedException {
         validateJobNameArg(jobName);
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
@@ -41,7 +41,7 @@ public class Job {
         helperTrigger = new TriggerContextHelper(withXmlActions, type)
         helperStep = new StepContextHelper(withXmlActions, type)
         helperPublisher = new PublisherContextHelper(withXmlActions, type)
-        helperTopLevel = new TopLevelHelper(withXmlActions, type)
+        helperTopLevel = new TopLevelHelper(withXmlActions, type, jobManagement)
         helperMaven = new MavenHelper(withXmlActions, type)
         helperBuildParameters = new BuildParametersContextHelper(withXmlActions, type)
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
@@ -45,4 +45,10 @@ public interface JobManagement {
      */
     Map<String,String> getParameters();
 
+    /**
+     * Returns the id of a Credentials object.
+     * @param credentialsDescription the description of the credentials to lookup
+     * @return id of Credentials or <code>null</code> if no credentials could be found
+     */
+    String getCredentialsId(String credentialsDescription);
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/TopLevelHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/TopLevelHelper.groovy
@@ -2,15 +2,18 @@ package javaposse.jobdsl.dsl.helpers
 
 import com.google.common.base.Preconditions
 import groovy.transform.Canonical
+import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.JobType
 import javaposse.jobdsl.dsl.WithXmlAction
 
 import static javaposse.jobdsl.dsl.helpers.TopLevelHelper.Timeout.absolute
 
 class TopLevelHelper extends AbstractHelper {
+    JobManagement jobManagement
 
-    TopLevelHelper(List<WithXmlAction> withXmlActions, JobType jobType) {
+    TopLevelHelper(List<WithXmlAction> withXmlActions, JobType jobType, JobManagement jobManagement) {
         super(withXmlActions, jobType)
+        this.jobManagement = jobManagement
     }
 
     def description(String descriptionString) {
@@ -499,6 +502,27 @@ class TopLevelHelper extends AbstractHelper {
             it / buildWrappers / 'com.datalex.jenkins.plugins.nodestalker.wrapper.NodeStalkerBuildWrapper' {
                 job jobName
                 shareWorkspace useSameWorkspace
+            }
+        }
+    }
+
+    /**
+     * <project>
+     *     <buildWrappers>
+     *         <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
+     *             <user>25899f16-1b91-4656-90cd-3f1c26ef6292</user>
+     *         </com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
+     *
+     * Provide SSH credentials to builds via a ssh-agent in Jenkins.
+     * @param credentials name of the credentials to use
+     */
+    def sshAgent(String credentials) {
+        Preconditions.checkNotNull(credentials, "credentials must not be null")
+        String id = jobManagement.getCredentialsId(credentials)
+        Preconditions.checkNotNull(id, "credentials not found")
+        execute {
+            it / buildWrappers / 'com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper' {
+                user id
             }
         }
     }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/TopLevelHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/TopLevelHelperSpec.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.dsl.helpers
 
+import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.JobType
 import javaposse.jobdsl.dsl.WithXmlAction
 import javaposse.jobdsl.dsl.WithXmlActionSpec
@@ -12,7 +13,8 @@ import static javaposse.jobdsl.dsl.helpers.TopLevelHelper.Timeout.likelyStuck
 public class TopLevelHelperSpec extends Specification {
 
     List<WithXmlAction> mockActions = Mock()
-    TopLevelHelper helper = new TopLevelHelper(mockActions, JobType.Freeform)
+    JobManagement mockJobManagement = Mock()
+    TopLevelHelper helper = new TopLevelHelper(mockActions, JobType.Freeform, mockJobManagement)
     Node root = new XmlParser().parse(new StringReader(WithXmlActionSpec.xml))
 
     def 'add description'() {
@@ -430,5 +432,39 @@ public class TopLevelHelperSpec extends Specification {
         def wrapper = root.buildWrappers[0].'com.datalex.jenkins.plugins.nodestalker.wrapper.NodeStalkerBuildWrapper'
         wrapper.job[0].value() == 'testJob'
         wrapper.shareWorkspace[0].value() == true
+    }
+
+    def 'sshAgent without credentials' () {
+        when:
+        def action = helper.sshAgent(null)
+        action.execute(root)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def 'sshAgent with invalid credentials' () {
+        setup:
+        mockJobManagement.getCredentialsId('foo') >> null
+
+        when:
+        def action = helper.sshAgent('foo')
+        action.execute(root)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def 'sshAgent' () {
+        setup:
+        mockJobManagement.getCredentialsId('acme') >> '4711'
+
+        when:
+        def action = helper.sshAgent('acme')
+        action.execute(root)
+
+        then:
+        def wrapper = root.buildWrappers[0].'com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper'
+        wrapper.user[0].value() == '4711'
     }
 }

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -52,6 +52,10 @@ jenkinsPlugin {
     }
 }
 
+dependencies {
+    optionalJenkinsPlugins([group: 'org.jenkins-ci.plugins', name: 'credentials', version: '1.6', ext: 'jar'])
+}
+
 tasks.jpi.manifest.attributes(["PluginFirstClassLoader": "true" ])
 
 //apply from: 'ide.gradle'

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -1,13 +1,17 @@
 package javaposse.jobdsl.plugin;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.google.common.base.Function;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Sets;
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.Plugin;
 import hudson.XmlFile;
 import hudson.model.*;
+import hudson.util.VersionNumber;
 import javaposse.jobdsl.dsl.*;
 import jenkins.model.Jenkins;
 import org.custommonkey.xmlunit.Diff;
@@ -20,6 +24,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static hudson.security.ACL.SYSTEM;
 
 /**
  * Manages Jenkins Jobs, providing facilities to retrieve and create / update.
@@ -91,6 +97,21 @@ public final class JenkinsJobManagement extends AbstractJobManagement {
     @Override
     public Map<String, String> getParameters() {
         return envVars;
+    }
+
+    @Override
+    public String getCredentialsId(String credentialsDescription) {
+        Plugin credentialsPlugin = jenkins.getPlugin("credentials");
+        if (credentialsPlugin != null && !credentialsPlugin.getWrapper().getVersionNumber().isOlderThan(new VersionNumber("1.6"))) {
+            for (CredentialsProvider credentialsProvider : jenkins.getExtensionList(CredentialsProvider.class)) {
+                for (StandardCredentials credentials : credentialsProvider.getCredentials(StandardCredentials.class, jenkins, SYSTEM)) {
+                    if (credentials.getDescription().equals(credentialsDescription)) {
+                        return credentials.getId();
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     @Override

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementTest.java
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementTest.java
@@ -1,0 +1,24 @@
+package javaposse.jobdsl.plugin;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertNull;
+
+public class JenkinsJobManagementTest {
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+    
+    @Test
+    public void getCredentialsIdWithoutCredentialsPlugin() {
+        // setup
+        JenkinsJobManagement jobManagement = new JenkinsJobManagement();
+        
+        // when
+        String id = jobManagement.getCredentialsId("test");
+        
+        // then
+        assertNull(id);
+    }
+}


### PR DESCRIPTION
This pull requests adds support for the [SSH Agent Plugin](https://wiki.jenkins-ci.org/display/JENKINS/SSH+Agent+Plugin).

``` groovy
job {
    ...
    sshAgent(String credentials)
    ...
}
```

Example:

``` groovy
job {
    ...
    sshAgent('my-credentials')
    ...
}
```

Unfortunately the config XML for the SSH Agent Plugin must contain the ID of the credentials and not the clear text name. Since the ID is not visible in the Jenkins web interface, it is not pratical for users to enter the ID in a job DSL script. So I added a method in the JobManagement interface which can lookup the ID of the credentials using the Jenkins API. Since the credentials API is not contained in core Jenkins, I added an optional dependency to the Credentials plugin. A test makes sure that the Job DSL plugin is working if the Credentials plugin is not installed.
