### PR TITLE
Added a buildName wrapper, for Build Name Setter plugin

### DIFF
--- a/docs/Job-DSL-Commands.md
+++ b/docs/Job-DSL-Commands.md
@@ -121,6 +121,7 @@ job(attributes) {
         preBuildCleanup(closure) // since 1.22
         logSizeChecker(closure) // since 1.23, see [Job Reference]] for details
         injectPasswords() // since 1.23
+        buildName(nameTemplate) // since 1.24
     }
     steps {
         shell(String commandStr)

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -1013,6 +1013,23 @@ job {
 
 (since 1.23)
 
+## [Build Name Setter Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build+Name+Setter+Plugin)
+
+Example:
+```groovy
+// define the build name based on the build number and an environment variable
+job {
+    wrappers {
+        buildName('#${BUILD_NUMBER} on ${ENV,var="BRANCH"}')
+    }
+}
+```
+
+Configures the Build Name Setter plugin. Tokens expansion mechanism is provided
+by the Token Macro Plugin.
+
+(Since 1.24)
+
 # Build Steps
 
 Adds step block to contain an ordered list of build steps. Cannot be used for jobs with type 'maven'.

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -466,4 +466,26 @@ class WrapperContext implements Context {
             failBuild(context.failBuild)
         }
     }
+
+    /**
+     * Enables the "Build Name Setter Plugin" build wrapper.<br>
+     * See https://wiki.jenkins-ci.org/display/JENKINS/Build+Name+Setter+Plugin
+     *
+     * <pre>
+     * &lt;buildWrappers>
+     *     &lt;org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
+     *         &lt;template>#${BUILD_NUMBER} on ${ENV,var="BRANCH"}&lt;/template>
+     *     &lt;/org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
+     * &lt;/buildWrappers>
+     * </pre>
+     *
+     * @param nameTemplate template defining the build name. Tokens expansion
+     *   mechanism is provided by the Token Macro Plugin.
+     */
+    def buildName(String nameTemplate) {
+        Preconditions.checkNotNull(nameTemplate, "Name template must not be null")
+        wrapperNodes << new NodeBuilder().'org.jenkinsci.plugins.buildnamesetter.BuildNameSetter' {
+            template nameTemplate
+        }
+    }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperHelperSpec.groovy
@@ -586,4 +586,27 @@ class WrapperHelperSpec extends Specification {
             children()[0].value() == true
         }
     }
+
+    def 'call buildName' () {
+        when:
+        helper.wrappers {
+            buildName('#${BUILD_NUMBER} && <test>')
+        }
+        executeHelperActionsOnRootNode()
+
+        then:
+        def wrapper = root.buildWrappers[0].'org.jenkinsci.plugins.buildnamesetter.BuildNameSetter'
+        wrapper.template[0].value() == '#${BUILD_NUMBER} && <test>'
+    }
+
+    def 'call buildName with null parameter' () {
+        when:
+        helper.wrappers {
+            buildName(null)
+        }
+
+        then:
+        thrown(NullPointerException)
+    }
+
 }


### PR DESCRIPTION
Hi,

I've written a little "buildWrapper" wrapper method. It enables and configures the Build Name Setter plugin, which allows defining how the job builds should be named:
https://wiki.jenkins-ci.org/display/JENKINS/Build+Name+Setter+Plugin

It would be nice to merge it for next version (currently I'm using it already through WrapperContext.metaClass).

Thanks,
Thomas.
