### PR TITLE
Failed Builds

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -109,7 +109,7 @@ public class DslScriptLoader {
                 LOGGER.log(Level.FINE, String.format("Saving job %s as %s", job.getName(), xml));
                 boolean created = jp.getJm().createOrUpdateConfig(job.getName(), xml, ignoreExisting);
                 String templateName = job instanceof Job ? ((Job) job).getTemplateName() : null;
-                generatedJobs.add(new GeneratedJob(templateName, job.getName(), created));
+                generatedJobs.add(new GeneratedJob(templateName, job.getName()));
             }
         }
         return generatedJobs;

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedJob.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedJob.java
@@ -3,9 +3,8 @@ package javaposse.jobdsl.dsl;
 public class GeneratedJob implements Comparable {
     private String templateName;
     private String jobName;
-    private boolean created;
 
-    public GeneratedJob(String templateName, String jobName, boolean created) {
+    public GeneratedJob(String templateName, String jobName) {
         super();
         this.templateName = templateName;
         this.jobName = jobName;
@@ -17,10 +16,6 @@ public class GeneratedJob implements Comparable {
 
     public String getTemplateName() {
         return templateName;
-    }
-
-    public boolean isCreated() {
-        return created;
     }
 
     @Override

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
@@ -13,7 +13,6 @@ import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.BuildListener;
 import hudson.model.Item;
-import hudson.model.Result;
 import hudson.tasks.Builder;
 import javaposse.jobdsl.dsl.DslScriptLoader;
 import javaposse.jobdsl.dsl.GeneratedItems;
@@ -158,18 +157,6 @@ public class ExecuteDslScripts extends Builder {
             GeneratedItems generatedItems = DslScriptLoader.runDslEngine(request, jm);
             freshJobs.addAll(generatedItems.getJobs());
             freshViews.addAll(generatedItems.getViews());
-        }
-
-        Set<GeneratedJob> failedJobs = new HashSet<GeneratedJob>();
-        for (GeneratedJob gj : freshJobs) {
-            if (gj.isCreated()) {
-                failedJobs.add(gj);
-            }
-        }
-
-        if (!failedJobs.isEmpty()) {
-            listener.getLogger().println("Failed jobs: " + Joiner.on(",").join(failedJobs));
-            build.setResult(Result.UNSTABLE);
         }
 
         updateTemplates(build, listener, freshJobs);

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ExecuteDslScriptsTest.java
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ExecuteDslScriptsTest.java
@@ -467,7 +467,7 @@ public class ExecuteDslScriptsTest {
         assertNotNull(buildAction);
         assertNotNull(buildAction.getModifiedJobs());
         assertEquals(1, buildAction.getModifiedJobs().size());
-        assertTrue(buildAction.getModifiedJobs().contains(new GeneratedJob(null, "test-folder", true)));
+        assertTrue(buildAction.getModifiedJobs().contains(new GeneratedJob(null, "test-folder")));
 
         // when
         GeneratedJobsAction action = job.getAction(GeneratedJobsAction.class);
@@ -476,10 +476,10 @@ public class ExecuteDslScriptsTest {
         assertNotNull(action);
         assertNotNull(action.findLastGeneratedJobs());
         assertEquals(1, action.findLastGeneratedJobs().size());
-        assertTrue(action.findLastGeneratedJobs().contains(new GeneratedJob(null, "test-folder", true)));
+        assertTrue(action.findLastGeneratedJobs().contains(new GeneratedJob(null, "test-folder")));
         assertNotNull(action.findAllGeneratedJobs());
         assertEquals(1, action.findAllGeneratedJobs().size());
-        assertTrue(action.findAllGeneratedJobs().contains(new GeneratedJob(null, "test-folder", true)));
+        assertTrue(action.findAllGeneratedJobs().contains(new GeneratedJob(null, "test-folder")));
         assertNotNull(action.getItems());
         assertEquals(1, action.getItems().size());
         assertTrue(action.getItems().contains(jenkinsRule.getInstance().getItem("test-folder")));


### PR DESCRIPTION
The code to set the seed job build to unstable when a job could not be created never worked. I removed it since nobody has missed that until now.
