### PR TITLE
Revert "Create and publish plugin JAR"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,16 +29,6 @@ subprojects {
         testCompile 'org.objenesis:objenesis:1.2' // used by Spock
     }
 
-    task jarSources(type: Jar) {
-        from sourceSets.main.allSource
-        classifier = 'sources'
-    }
-
-    task jarJavadocs(type: Jar, dependsOn: 'javadoc') {
-        from project.javadoc.destinationDir
-        classifier = 'javadoc'
-    }
-
     codenarc {
         toolVersion = '0.21'
         configFile = file('../config/codenarc/rules.groovy')
@@ -74,6 +64,16 @@ project(':job-dsl-core') {
         manifest {
             attributes 'Main-Class': project.mainClassName
         }
+    }
+
+    task jarSources(type: Jar) {
+        from sourceSets.main.allSource
+        classifier = 'sources'
+    }
+
+    task jarJavadocs(type: Jar, dependsOn: 'javadoc') {
+        from project.javadoc.destinationDir
+        classifier = 'javadoc'
     }
 
     task jarGroovydocs(type: Jar, dependsOn: 'groovydoc') {

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -45,12 +45,6 @@ jenkinsPlugin {
     }
 }
 
-artifacts {
-    archives jar
-    archives jarJavadocs
-    archives jarSources
-}
-
 dependencies {
     compile project(':job-dsl-core')
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:cloudbees-folder:4.2@jar'


### PR DESCRIPTION
The change generated a POM for the JAR instead of a POM for the JPI. I have no idea how to fix it, so I'm reverting the change. Unfortunately we need the JAR some day so that other plugins can implement the extension point. I'm close to migrating the Gradle build to Maven...
