### PR TITLE
Text Finder Plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextHelper.groovy
@@ -740,5 +740,27 @@ class PublisherContextHelper extends AbstractContextHelper<PublisherContextHelpe
                 setForMatrix(multiConfigurationBuild)
             }
         }
+
+        /**
+         * Configures the Jenkins Text Finder plugin
+         *
+         * <publishers>
+         *     <hudson.plugins.textfinder.TextFinderPublisher>
+         *         <fileSet>*.txt</fileSet>
+         *         <regexp/>
+         *         <succeedIfFound>false</succeedIfFound>
+         *         <unstableIfFound>false</unstableIfFound>
+         *         <alsoCheckConsoleOutput>false</alsoCheckConsoleOutput>
+         *     </hudson.plugins.textfinder.TextFinderPublisher>
+         */
+        def textFinder(String regularExpression, String fileSet = '', boolean alsoCheckConsoleOutput = false, boolean succeedIfFound = false, unstableIfFound = false) {
+            publisherNodes << NodeBuilder.newInstance().'hudson.plugins.textfinder.TextFinderPublisher' {
+                delegate.fileSet(fileSet)
+                delegate.regexp(regularExpression)
+                delegate.alsoCheckConsoleOutput(alsoCheckConsoleOutput)
+                delegate.succeedIfFound(succeedIfFound)
+                delegate.unstableIfFound(unstableIfFound)
+            }
+        }
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
@@ -1022,4 +1022,74 @@ public class PublisherHelperSpec extends Specification {
         context.publisherNodes[0].descriptionForFailed[0].value() == 'NOES!'
         context.publisherNodes[0].setForMatrix[0].value() == true
     }
+
+    def 'call textFinder with one argument'() {
+        when:
+        context.textFinder('foo')
+
+        then:
+        context.publisherNodes.size() == 1
+        context.publisherNodes[0].name() == 'hudson.plugins.textfinder.TextFinderPublisher'
+        context.publisherNodes[0].regexp[0].value() == 'foo'
+        context.publisherNodes[0].fileSet[0].value() == ''
+        context.publisherNodes[0].alsoCheckConsoleOutput[0].value() == false
+        context.publisherNodes[0].succeedIfFound[0].value() == false
+        context.publisherNodes[0].unstableIfFound[0].value() == false
+    }
+
+    def 'call textFinder with two arguments'() {
+        when:
+        context.textFinder('foo', '*.txt')
+
+        then:
+        context.publisherNodes.size() == 1
+        context.publisherNodes[0].name() == 'hudson.plugins.textfinder.TextFinderPublisher'
+        context.publisherNodes[0].regexp[0].value() == 'foo'
+        context.publisherNodes[0].fileSet[0].value() == '*.txt'
+        context.publisherNodes[0].alsoCheckConsoleOutput[0].value() == false
+        context.publisherNodes[0].succeedIfFound[0].value() == false
+        context.publisherNodes[0].unstableIfFound[0].value() == false
+    }
+
+    def 'call textFinder with three arguments'() {
+        when:
+        context.textFinder('foo', '*.txt', true)
+
+        then:
+        context.publisherNodes.size() == 1
+        context.publisherNodes[0].name() == 'hudson.plugins.textfinder.TextFinderPublisher'
+        context.publisherNodes[0].regexp[0].value() == 'foo'
+        context.publisherNodes[0].fileSet[0].value() == '*.txt'
+        context.publisherNodes[0].alsoCheckConsoleOutput[0].value() == true
+        context.publisherNodes[0].succeedIfFound[0].value() == false
+        context.publisherNodes[0].unstableIfFound[0].value() == false
+    }
+
+    def 'call textFinder with four arguments'() {
+        when:
+        context.textFinder('foo', '*.txt', true, true)
+
+        then:
+        context.publisherNodes.size() == 1
+        context.publisherNodes[0].name() == 'hudson.plugins.textfinder.TextFinderPublisher'
+        context.publisherNodes[0].regexp[0].value() == 'foo'
+        context.publisherNodes[0].fileSet[0].value() == '*.txt'
+        context.publisherNodes[0].alsoCheckConsoleOutput[0].value() == true
+        context.publisherNodes[0].succeedIfFound[0].value() == true
+        context.publisherNodes[0].unstableIfFound[0].value() == false
+    }
+
+    def 'call textFinder with five arguments'() {
+        when:
+        context.textFinder('foo', '*.txt', true, true, true)
+
+        then:
+        context.publisherNodes.size() == 1
+        context.publisherNodes[0].name() == 'hudson.plugins.textfinder.TextFinderPublisher'
+        context.publisherNodes[0].regexp[0].value() == 'foo'
+        context.publisherNodes[0].fileSet[0].value() == '*.txt'
+        context.publisherNodes[0].alsoCheckConsoleOutput[0].value() == true
+        context.publisherNodes[0].succeedIfFound[0].value() == true
+        context.publisherNodes[0].unstableIfFound[0].value() == true
+    }
 }


### PR DESCRIPTION
This pull request adds support for Jenkins Text Finder plugin.

``` groovy
job {
    ...
    publishers {
        ....
        textFinder(String regularExpression, String fileSet = '', boolean alsoCheckConsoleOutput = false, boolean succeedIfFound = false, unstableIfFound = false)
    }
}
```

Example:

``` groovy
job {
    ...
    publishers {
        ...
        textFinder(/\[ERROR\]/, '**/*.log', false, false, true)
    }
}
```
