### PR TITLE
[JENKINS-21935] added DSL support for the repository-connector plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -182,6 +182,8 @@ public class DslScriptLoader {
         icz.addImports("javaposse.jobdsl.dsl.views.ListView.StatusFilter");
         icz.addImports("javaposse.jobdsl.dsl.views.BuildPipelineView.OutputStyle");
         icz.addImports("javaposse.jobdsl.dsl.views.DeliveryPipelineView.Sorting");
+        icz.addImports("javaposse.jobdsl.dsl.helpers.step.RepositoryConnectorContext.RepositoryConnectorChecksumPolicy");
+        icz.addImports("javaposse.jobdsl.dsl.helpers.step.RepositoryConnectorContext.RepositoryConnectorUpdatePolicy");
         config.addCompilationCustomizers(icz);
 
         config.setOutput(new PrintWriter(jobManagement.getOutputStream())); // This seems to do nothing

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/RepositoryConnectorArtifactContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/RepositoryConnectorArtifactContext.groovy
@@ -1,0 +1,68 @@
+package javaposse.jobdsl.dsl.helpers.step
+
+import javaposse.jobdsl.dsl.helpers.Context
+
+/**
+ * <p>DSL Support for the repository-connector plugin's artifacts subsection.</p>
+ * <p><a href="https://wiki.jenkins-ci.org/display/JENKINS/Repository+Connector+Plugin">Repository Connector Plugin</a></p>
+ */
+class RepositoryConnectorArtifactContext implements Context {
+
+    String groupId
+    String artifactId
+    String classifier = ''
+    String version
+    String extension
+    String targetFileName
+
+    /**
+     * <p>Id of the Maven group.</p>
+     * @param groupId groupId of the Maven coordinates
+     */
+    def groupId(String groupId) {
+        this.groupId = groupId
+    }
+
+    /**
+     * <p>Id of the Maven artefact</p>
+     * @param artifactId artefact id of the maven coordinates
+     */
+    void artifactId(String artifactId) {
+        this.artifactId = artifactId
+    }
+
+    /**
+     * <p>Maven version classifier (optional)</p>
+     * @param classifier version classifier which is appended
+     * to the version separated by a dash
+     * e.g. "javadoc" or "sources" (default: <empty>)
+     */
+    void classifier(String classifier) {
+        this.classifier = classifier
+    }
+
+    /**
+     * <p>Version of the artifact to download.</p>
+     * @param version specific artifact version, RELEASE, LATEST or a
+     * version range e.g. [0-SNAPSHOT,) are supported.
+     */
+    void version(String version) {
+        this.version = version
+    }
+
+    /**
+     * <p>Artifact extension</p>
+     * @param extension e.g. jar, war, ear
+     */
+    void extension(String extension) {
+        this.extension = extension
+    }
+
+    /**
+     * <p>Target file name</p>
+     * @param targetFileName the name of the downloaded file
+     */
+    void targetFileName(String targetFileName) {
+        this.targetFileName = targetFileName
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/RepositoryConnectorArtifactContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/RepositoryConnectorArtifactContext.groovy
@@ -4,7 +4,9 @@ import javaposse.jobdsl.dsl.helpers.Context
 
 /**
  * <p>DSL Support for the repository-connector plugin's artifacts subsection.</p>
- * <p><a href="https://wiki.jenkins-ci.org/display/JENKINS/Repository+Connector+Plugin">Repository Connector Plugin</a></p>
+ * <p>
+ *     <a href="https://wiki.jenkins-ci.org/display/JENKINS/Repository+Connector+Plugin">Repository Connector Plugin</a>
+ * </p>
  */
 class RepositoryConnectorArtifactContext implements Context {
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/RepositoryConnectorContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/RepositoryConnectorContext.groovy
@@ -5,18 +5,20 @@ import javaposse.jobdsl.dsl.helpers.Context
 
 /**
  * <p>DSL Support for the repository-connector plugin.</p>
- * <p><a href="https://wiki.jenkins-ci.org/display/JENKINS/Repository+Connector+Plugin">Repository Connector Plugin</a></p>
+ * <p>
+ *     <a href="https://wiki.jenkins-ci.org/display/JENKINS/Repository+Connector+Plugin">Repository Connector Plugin</a>
+ * </p>
  */
 class RepositoryConnectorContext implements Context {
 
     /**
      * <p>Enumeration of available artifact checksum policies.</p>
      */
-    public static enum RepositoryConnectorChecksumPolicy {
+    static enum RepositoryConnectorChecksumPolicy {
 
-        WARN("warn"),
+        WARN('warn'),
 
-        FAIL("fail")
+        FAIL('fail')
 
         private final String stringRepresentation
 
@@ -25,8 +27,8 @@ class RepositoryConnectorContext implements Context {
         }
 
         @Override
-        public String toString() {
-            return this.stringRepresentation
+        String toString() {
+            this.stringRepresentation
         }
 
     }
@@ -34,13 +36,13 @@ class RepositoryConnectorContext implements Context {
     /**
      * <p>Enumeration of available repository update policies.</p>
      */
-    public static enum RepositoryConnectorUpdatePolicy {
+    static enum RepositoryConnectorUpdatePolicy {
 
-        DAILY("daily"),
+        DAILY('daily'),
 
-        NEVER("never"),
+        NEVER('never'),
 
-        ALWAYS("always")
+        ALWAYS('always')
 
         private final String stringRepresentation
 
@@ -49,8 +51,8 @@ class RepositoryConnectorContext implements Context {
         }
 
         @Override
-        public String toString() {
-            return this.stringRepresentation
+        String toString() {
+            this.stringRepresentation
         }
     }
 
@@ -156,7 +158,8 @@ class RepositoryConnectorContext implements Context {
      *     </artifacts>
      *}
      * </pre>
-     * @see <a href="https://wiki.jenkins-ci.org/display/JENKINS/Repository+Connector+Plugin">Repository Connector Plugin</a>
+     * @see
+     * <a href="https://wiki.jenkins-ci.org/display/JENKINS/Repository+Connector+Plugin">Repository Connector Plugin</a>
      */
     def artifact(Closure artifactClosure) {
         RepositoryConnectorArtifactContext context = new RepositoryConnectorArtifactContext()

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/RepositoryConnectorContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/RepositoryConnectorContext.groovy
@@ -1,0 +1,177 @@
+package javaposse.jobdsl.dsl.helpers.step
+
+import javaposse.jobdsl.dsl.helpers.AbstractContextHelper
+import javaposse.jobdsl.dsl.helpers.Context
+
+/**
+ * <p>DSL Support for the repository-connector plugin.</p>
+ * <p><a href="https://wiki.jenkins-ci.org/display/JENKINS/Repository+Connector+Plugin">Repository Connector Plugin</a></p>
+ */
+class RepositoryConnectorContext implements Context {
+
+    /**
+     * <p>Enumeration of available artifact checksum policies.</p>
+     */
+    public static enum RepositoryConnectorChecksumPolicy {
+
+        WARN("warn"),
+
+        FAIL("fail")
+
+        private final String stringRepresentation
+
+        RepositoryConnectorChecksumPolicy(String stringRepresentation) {
+            this.stringRepresentation = stringRepresentation
+        }
+
+        @Override
+        public String toString() {
+            return this.stringRepresentation
+        }
+
+    }
+
+    /**
+     * <p>Enumeration of available repository update policies.</p>
+     */
+    public static enum RepositoryConnectorUpdatePolicy {
+
+        DAILY("daily"),
+
+        NEVER("never"),
+
+        ALWAYS("always")
+
+        private final String stringRepresentation
+
+        RepositoryConnectorUpdatePolicy(String stringRepresentation) {
+            this.stringRepresentation = stringRepresentation
+        }
+
+        @Override
+        public String toString() {
+            return this.stringRepresentation
+        }
+    }
+
+    List<Node> artifactNodes = []
+
+    String targetDirectory
+
+    boolean failOnError = false
+    boolean enableRepoLogging = false
+
+    RepositoryConnectorUpdatePolicy snapshotUpdatePolicy = RepositoryConnectorUpdatePolicy.DAILY
+    RepositoryConnectorUpdatePolicy releaseUpdatePolicy = RepositoryConnectorUpdatePolicy.DAILY
+    RepositoryConnectorChecksumPolicy snapshotChecksumPolicy = RepositoryConnectorChecksumPolicy.WARN
+    RepositoryConnectorChecksumPolicy releaseChecksumPolicy = RepositoryConnectorChecksumPolicy.WARN
+
+    /**
+     * <p>Defines the directory where the artifact gets stored.</p>
+     * @param targetDirectory e.g. 'target'
+     */
+    def targetDirectory(String targetDirectory) {
+        this.targetDirectory = targetDirectory
+    }
+
+    /**
+     * <p>Fails the build on the first artifact, which can not be retrieved.</p>
+     * @param failOnError (default: false)
+     */
+    def failOnError(boolean failOnError = true) {
+        this.failOnError = failOnError
+    }
+
+    /**
+     * <p>Enables logging for repository and transfer.</p>
+     * @param enableRepoLogging (default: false)
+     */
+    def enableRepoLogging(boolean enableRepoLogging = true) {
+        this.enableRepoLogging = enableRepoLogging
+    }
+
+    /**
+     * <p>Maven snapshot update policy.</p>
+     * @param snapshotUpdatePolicy must be one of {@link RepositoryConnectorUpdatePolicy}:
+     * <ul>
+     *     <li>{@link RepositoryConnectorUpdatePolicy#DAILY} (default)</li>
+     *     <li>{@link RepositoryConnectorUpdatePolicy#NEVER}</li>
+     *     <li>{@link RepositoryConnectorUpdatePolicy#ALWAYS}</li>
+     * </ul>
+     */
+    def snapshotUpdatePolicy(RepositoryConnectorUpdatePolicy snapshotUpdatePolicy) {
+        this.snapshotUpdatePolicy = snapshotUpdatePolicy
+    }
+
+    /**
+     * <p>Maven release update policy.</p>
+     * @param releaseUpdatePolicy must be one of {@link RepositoryConnectorUpdatePolicy}:
+     * <ul>
+     *     <li>{@link RepositoryConnectorUpdatePolicy#DAILY} (default)</li>
+     *     <li>{@link RepositoryConnectorUpdatePolicy#NEVER}</li>
+     *     <li>{@link RepositoryConnectorUpdatePolicy#ALWAYS}</li>
+     * </ul>
+     */
+    def releaseUpdatePolicy(RepositoryConnectorUpdatePolicy releaseUpdatePolicy) {
+        this.releaseUpdatePolicy = releaseUpdatePolicy
+    }
+
+    /**
+     * <p>What to do when verification of an snapshot artifact checksum fails.</p>
+     * @param snapshotChecksumPolicy must be one of {@link RepositoryConnectorChecksumPolicy}:
+     * <ul>
+     *     <li>{@link RepositoryConnectorChecksumPolicy#WARN} (default)</li>
+     *     <li>{@link RepositoryConnectorChecksumPolicy#FAIL}</li>
+     * </ul>
+     */
+    def snapshotChecksumPolicy(RepositoryConnectorChecksumPolicy snapshotChecksumPolicy) {
+        this.snapshotChecksumPolicy = snapshotChecksumPolicy
+    }
+
+    /**
+     * <p>What to do when verification of an release artifact checksum fails.</p>
+     * @param releaseChecksumPolicy must be one of {@link RepositoryConnectorChecksumPolicy}:
+     * <ul>
+     *     <li>{@link RepositoryConnectorChecksumPolicy#WARN} (default)</li>
+     *     <li>{@link RepositoryConnectorChecksumPolicy#FAIL}</li>
+     * </ul>
+     */
+    def releaseChecksumPolicy(RepositoryConnectorChecksumPolicy releaseChecksumPolicy) {
+        this.releaseChecksumPolicy = releaseChecksumPolicy
+    }
+
+    /**
+     * <p>Configures the resolution of an artifact from an repository using the repository-connector plugin.</p>
+     * <pre>
+     * {@code
+     *     <artifacts>
+     *       <org.jvnet.hudson.plugins.repositoryconnector.Artifact>
+     *         <groupId>de.test.me</groupId>
+     *         <artifactId>myTestArtifact</artifactId>
+     *         <classifier/>
+     *         <version>RELEASE</version>
+     *         <extension>war</extension>
+     *         <targetFileName>myTestArtifact.war</targetFileName>
+     *       </org.jvnet.hudson.plugins.repositoryconnector.Artifact>
+     *     </artifacts>
+     *}
+     * </pre>
+     * @see <a href="https://wiki.jenkins-ci.org/display/JENKINS/Repository+Connector+Plugin">Repository Connector Plugin</a>
+     */
+    def artifact(Closure artifactClosure) {
+        RepositoryConnectorArtifactContext context = new RepositoryConnectorArtifactContext()
+        AbstractContextHelper.executeInContext(artifactClosure, context)
+
+        def nodeBuilder = NodeBuilder.newInstance()
+        Node artifactNode = nodeBuilder.'org.jvnet.hudson.plugins.repositoryconnector.Artifact' {
+            groupId context.groupId
+            artifactId context.artifactId
+            classifier context.classifier
+            version context.version
+            extension context.extension
+            targetFileName context.targetFileName
+        }
+
+        artifactNodes << artifactNode
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -536,7 +536,9 @@ class StepContext implements Context {
     }
 
     /**
-     * <p>Configures the resolution of one or more artifacts from an repository using the repository-connector plugin.</p>
+     * <p>
+     *     Configures the resolution of one or more artifacts from an repository using the repository-connector plugin.
+     * </p>
      * <pre>
      * {@code
      * <org.jvnet.hudson.plugins.repositoryconnector.ArtifactResolver>
@@ -564,7 +566,8 @@ class StepContext implements Context {
      * </org.jvnet.hudson.plugins.repositoryconnector.ArtifactResolver>
      * }
      * </pre>
-     * @see <a href="https://wiki.jenkins-ci.org/display/JENKINS/Repository+Connector+Plugin">Repository Connector Plugin</a>
+     * @see
+     * <a href="https://wiki.jenkins-ci.org/display/JENKINS/Repository+Connector+Plugin">Repository Connector Plugin</a>
      */
     def resolveArtifact(Closure repositoryConnectorContext) {
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -536,6 +536,61 @@ class StepContext implements Context {
     }
 
     /**
+     * <p>Configures the resolution of one or more artifacts from an repository using the repository-connector plugin.</p>
+     * <pre>
+     * {@code
+     * <org.jvnet.hudson.plugins.repositoryconnector.ArtifactResolver>
+     *     <targetDirectory>target</targetDirectory>
+     *
+     *     <failOnError>false</failOnError>
+     *     <enableRepoLogging>false</enableRepoLogging>
+     *
+     *     <snapshotUpdatePolicy>daily</snapshotUpdatePolicy>
+     *     <releaseUpdatePolicy>daily</releaseUpdatePolicy>
+     *
+     *     <snapshotChecksumPolicy>warn</snapshotChecksumPolicy>
+     *     <releaseChecksumPolicy>warn</releaseChecksumPolicy>
+     *
+     *     <artifacts>
+     *       <org.jvnet.hudson.plugins.repositoryconnector.Artifact>
+     *         <groupId>de.test.me</groupId>
+     *         <artifactId>myTestArtifact</artifactId>
+     *         <classifier/>
+     *         <version>RELEASE</version>
+     *         <extension>war</extension>
+     *         <targetFileName>myTestArtifact.war</targetFileName>
+     *       </org.jvnet.hudson.plugins.repositoryconnector.Artifact>
+     *     </artifacts>
+     * </org.jvnet.hudson.plugins.repositoryconnector.ArtifactResolver>
+     * }
+     * </pre>
+     * @see <a href="https://wiki.jenkins-ci.org/display/JENKINS/Repository+Connector+Plugin">Repository Connector Plugin</a>
+     */
+    def resolveArtifact(Closure repositoryConnectorContext) {
+
+        RepositoryConnectorContext context = new RepositoryConnectorContext()
+        AbstractContextHelper.executeInContext(repositoryConnectorContext, context)
+
+        def nodeBuilder = NodeBuilder.newInstance()
+
+        Node artifactResolverNode = nodeBuilder.'org.jvnet.hudson.plugins.repositoryconnector.ArtifactResolver' {
+            targetDirectory context.targetDirectory
+
+            failOnError context.failOnError
+            enableRepoLogging context.enableRepoLogging
+
+            snapshotUpdatePolicy context.snapshotUpdatePolicy.toString()
+            releaseUpdatePolicy context.releaseUpdatePolicy.toString()
+            snapshotChecksumPolicy context.snapshotChecksumPolicy.toString()
+            releaseChecksumPolicy context.releaseChecksumPolicy.toString()
+
+            artifacts context.artifactNodes
+        }
+
+        stepNodes << artifactResolverNode
+    }
+
+    /**
      * phaseName will have to be provided in the closure
      *
      * <com.tikal.jenkins.plugins.multijob.MultiJobBuilder>

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepHelperSpec.groovy
@@ -710,7 +710,7 @@ class StepHelperSpec extends Specification {
 
     def 'call resolveArtifact with minimal arguments' () {
         when:
-        context.resolveArtifact() {
+        context.resolveArtifact {
             targetDirectory 'target'
 
             artifact {
@@ -736,7 +736,8 @@ class StepHelperSpec extends Specification {
         repositoryConnectorNode.snapshotChecksumPolicy[0].value() == RepositoryConnectorChecksumPolicy.WARN.toString()
         repositoryConnectorNode.releaseChecksumPolicy[0].value() == RepositoryConnectorChecksumPolicy.WARN.toString()
 
-        def artifactNode = repositoryConnectorNode.artifacts[0].'org.jvnet.hudson.plugins.repositoryconnector.Artifact'[0]
+        def artifactNode =
+                repositoryConnectorNode.artifacts[0].'org.jvnet.hudson.plugins.repositoryconnector.Artifact'[0]
 
         artifactNode.groupId[0].value() == 'de.test.me'
         artifactNode.artifactId[0].value() == 'myTestArtifact'
@@ -747,7 +748,7 @@ class StepHelperSpec extends Specification {
 
     def 'call resolveArtifact with all arguments and two artifacts' () {
         when:
-        context.resolveArtifact() {
+        context.resolveArtifact {
             failOnError()
             enableRepoLogging()
 
@@ -789,7 +790,8 @@ class StepHelperSpec extends Specification {
         repositoryConnectorNode.snapshotChecksumPolicy[0].value() == RepositoryConnectorChecksumPolicy.WARN.toString()
         repositoryConnectorNode.releaseChecksumPolicy[0].value() == RepositoryConnectorChecksumPolicy.WARN.toString()
 
-        def artifactNode = repositoryConnectorNode.artifacts[0].'org.jvnet.hudson.plugins.repositoryconnector.Artifact'[0]
+        def artifactNode =
+                repositoryConnectorNode.artifacts[0].'org.jvnet.hudson.plugins.repositoryconnector.Artifact'[0]
 
         artifactNode.groupId[0].value() == 'org.slf4j'
         artifactNode.artifactId[0].value() == 'slf4j-api'
@@ -798,7 +800,8 @@ class StepHelperSpec extends Specification {
         artifactNode.extension[0].value() == 'jar'
         artifactNode.targetFileName[0].value() == 'slf4j-api-1.7.6-TEST.jar'
 
-        def artifactNodeTwo = repositoryConnectorNode.artifacts[0].'org.jvnet.hudson.plugins.repositoryconnector.Artifact'[1]
+        def artifactNodeTwo =
+                repositoryConnectorNode.artifacts[0].'org.jvnet.hudson.plugins.repositoryconnector.Artifact'[1]
 
         artifactNodeTwo.groupId[0].value() == 'ch.qos.logback'
         artifactNodeTwo.artifactId[0].value() == 'logback-classic'


### PR DESCRIPTION
This pull request adds support for the repository-connector plugin.

I tested the plugin on Jenkins 1.532.1 and repository-connector plugin 0.8.2 running on Windows 2008 R2 SP1. Also tested on Jenkins 1.480 repository-connector plugin 0.8.2 on Windows 7.

Please review and merge.