### PR TITLE
TextFinder: fileSet should not be present if empty

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextHelper.groovy
@@ -757,7 +757,7 @@ class PublisherContextHelper extends AbstractContextHelper<PublisherContextHelpe
          */
         def textFinder(String regularExpression, String fileSet = '', boolean alsoCheckConsoleOutput = false, boolean succeedIfFound = false, unstableIfFound = false) {
             publisherNodes << NodeBuilder.newInstance().'hudson.plugins.textfinder.TextFinderPublisher' {
-                delegate.fileSet(fileSet)
+                if (fileSet) delegate.fileSet(fileSet)
                 delegate.regexp(regularExpression)
                 delegate.alsoCheckConsoleOutput(alsoCheckConsoleOutput)
                 delegate.succeedIfFound(succeedIfFound)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
@@ -1050,7 +1050,7 @@ public class PublisherHelperSpec extends Specification {
         context.publisherNodes.size() == 1
         context.publisherNodes[0].name() == 'hudson.plugins.textfinder.TextFinderPublisher'
         context.publisherNodes[0].regexp[0].value() == 'foo'
-        context.publisherNodes[0].fileSet[0].value() == ''
+        context.publisherNodes[0].fileSet.size() == 0
         context.publisherNodes[0].alsoCheckConsoleOutput[0].value() == false
         context.publisherNodes[0].succeedIfFound[0].value() == false
         context.publisherNodes[0].unstableIfFound[0].value() == false


### PR DESCRIPTION
If the fileSet is provided but has an empty body, it appears to match all files, thus grepping the entire workspace.

This change will only add the element if the value is non-empty (truthy).

Affected test has been updated, and currently running this on our production jenkins instance :)
