### PR TITLE
Added patch to prevent job configuration dialog breaking

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/MonitorTemplateJobs.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/MonitorTemplateJobs.java
@@ -4,7 +4,6 @@ package javaposse.jobdsl.plugin;
 import com.google.common.base.Function;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 import hudson.Extension;
 import hudson.Util;
 import hudson.XmlFile;
@@ -15,7 +14,6 @@ import hudson.model.Saveable;
 import hudson.model.listeners.SaveableListener;
 import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
-import org.apache.commons.collections.MultiMap;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -48,25 +46,21 @@ public class MonitorTemplateJobs extends SaveableListener {
         String possibleTemplateName = project.getName();
 
         DescriptorImpl descriptor = Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class);
-
         if (descriptor == null) {
             LOGGER.warning("Unable to get DescriptorImpl");
         }
 
         Multimap<String,SeedReference> templateJobMap = (descriptor != null? descriptor.getTemplateJobMap(): null);
-
         if (templateJobMap == null) {
             LOGGER.warning("Descriptor returned no template job map.");
         }
 
         Collection<SeedReference> seedJobReferences = templateJobMap != null? templateJobMap.get(possibleTemplateName): Collections.<SeedReference>emptyList();
-
         if (seedJobReferences.isEmpty()) {
             return;
         }
 
         final String digest;
-
         try {
             digest = Util.getDigestOf(new FileInputStream(project.getConfigFile().getFile()));
         } catch (IOException e) {

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/MonitorTemplateJobs.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/MonitorTemplateJobs.java
@@ -3,6 +3,8 @@ package javaposse.jobdsl.plugin;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicates;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import hudson.Extension;
 import hudson.Util;
 import hudson.XmlFile;
@@ -13,10 +15,12 @@ import hudson.model.Saveable;
 import hudson.model.listeners.SaveableListener;
 import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
+import org.apache.commons.collections.MultiMap;
 
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.logging.Logger;
 
 import static com.google.common.collect.Collections2.filter;
@@ -44,13 +48,25 @@ public class MonitorTemplateJobs extends SaveableListener {
         String possibleTemplateName = project.getName();
 
         DescriptorImpl descriptor = Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class);
-        Collection<SeedReference> seedJobReferences = descriptor.getTemplateJobMap().get(possibleTemplateName);
+
+        if (descriptor == null) {
+            LOGGER.warning("Unable to get DescriptorImpl");
+        }
+
+        Multimap<String,SeedReference> templateJobMap = (descriptor != null? descriptor.getTemplateJobMap(): null);
+
+        if (templateJobMap == null) {
+            LOGGER.warning("Descriptor returned no template job map.");
+        }
+
+        Collection<SeedReference> seedJobReferences = templateJobMap != null? templateJobMap.get(possibleTemplateName): Collections.<SeedReference>emptyList();
 
         if (seedJobReferences.isEmpty()) {
             return;
         }
 
         final String digest;
+
         try {
             digest = Util.getDigestOf(new FileInputStream(project.getConfigFile().getFile()));
         } catch (IOException e) {


### PR DESCRIPTION
I experienced that in some cases the configuration of jobs was no longer possible  
because the Definition Template lookup returned null.

Just added some code to prevent the NPE percolating up and breaking the Job Configuration UI.