### PR TITLE
Deprecation Warnings

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
@@ -61,4 +61,9 @@ public interface JobManagement {
      * @return id of Credentials or <code>null</code> if no credentials could be found
      */
     String getCredentialsId(String credentialsDescription);
+
+    /**
+     * Logs a deprecation warning for the calling method.
+     */
+    void logDeprecationWarning();
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
@@ -1,0 +1,63 @@
+package javaposse.jobdsl.dsl
+
+import spock.lang.Specification
+
+import static org.codehaus.groovy.runtime.InvokerHelper.createScript
+
+class AbstractJobManagementSpec extends Specification {
+    def 'deprecation warning in DSL script'() {
+        setup:
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream()
+        AbstractJobManagement jobManagement = new TestJobManagement(new PrintStream(buffer))
+
+        GroovyClassLoader classLoader = new GroovyClassLoader();
+        Class scriptClass = classLoader.parseClass(this.class.getResourceAsStream('/deprecation.groovy').text);
+        Script script = createScript(scriptClass, new Binding([jm: jobManagement]));
+
+        when:
+        script.run()
+
+        then:
+        buffer.toString().trim() == 'Warning: testMethod is deprecated (DSL script, line 1)'
+    }
+
+    def 'deprecation warning in source file'() {
+        setup:
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream()
+        AbstractJobManagement jobManagement = new TestJobManagement(new PrintStream(buffer))
+
+        URL[] roots = [this.class.getResource("/deprecation.groovy")]
+        GroovyScriptEngine groovyScriptEngine = new GroovyScriptEngine(roots)
+
+        when:
+        groovyScriptEngine.run('deprecation.groovy', new Binding([jm: jobManagement]));
+
+        then:
+        buffer.toString().trim() == 'Warning: testMethod is deprecated (deprecation.groovy, line 1)'
+    }
+
+    static class TestJobManagement extends AbstractJobManagement {
+        protected TestJobManagement(PrintStream out) {
+            super(out)
+        }
+
+        @Override
+        String getConfig(String jobName) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        boolean createOrUpdateConfig(String jobName, String config, boolean ignoreExisting) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        void createOrUpdateView(String viewName, String config, boolean ignoreExisting) {
+            throw new UnsupportedOperationException()
+        }
+
+        void testMethod() {
+            logDeprecationWarning()
+        }
+    }
+}

--- a/job-dsl-core/src/test/resources/deprecation.groovy
+++ b/job-dsl-core/src/test/resources/deprecation.groovy
@@ -1,0 +1,1 @@
+jm.testMethod()


### PR DESCRIPTION
I added a method to log a deprecation warning for the calling method. It is intended to be called from deprecated DSL methods so that users see a deprecation warnings in the build log.

It does some magic to analyze the stack trace to find the deprecated method and the code line calling that method.
