### PR TITLE
Added ItemDiscover, ItemCancel, and ScmTag permissions to the Permissions enum

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/Permissions.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/Permissions.groovy
@@ -1,12 +1,12 @@
 package javaposse.jobdsl.dsl.helpers
 
 enum Permissions {
-    ItemConfigure('hudson.model.Item.Configure'),
-    ItemWorkspace('hudson.model.Item.Workspace'),
     ItemDelete('hudson.model.Item.Delete'),
-    ItemBuild('hudson.model.Item.Build'),
+    ItemConfigure('hudson.model.Item.Configure'),
     ItemRead('hudson.model.Item.Read'),
     ItemDiscover('hudson.model.Item.Discover'),
+    ItemBuild('hudson.model.Item.Build'),
+    ItemWorkspace('hudson.model.Item.Workspace'),
     ItemCancel('hudson.model.Item.Cancel'),
     ItemRelease('hudson.model.Item.Release'),
     ItemExtendedRead('hudson.model.Item.ExtendedRead'),


### PR DESCRIPTION
These additional permissions should be useful for other standard permissions.
