### PR TITLE
Added support for the Description Setter Plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextHelper.groovy
@@ -728,7 +728,9 @@ class PublisherContextHelper extends AbstractContextHelper<PublisherContextHelpe
                 regexp(regularExpression)
                 regexpForFailed(regularExpressionForFailed)
                 delegate.description(description)
-                delegate.descriptionForFailed(descriptionForFailed)
+                if (descriptionForFailed) {
+                    delegate.descriptionForFailed(descriptionForFailed)
+                }
                 setForMatrix(multiConfigurationBuild)
             }
         }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
@@ -963,7 +963,7 @@ public class PublisherHelperSpec extends Specification {
         context.publisherNodes[0].regexp[0].value() == 'success'
         context.publisherNodes[0].regexpForFailed[0].value() == ''
         context.publisherNodes[0].description[0].value() == ''
-        context.publisherNodes[0].descriptionForFailed[0].value() == ''
+        context.publisherNodes[0].descriptionForFailed == []
         context.publisherNodes[0].setForMatrix[0].value() == false
     }
 
@@ -977,7 +977,7 @@ public class PublisherHelperSpec extends Specification {
         context.publisherNodes[0].regexp[0].value() == 'success'
         context.publisherNodes[0].regexpForFailed[0].value() == ''
         context.publisherNodes[0].description[0].value() == 'AWSUM!'
-        context.publisherNodes[0].descriptionForFailed[0].value() == ''
+        context.publisherNodes[0].descriptionForFailed == []
         context.publisherNodes[0].setForMatrix[0].value() == false
     }
 
@@ -991,7 +991,7 @@ public class PublisherHelperSpec extends Specification {
         context.publisherNodes[0].regexp[0].value() == 'success'
         context.publisherNodes[0].regexpForFailed[0].value() == 'failed'
         context.publisherNodes[0].description[0].value() == 'AWSUM!'
-        context.publisherNodes[0].descriptionForFailed[0].value() == ''
+        context.publisherNodes[0].descriptionForFailed == []
         context.publisherNodes[0].setForMatrix[0].value() == false
     }
 


### PR DESCRIPTION
This pull request adds support for the [Description Setter Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Description+Setter+Plugin) which automatically sets a description for the build after it has completed.

The syntax is:

``` groovy
job {
    ...
    publishers {
        buildDescription(String regularExpression, String description = '', String regularExpressionForFailed = '', String descriptionForFailed = '', boolean multiConfigurationBuild = false)
        ....
    }
}
```

Arguments:
- `regularExpression` If configured, the regular expression will be applied to each line in the build log. A description will be set based on the first match.
- `description` The description to set on the build. If a regular expression is configured, every instance of \n will be replaced with the n-th group of the regular expression match. If the description is empty, the first group selected by the regular expression will be used as description. If no regular expression is configured, the description is taken verbatim.
- `regularExpressionForFailed` If set, this regular expression will be used instead of the regular regular expression when the build has failed.
- `descriptionForFailed` The description to use for failed builds.
- `multiConfigurationBuild` Also set the description on a multi-configuration build. The first description found for any of the invididual builds will be used as description for the multi-configuration build.
