### PR TITLE
Add support for specifying post build task publisher tasks via DSL

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PostBuildTaskContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PostBuildTaskContext.groovy
@@ -7,15 +7,14 @@ import javaposse.jobdsl.dsl.helpers.Context
 class PostBuildTaskContext implements Context {
     def tasks = []
 
-    // TODO Allow for multiple pairs of logText and operator! Can we add a smart dsl method for the two operators: AND and OR?
-    def task(String logText, String script, String operator = 'AND', boolean escalate = false, boolean runIfSuccessful = false) {
+    def task(String logText, String script, boolean escalate = false, boolean runIfSuccessful = false) {
         Preconditions.checkArgument(logText != null && logText.length() > 0, "Log Text to match is required!")
         Preconditions.checkArgument(script != null && script.length() > 0, "Script to run is required!")
 
         tasks << new PostBuildTask(
             logText: logText,
             script: script,
-            operator: operator,
+            operator: 'AND',
             escalateStatus: escalate,
             runIfJobSuccessful: runIfSuccessful
         )

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextHelper.groovy
@@ -765,44 +765,44 @@ class PublisherContextHelper extends AbstractContextHelper<PublisherContextHelpe
             }
         }
 
-		/**
+        /**
          * Configures the Jenkins Post Build Task plugin
          *
          * <publishers>
-         *     	<hudson.plugins.postbuildtask.PostbuildTask plugin="postbuild-task@1.8">
-			        <tasks>
-			            <hudson.plugins.postbuildtask.TaskProperties>
-			                <logTexts>
-			                    <hudson.plugins.postbuildtask.LogProperties>
-			                        <logText>BUILD SUCCESSFUL</logText>
-			                        <operator>AND</operator>
-			                    </hudson.plugins.postbuildtask.LogProperties>
-			                </logTexts>
-			                <EscalateStatus>false</EscalateStatus>
-			                <RunIfJobSuccessful>false</RunIfJobSuccessful>
-			                <script>git clean -fdx</script>
-			            </hudson.plugins.postbuildtask.TaskProperties>
-			        </tasks>
-			    </hudson.plugins.postbuildtask.PostbuildTask>
+         *     <hudson.plugins.postbuildtask.PostbuildTask>
+         *          <tasks>
+         *              <hudson.plugins.postbuildtask.TaskProperties>
+         *                  <logTexts>
+         *                      <hudson.plugins.postbuildtask.LogProperties>
+         *                          <logText>BUILD SUCCESSFUL</logText>
+         *                          <operator>AND</operator>
+         *                      </hudson.plugins.postbuildtask.LogProperties>
+         *                  </logTexts>
+         *                  <EscalateStatus>false</EscalateStatus>
+         *                  <RunIfJobSuccessful>false</RunIfJobSuccessful>
+         *                  <script>git clean -fdx</script>
+         *              </hudson.plugins.postbuildtask.TaskProperties>
+         *          </tasks>
+         *      </hudson.plugins.postbuildtask.PostbuildTask>
          */
         def postBuildTask(Closure postBuildClosure) {
             PostBuildTaskContext postBuildContext = new PostBuildTaskContext()
             AbstractContextHelper.executeInContext(postBuildClosure, postBuildContext)
 
-            publisherNodes << NodeBuilder.newInstance().'hudson.plugins.postbuildtask.PostbuildTask'(plugin: 'postbuild-task@1.8') {
+            publisherNodes << NodeBuilder.newInstance().'hudson.plugins.postbuildtask.PostbuildTask' {
                 tasks {
-					postBuildContext.tasks.each { PostBuildTaskContext.PostBuildTask task ->
+                    postBuildContext.tasks.each { PostBuildTaskContext.PostBuildTask task ->
                         'hudson.plugins.postbuildtask.TaskProperties' {
-						    logTexts {
-						        'hudson.plugins.postbuildtask.LogProperties' {
-						            'logText'(task.logText)
-						            'operator'(task.operator)
-						        }
-						    }
-						    'EscalateStatus'(task.escalateStatus)
-						    'RunIfJobSuccessful'(task.runIfJobSuccessful)
-						    'script'(task.script)
-					    }
+                            logTexts {
+                                'hudson.plugins.postbuildtask.LogProperties' {
+                                    logText(task.logText)
+                                    operator(task.operator)
+                                }
+                            }
+                            EscalateStatus(task.escalateStatus)
+                            RunIfJobSuccessful(task.runIfJobSuccessful)
+                            script(task.script)
+                        }
                     }
                 }
             }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
@@ -1121,10 +1121,10 @@ public class PublisherHelperSpec extends Specification {
         then:
         context.publisherNodes.size() == 1
         context.publisherNodes[0].name() == 'hudson.plugins.postbuildtask.PostbuildTask'
-        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].'logTexts'[0].'hudson.plugins.postbuildtask.LogProperties'[0].logText[0].value() == 'BUILD SUCCESSFUL'
-        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].'logTexts'[0].'hudson.plugins.postbuildtask.LogProperties'[0].operator[0].value() == 'AND'
-        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].'EscalateStatus'[0].value() == false
-        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].'RunIfJobSuccessful'[0].value() == false
+        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].logTexts[0].'hudson.plugins.postbuildtask.LogProperties'[0].logText[0].value() == 'BUILD SUCCESSFUL'
+        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].logTexts[0].'hudson.plugins.postbuildtask.LogProperties'[0].operator[0].value() == 'AND'
+        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].EscalateStatus[0].value() == false
+        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].RunIfJobSuccessful[0].value() == false
         context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].script[0].value() == 'git clean -fdx'
     }
 
@@ -1132,22 +1132,22 @@ public class PublisherHelperSpec extends Specification {
         when:
         context.postBuildTask() {
             task('BUILD SUCCESSFUL', 'git clean -fdx')
-            task('BUILD FAILED', 'git gc', 'OR', true, true)
+            task('BUILD FAILED', 'git gc', true, true)
         }
 
         then:
         context.publisherNodes.size() == 1
         context.publisherNodes[0].name() == 'hudson.plugins.postbuildtask.PostbuildTask'
-        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].'logTexts'[0].'hudson.plugins.postbuildtask.LogProperties'[0].logText[0].value() == 'BUILD SUCCESSFUL'
-        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].'logTexts'[0].'hudson.plugins.postbuildtask.LogProperties'[0].operator[0].value() == 'AND'
-        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].'EscalateStatus'[0].value() == false
-        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].'RunIfJobSuccessful'[0].value() == false
+        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].logTexts[0].'hudson.plugins.postbuildtask.LogProperties'[0].logText[0].value() == 'BUILD SUCCESSFUL'
+        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].logTexts[0].'hudson.plugins.postbuildtask.LogProperties'[0].operator[0].value() == 'AND'
+        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].EscalateStatus[0].value() == false
+        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].RunIfJobSuccessful[0].value() == false
         context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[0].script[0].value() == 'git clean -fdx'
 
-        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[1].'logTexts'[0].'hudson.plugins.postbuildtask.LogProperties'[0].logText[0].value() == 'BUILD FAILED'
-        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[1].'logTexts'[0].'hudson.plugins.postbuildtask.LogProperties'[0].operator[0].value() == 'OR'
-        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[1].'EscalateStatus'[0].value() == true
-        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[1].'RunIfJobSuccessful'[0].value() == true
+        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[1].logTexts[0].'hudson.plugins.postbuildtask.LogProperties'[0].logText[0].value() == 'BUILD FAILED'
+        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[1].logTexts[0].'hudson.plugins.postbuildtask.LogProperties'[0].operator[0].value() == 'AND'
+        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[1].EscalateStatus[0].value() == true
+        context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[1].RunIfJobSuccessful[0].value() == true
         context.publisherNodes[0].tasks[0].'hudson.plugins.postbuildtask.TaskProperties'[1].script[0].value() == 'git gc'
     }
 }


### PR DESCRIPTION
This adds basic support for the post build task publisher. This can support multiple tasks, but does not yet support multiple text matches chained within a task (using or/and operators).
