### PR TITLE
allow to specify the Maven installation

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -39,7 +39,7 @@ public class DslScriptLoader {
         // Add static imports of a few common types, like JobType
         ImportCustomizer icz = new ImportCustomizer();
         icz.addStaticStars("javaposse.jobdsl.dsl.JobType");
-        icz.addStaticStars("javaposse.jobdsl.dsl.helpers.MavenHelper.LocalRepositoryLocation");
+        icz.addStaticStars("javaposse.jobdsl.dsl.helpers.common.MavenContext.LocalRepositoryLocation");
         config.addCompilationCustomizers(icz);
 
         GroovyScriptEngine engine = //scriptRequest.resourceConnector!=null?

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/MavenHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/MavenHelper.groovy
@@ -2,12 +2,13 @@ package javaposse.jobdsl.dsl.helpers
 
 import javaposse.jobdsl.dsl.JobType
 import javaposse.jobdsl.dsl.WithXmlAction
+import javaposse.jobdsl.dsl.helpers.common.MavenContext
 import javaposse.jobdsl.dsl.helpers.step.AbstractStepContext
 
 import static com.google.common.base.Preconditions.checkNotNull
 import static com.google.common.base.Preconditions.checkState
 
-class MavenHelper extends AbstractHelper {
+class MavenHelper extends AbstractHelper implements MavenContext {
 
     StringBuilder allGoals = new StringBuilder()
     StringBuilder allMavenOpts = new StringBuilder()
@@ -113,7 +114,7 @@ class MavenHelper extends AbstractHelper {
      * Set to use isolated local Maven repositories.
      * @param location the local repository to use for isolation
      */
-    def localRepository(LocalRepositoryLocation location) {
+    def localRepository(MavenContext.LocalRepositoryLocation location) {
         checkState type == JobType.Maven, "localRepository can only be applied for Maven jobs"
         checkNotNull location, "localRepository can not be null"
         execute { Node node ->
@@ -145,14 +146,11 @@ class MavenHelper extends AbstractHelper {
         }
     }
 
-    public enum LocalRepositoryLocation {
-        LocalToExecutor('hudson.maven.local_repo.PerExecutorLocalRepositoryLocator'),
-        LocalToWorkspace('hudson.maven.local_repo.PerJobLocalRepositoryLocator')
-
-        String type
-
-        public LocalRepositoryLocation(String type) {
-            this.type = type
+    def mavenInstallation(String name) {
+        checkState type == JobType.Maven, "mavenInstallation can only be applied for Maven jobs"
+        checkNotNull name, "name can not be null"
+        execute { Node node ->
+            appendOrReplaceNode node, 'mavenName', name
         }
     }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/MavenContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/MavenContext.groovy
@@ -1,0 +1,48 @@
+package javaposse.jobdsl.dsl.helpers.common
+
+import javaposse.jobdsl.dsl.helpers.Context
+
+interface MavenContext extends Context {
+    /**
+     * Specifies the path to the root POM.
+     * @param rootPOM path to the root POM
+     */
+    def rootPOM(String rootPOM)
+
+    /**
+     * Specifies the goals to execute.
+     * @param goals the goals to execute
+     */
+    def goals(String goals)
+
+    /**
+     * Specifies the JVM options needed when launching Maven as an external process.
+     * @param mavenOpts JVM options needed when launching Maven
+     */
+    def mavenOpts(String mavenOpts)
+
+    /**
+     * <localRepository class="hudson.maven.local_repo.PerJobLocalRepositoryLocator"/>
+     *
+     * Set to use isolated local Maven repositories.
+     * @param location the local repository to use for isolation
+     */
+    def localRepository(LocalRepositoryLocation location)
+
+    /**
+     * Specifies the Maven installation for executing this step or job
+     * @param name name of the Maven installation to use
+     */
+    def mavenInstallation(String name)
+
+    public enum LocalRepositoryLocation {
+        LocalToExecutor('hudson.maven.local_repo.PerExecutorLocalRepositoryLocator'),
+        LocalToWorkspace('hudson.maven.local_repo.PerJobLocalRepositoryLocator')
+
+        String type
+
+        public LocalRepositoryLocation(String type) {
+            this.type = type
+        }
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MavenContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MavenContext.groovy
@@ -1,0 +1,41 @@
+package javaposse.jobdsl.dsl.helpers.step
+
+import javaposse.jobdsl.dsl.helpers.common.MavenContext.LocalRepositoryLocation
+
+class MavenContext implements javaposse.jobdsl.dsl.helpers.common.MavenContext {
+    String rootPOM
+    List<String> goals = []
+    List<String> mavenOpts = []
+    LocalRepositoryLocation localRepositoryLocation
+    String mavenInstallation = '(Default)'
+    Closure configureBlock
+    
+    @Override
+    def rootPOM(String rootPOM) {
+        this.rootPOM = rootPOM
+    }
+
+    @Override
+    def goals(String goals) {
+        this.goals << goals
+    }
+
+    @Override
+    def mavenOpts(String mavenOpts) {
+        this.mavenOpts << mavenOpts
+    }
+
+    @Override
+    def localRepository(LocalRepositoryLocation location) {
+        this.localRepositoryLocation = location
+    }
+
+    @Override
+    def mavenInstallation(String name) {
+        this.mavenInstallation = name
+    }
+    
+    def configure(Closure closure) {
+        this.configureBlock = closure
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/MavenHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/MavenHelperSpec.groovy
@@ -3,6 +3,7 @@ package javaposse.jobdsl.dsl.helpers
 import javaposse.jobdsl.dsl.JobType
 import javaposse.jobdsl.dsl.WithXmlAction
 import javaposse.jobdsl.dsl.WithXmlActionSpec
+import javaposse.jobdsl.dsl.helpers.common.MavenContext
 import spock.lang.Specification
 
 public class MavenHelperSpec extends Specification {
@@ -250,7 +251,7 @@ public class MavenHelperSpec extends Specification {
         MavenHelper helper = new MavenHelper(mockActions, JobType.Freeform)
 
         when:
-        helper.localRepository(MavenHelper.LocalRepositoryLocation.LocalToExecutor)
+        helper.localRepository(MavenContext.LocalRepositoryLocation.LocalToExecutor)
 
         then:
         thrown(IllegalStateException)
@@ -266,7 +267,7 @@ public class MavenHelperSpec extends Specification {
 
     def 'localRepository constructs xml for LocalToExecutor'() {
         when:
-        def action = helper.localRepository(MavenHelper.LocalRepositoryLocation.LocalToExecutor)
+        def action = helper.localRepository(MavenContext.LocalRepositoryLocation.LocalToExecutor)
         action.execute(root)
 
         then:
@@ -275,7 +276,7 @@ public class MavenHelperSpec extends Specification {
 
     def 'localRepository constructs xml for LocalToWorkspace'() {
         when:
-        def action = helper.localRepository(MavenHelper.LocalRepositoryLocation.LocalToWorkspace)
+        def action = helper.localRepository(MavenContext.LocalRepositoryLocation.LocalToWorkspace)
         action.execute(root)
 
         then:
@@ -326,5 +327,34 @@ public class MavenHelperSpec extends Specification {
         then:
         root.postbuilders[0].children()[0].name() == 'hudson.tasks.Shell'
         root.postbuilders[0].children()[0].command[0].value() == 'ls'
+    }
+
+    def 'can run mavenInstallation'() {
+        when:
+        helper.mavenInstallation('test')
+
+        then:
+        1 * mockActions.add(_)
+    }
+
+    def 'cannot run mavenInstallation for free style jobs'() {
+        setup:
+        MavenHelper helper = new MavenHelper(mockActions, JobType.Freeform)
+
+        when:
+        helper.mavenInstallation('test')
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def 'mavenInstallation constructs xml'() {
+        when:
+        def action = helper.mavenInstallation('test')
+        action.execute(root)
+
+        then:
+        root.mavenName.size() == 1
+        root.mavenName[0].value() == 'test'
     }
 }


### PR DESCRIPTION
This adds a new top-level method and a variant of the maven step which can be configured with a closure.

``` groovy
job(type: Maven) {
    ...
    mavenInstallation('Maven 3.0.5')
    ...
}
```

``` groovy
job {
    ...
    steps {
        ...
        maven {
            rootPOM('pom.xml')
            goals('clean install')
            mavenInstallation('Maven 3.0.5')
        }
        ...
    }
    ...
}
```
