### PR TITLE
Ignore ClassJavadoc Rule

### DIFF
--- a/config/codenarc/rules.groovy
+++ b/config/codenarc/rules.groovy
@@ -41,7 +41,7 @@ ruleset {
             characterAfterColonRegex = /\s/
         }
 
-        // TODO: fix violations
+        // we don't care for now
         exclude 'ClassJavadoc'
         // TODO: fix violations
         exclude 'ConsecutiveBlankLines'


### PR DESCRIPTION
There are more than 80 violations, mainly context classes, which do not necessarily need Javadoc.
