### PR TITLE
Add FlexiblePublish

### DIFF
--- a/docs/Job-DSL-Commands.md
+++ b/docs/Job-DSL-Commands.md
@@ -238,6 +238,7 @@ job(Map<String, ?> arguments = [:]) {
         findbugs(String pattern, boolean isRankActivated = false,
                  Closure staticAnalysisClosure = null)
         fingerprint(String targets, boolean recordBuildArtifacts = false)
+        flexiblePublish(Closure flexiblePublishClosure = null) // since 1.24
         flowdock(String token, Closure flowdockClosure = null) // since 1.23
         flowdock(String[] tokens, flowdockClosure = null) // since 1.23
         git(Closure gitPublisherClosure) // since 1.22

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -3313,6 +3313,72 @@ job {
 
 (since 1.24)
 
+## Flexible publish
+
+```groovy
+job {
+    publishers {
+        flexiblePublish {
+            condition {
+                /* Any run condition closure, see conditionalSteps above. */
+            }
+            publisher {
+                /* Any single publisher closure. */ 
+            }
+            step {
+                /* Any single build step closure. */
+            }
+        }
+    }
+}
+```
+
+Configures a conditional publisher action. Requires the 
+[Flexible publish plugin](https://wiki.jenkins-ci.org/display/JENKINS/Flexible+Publish+Plugin).
+If the
+[Any build step plugin](https://wiki.jenkins-ci.org/display/JENKINS/Any+Build+Step+Plugin)
+is installed, then a build step can be used instead of a publisher. Note that
+in any case, only one build step or one publisher can be given (this is a
+limitation of the jenkins FlexiblePublish publisher).
+
+Examples:
+
+```groovy
+job {
+    publishers {
+        flexiblePublish {
+            condition {
+                status 'ABORTED', 'FAILURE'
+            }
+            publisher {
+               wsCleanup()
+            }
+        }
+    }
+}
+```
+
+```groovy
+job {
+    publishers {
+        flexiblePublish {
+            condition {
+                and {
+                    stringsEqual 'foo', 'bar'
+                } {
+                    status 'SUCCESS'
+                }
+            }
+            step {
+               shell 'echo hello!'
+            }
+        }
+    }
+}
+```
+
+(since 1.24)
+
 # Parameters
 **Note: In all cases apart from File Parameter the parameterName argument can't be null or empty**
 _Note: The Password Parameter is not yet supported. See https://issues.jenkins-ci.org/browse/JENKINS-18141_

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/FlexiblePublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/FlexiblePublisherContext.groovy
@@ -1,0 +1,44 @@
+package javaposse.jobdsl.dsl.helpers.publisher
+
+import javaposse.jobdsl.dsl.helpers.step.AbstractStepContext
+import javaposse.jobdsl.dsl.helpers.Context
+import javaposse.jobdsl.dsl.helpers.AbstractContextHelper
+import javaposse.jobdsl.dsl.JobManagement
+
+import javaposse.jobdsl.dsl.helpers.step.condition.RunCondition
+import javaposse.jobdsl.dsl.helpers.step.condition.RunConditionFactory
+
+import static com.google.common.base.Preconditions.checkArgument
+import static com.google.common.base.Preconditions.checkState
+
+class FlexiblePublisherContext implements Context {
+    final JobManagement jobManagement
+
+    RunCondition condition
+    AbstractStepContext stepContext
+    PublisherContext publisherContext
+
+    FlexiblePublisherContext(JobManagement jobManagement) {
+        this.jobManagement = jobManagement
+    }
+
+    def condition(Closure closure) {
+        condition = RunConditionFactory.of(closure)
+    }
+
+    def step(Closure closure) {
+        checkState(publisherContext == null, 'Only 1 of step or publisher can be provided')
+
+        stepContext = new AbstractStepContext(jobManagement)
+        AbstractContextHelper.executeInContext(closure, stepContext)
+        checkArgument(stepContext.stepNodes.size() == 1, 'Only 1 build step action allowed')
+    }
+
+    def publisher(Closure closure) {
+        checkState(stepContext == null, 'Only 1 of step or publisher can be provided')
+        /* We pass null as the 'jobManagement' parameter because it appears to be unused. */
+        publisherContext = new PublisherContext(jobManagement)
+        AbstractContextHelper.executeInContext(closure, publisherContext)
+        checkArgument(publisherContext.publisherNodes.size() == 1, 'Only 1 publish action allowed')
+    }
+}


### PR DESCRIPTION
## Overview

Adds support for the FlexiblePublish plugin, and fixes some bugs in run conditions (in particular, for the alwaysRun condition and the build status condition). These run conditions are frequently (and apparently, exclusively) used in conjunction with the flexible publish plugin, which is why they were fixed in one wad.
## Implementation

This wad includes 3 related changes:
### Build Status Condition

The build status condition was previously built using a SimpleCondition. Unfortunately, this generated the wrong XML for the Run Condition Plugin version 1.0: it was generating blobs of the form:

```
<condition class="org.jenkins_ci.plugins.run_condition.core.StatusCondition">
  <worstResult>SUCCESS</worstResult>
  <bestResult>FAILURE</bestResult>
</condition>
```

Whereas using the gui to configure a job generated XML of the form:

```
<condition class="org.jenkins_ci.plugins.run_condition.core.StatusCondition" plugin="run-condition@1.0">
  <worstResult>
    <name>FAILURE</name>
    <ordinal>2</ordinal>
    <color>RED</color>
    <completeBuild>true</completeBuild>
  </worstResult>
  <bestResult>
     <name>SUCCESS</name>
     <ordinal>0</ordinal>
     <color>BLUE</color>
     <completeBuild>true</completeBuild>
  </bestResult>
</condition>
```

Through further experimentation, we found that the `ordinal` tag was necessary and sufficient for jenkins to correctly process the job. Unfortunately, this meant we couldn't use a `SimpleCondition` for build status anymore, as the testing infrastructure wasn't able to handle `SimpleCondition` nodes with children.
### Always Run Condition

The Always Run condition was generating xml nodes with an incorrect class: they had `org.jenkins_ci.plugins.run_condition.core.AlwaysRunCondition` instead of `org.jenkins_ci.plugins.run_condition.core.AlwaysRun`. Due to how the `SimpleCondition` class was designed (it always adds 'Condition' to the name of the class), it was easier to create a new class for the AlwaysRunCondition.
### Flexible publisher

The flexible publish class was designed to use the existing contexts (the `PublisherContext`, the `AbstractStepContext`, and the `RunConditionFactory`) to be as simple as possible.
## Testing done

In addition to the included tests, we have been using this internally for a while via the following monkey patches:

```
        /*                                                                      
         * A condition that matches if the current build status is better than  
         * or equal to worstResult and worse than or equal to bestResult.       
         *                                                                      
         * Example - the following matches only successful builds.              
         *                                                                      
         *    condition {                                                       
         *        status 'SUCCESS', 'SUCCESS'                                   
         *    }                                                                 
         */                                                                     
        RunConditionContext.metaClass.status { String worstResult, String bestResult = null ->
            bestResult = bestResult ?: worstResult                              

            def statuses = [                                                    
                'SUCCESS',                                                         
                'UNSTABLE',                                                        
                'FAILURE',                                                         
                'NOT_BUILT',                                                       
                'ABORTED',                                                         
            ]                                                                      

            assert statuses.contains(worstResult)                                  
            assert statuses.contains(bestResult)                                   

            condition = new SimpleCondition(                                       
                name: 'Status',                                                    
                args: ['worstResult': {                                            
                    ordinal statuses.findIndexOf { it == worstResult }             
                }, 'bestResult': {                                                 
                    ordinal statuses.findIndexOf { it == bestResult }              
                }])                                                                
        }  

        /*                                                                         
         * Unfortunately, alwaysRun doesn't work in the current version of the  
         * dsl plugin - it creates an AlwaysRunCondition node, rather than an   
         * AlwaysRun node. We fix it here.                                         
         */                                                                        
        RunConditionContext.metaClass.alwaysRun { ->                               
            condition = new AlwaysRunCondition()                                   
        }                                                                          

        PublisherContext.metaClass.flexible_publish { Closure closure ->           
                def innerContext = new FlexiblePublisherContext()                  
                AbstractContextHelper.executeInContext(closure, innerContext)   

                publisherNodes << innerContext.node                                
        }   
```

With the FlexiblePublisherContext included below basically unchanged (the only difference is I added the asserts here).
