### PR TITLE
Added spec element to GhprbTrigger.

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
@@ -155,6 +155,7 @@ class TriggerContext implements Context {
             whitelist pullRequestBuilderContext.userWhitelist.join('\n')
             orgslist pullRequestBuilderContext.orgWhitelist.join('\n')
             delegate.cron(pullRequestBuilderContext.cron)
+            spec pullRequestBuilderContext.cron
             triggerPhrase pullRequestBuilderContext.triggerPhrase
             onlyTriggerPhrase pullRequestBuilderContext.onlyTriggerPhrase
             useGitHubHooks pullRequestBuilderContext.useGitHubHooks

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerHelperSpec.groovy
@@ -309,6 +309,7 @@ public class TriggerHelperSpec extends Specification {
             permitAll[0].value() == false
             autoCloseFailedPullRequests[0].value() == false
             cron[0].value() == 'H/5 * * * *'
+            spec[0].value() == 'H/5 * * * *'
             triggerPhrase[0].value() == ''
             adminlist[0].value() == ''
             whitelist[0].value() == ''
@@ -356,6 +357,7 @@ public class TriggerHelperSpec extends Specification {
             whitelist[0].value() == 'test'
             orgslist[0].value() == 'test'
             cron[0].value() == '*/5 * * * *'
+            spec[0].value() == '*/5 * * * *'
             triggerPhrase[0].value() == 'ok to test'
             onlyTriggerPhrase[0].value() == true
             useGitHubHooks[0].value() == true


### PR DESCRIPTION
By default, the GhprbTrigger XML element generated does not contain a <spec> element. When this element is not present, Jenkins will not use the trigger (tested with Jenkins v1.565, Git client plugin v1.9.1, Git plugin v2.2.1, Github API plugin v1.44, Github Authentication plugin v0.16, Github plugin v1.8, Github Pull Request Builder plugin v1.12).

By default, the spec element seems to get the same value as the cron element (when configured manually).

Not sure if this is the correct fix, just let me know when it isn't.
