### PR TITLE
Publish the JAR of the job-dsl-core project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,8 @@ defaultTasks 'build' // For BuildHive
 subprojects {
     group = "org.jenkinsci.plugins"
     apply plugin: 'groovy'
+    apply plugin: 'idea'
+    apply plugin: 'maven' // For artifactory publishing
     sourceCompatibility = 1.5
     targetCompatibility = 1.5
     dependencies {
@@ -20,6 +22,28 @@ subprojects {
     test {
         useJUnit() // Causes "failed to create temp file to extract class from jar into"
     }
+
+    task jarSources(type:Jar){
+        from sourceSets.main.allSource
+        classifier = 'source'
+    }
+
+    task jarJavadocs (type: Jar, dependsOn: 'javadoc') {
+        from project.javadoc.destinationDir
+        classifier = 'javadoc'
+    }
+
+    task jarGroovydocs (type: Jar, dependsOn: 'groovydoc') {
+        from project.groovydoc.destinationDir
+        classifier = 'groovydoc'
+    }
+
+    artifacts {
+        archives jarJavadocs
+        archives jarGroovydocs
+        archives jarSources
+    }
+
 }
 
 buildscript {
@@ -31,9 +55,17 @@ buildscript {
     }
 }
 
+private Properties loadDotJenkinsOrg() {
+    Properties props = new Properties()
+    def dot = new File(new File(System.getProperty("user.home")), ".jenkins-ci.org")
+    if (!dot.exists())
+        throw new Exception("Trying to deploy to Jenkins community repository but there's no credential file ${dot}. See https://wiki.jenkins-ci.org/display/JENKINS/Dot+Jenkins+Ci+Dot+Org")
+    dot.withInputStream { i -> props.load(i) }
+    return props
+}
+
 project(':job-dsl-core') {
     apply plugin: 'application'
-    apply plugin: 'maven' // For artifactory publishing
 
     description = "Generates Jenkins jobs via a DSL"
     dependencies {
@@ -58,6 +90,21 @@ project(':job-dsl-core') {
     artifacts {
         archives oneJar
     }
+
+    uploadArchives {
+        repositories {
+            mavenDeployer {
+                def props = loadDotJenkinsOrg()
+                repository(url: 'http://maven.jenkins-ci.org:8081/content/repositories/releases') {
+                    authentication(userName:props["userName"], password:props["password"])
+                }
+                snapshotRepository(url: 'http://maven.jenkins-ci.org:8081/content/repositories/snapshots') {
+                    authentication(userName:props["userName"], password:props["password"])
+                }
+            }
+        }
+    }
+
 
     run {
         if ( project.hasProperty('args') ) {

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -17,6 +17,10 @@ repositories {
     }
 }
 
+artifacts {
+    archives jar
+}
+
 configurations.testCompile.exclude group: 'org.jenkins-ci.modules', module:'instance-identity'
 configurations.testCompile.exclude group: 'org.jenkins-ci.modules', module:'ssh-cli-auth'
 


### PR DESCRIPTION
Make gradle upload the artifacts of the job-dsl-core project.
Additionally, javadoc, groovydoc and sources get uploaded for the core and the plugin.
