### PR TITLE
Pass Closure from publishCloneWorkspace to Context

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/CloneWorkspaceContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/CloneWorkspaceContext.groovy
@@ -4,15 +4,10 @@ import javaposse.jobdsl.dsl.helpers.Context
 
 class CloneWorkspaceContext implements Context {
 
-    String workspaceGlob = ''
     String workspaceExcludeGlob = ''
     String criteria = 'Any' // 'Not Failed', 'Successful'
     String archiveMethod = 'TAR' // 'ZIP'
     boolean overrideDefaultExcludes = false
-
-    void workspaceGlob(String workspaceGlob) {
-        this.workspaceGlob = workspaceGlob
-    }
 
     void workspaceExcludeGlob(String workspaceExcludeGlob) {
         this.workspaceExcludeGlob = workspaceExcludeGlob

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextHelper.groovy
@@ -419,21 +419,23 @@ class PublisherContextHelper extends AbstractContextHelper<PublisherContextHelpe
          * </hudson.plugins.cloneworkspace.CloneWorkspacePublisher>
          */
         def publishCloneWorkspace(String workspaceGlob, Closure cloneWorkspaceClosure) {
-            publishCloneWorkspace(workspaceGlob, '', 'Any', 'TAR', false, null)
+            publishCloneWorkspace(workspaceGlob, '', 'Any', 'TAR', false, cloneWorkspaceClosure)
         }
 
         def publishCloneWorkspace(String workspaceGlob, String workspaceExcludeGlob, Closure cloneWorkspaceClosure) {
-            publishCloneWorkspace(workspaceGlob, workspaceExcludeGlob, 'Any', 'TAR', false, null)
+            publishCloneWorkspace(workspaceGlob, workspaceExcludeGlob, 'Any', 'TAR', false, cloneWorkspaceClosure)
         }
 
         def publishCloneWorkspace(String workspaceGlob, String workspaceExcludeGlob, String criteria, String archiveMethod, Closure cloneWorkspaceClosure) {
-            publishCloneWorkspace(workspaceGlob, workspaceExcludeGlob, criteria, archiveMethod, false, null)
+            publishCloneWorkspace(workspaceGlob, workspaceExcludeGlob, criteria, archiveMethod, false, cloneWorkspaceClosure)
         }
 
         def publishCloneWorkspace(String workspaceGlobArg, String workspaceExcludeGlobArg = '', String criteriaArg = 'Any', String archiveMethodArg = 'TAR', boolean overrideDefaultExcludesArg = false, Closure cloneWorkspaceClosure = null) {
             CloneWorkspaceContext cloneWorkspaceContext = new CloneWorkspaceContext()
             cloneWorkspaceContext.criteria = criteriaArg ?: 'Any'
             cloneWorkspaceContext.archiveMethod = archiveMethodArg ?: 'TAR'
+            cloneWorkspaceContext.workspaceExcludeGlob = workspaceExcludeGlobArg ?: ''
+            cloneWorkspaceContext.overrideDefaultExcludes = overrideDefaultExcludesArg ?: false
             AbstractContextHelper.executeInContext(cloneWorkspaceClosure, cloneWorkspaceContext)
 
             // Validate values
@@ -443,10 +445,10 @@ class PublisherContextHelper extends AbstractContextHelper<PublisherContextHelpe
             def nodeBuilder = NodeBuilder.newInstance()
             def publishNode = nodeBuilder.'hudson.plugins.cloneworkspace.CloneWorkspacePublisher' {
                 workspaceGlob workspaceGlobArg
-                workspaceExcludeGlob workspaceExcludeGlobArg
-                criteria criteriaArg
-                archiveMethod archiveMethodArg
-                overrideDefaultExcludes overrideDefaultExcludesArg
+                workspaceExcludeGlob cloneWorkspaceContext.workspaceExcludeGlob
+                criteria cloneWorkspaceContext.criteria
+                archiveMethod cloneWorkspaceContext.archiveMethod
+                overrideDefaultExcludes cloneWorkspaceContext.overrideDefaultExcludes
             }
             publisherNodes << publishNode
         }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
@@ -437,6 +437,25 @@ public class PublisherHelperSpec extends Specification {
         thrown(AssertionError)
     }
 
+    def 'call Clone Workspace with Closure'() {
+        when:
+        context.publishCloneWorkspace('*/**') {
+            criteria 'Not Failed'
+            archiveMethod 'ZIP'
+            workspaceExcludeGlob '*/.svn'
+            overrideDefaultExcludes true
+        }
+
+        then:
+        Node publisherNode = context.publisherNodes[0]
+        publisherNode.name() == 'hudson.plugins.cloneworkspace.CloneWorkspacePublisher'
+        publisherNode.workspaceGlob[0].value() == '*/**'
+        publisherNode.workspaceExcludeGlob[0].value() == '*/.svn'
+        publisherNode.criteria[0].value() == 'Not Failed'
+        publisherNode.archiveMethod[0].value() == 'ZIP'
+        publisherNode.overrideDefaultExcludes[0].value() == true
+    }
+
     def 'call scp publish with not enough entries'() {
         when:
         context.publishScp('javadoc', null)


### PR DESCRIPTION
Seems like the closure for the publishCloneWorkspace methods with not full arguments has been thrown away... This commit fixes this issue.
