### PR TITLE
Added Github Commit Notifier publisher.

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -952,11 +952,10 @@ class PublisherContext implements Context {
      * Create commit status notifications on the commits based on the outcome of the build.
      *
      * <publishers>
-     *     <com.cloudbees.jenkins.GitHubCommitNotifier plugin="github@1.8"/>
+     *     <com.cloudbees.jenkins.GitHubCommitNotifier/>
      * </publishers>
      */
     def githubCommitNotifier() {
-        def attributes = [plugin: 'github@1.8']
-        publisherNodes << new NodeBuilder().'com.cloudbees.jenkins.GitHubCommitNotifier'(attributes)
+        publisherNodes << new NodeBuilder().'com.cloudbees.jenkins.GitHubCommitNotifier'()
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
@@ -1527,6 +1527,5 @@ public class PublisherHelperSpec extends Specification {
         context.publisherNodes.size() == 1
         def githubCommitNotifier = context.publisherNodes[0]
         githubCommitNotifier.name() == 'com.cloudbees.jenkins.GitHubCommitNotifier'
-        githubCommitNotifier.attribute('plugin') == "github@1.8"
     }
 }


### PR DESCRIPTION
Can be used in the publishers block using 'githubCommitNotifier()'.

I will update the wiki in a moment.
