### PR TITLE
Drop Java 5 Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ subprojects {
     apply plugin: 'maven' // for publishing
     apply plugin: 'codenarc'
 
-    sourceCompatibility = 1.5
-    targetCompatibility = 1.5
+    sourceCompatibility = 1.6
+    targetCompatibility = 1.6
 
     dependencies {
         compile 'org.codehaus.groovy:groovy-all:1.8.6'

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -14,6 +14,7 @@ And finally, if you want to get more involved, [here's how...](https://github.co
 
 ## Release Notes
 * 1.25 (unreleased)
+ * Dropped support for Java 5, Java 6 or later is required at runtime
 * 1.24 (July 05 2014)
  * Support for [Build Name Setter Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build+Name+Setter+Plugin)
  * Support for [RunDeck Plugin](https://wiki.jenkins-ci.org/display/JENKINS/RunDeck+Plugin)


### PR DESCRIPTION
We have been using Java 6 API at least since 1.20, so I'm officially dropping Java 6 support although plugins depending on Jenkins <1.520 should support Java 5, see https://wiki.jenkins-ci.org/display/JENKINS/Java+5+Compatibility.
