### PR TITLE
Node param

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -29,6 +29,7 @@ And finally, if you want to get more involved, [here's how...](https://github.co
  * Short names in the Gerrit trigger event closure have been replaced by DSL methods, see [[Migration]]
  * The `archiveJunit` method with boolean arguments has been deprecated, see [[Migration]]
  * `javaposse.jobdsl.dsl.helpers.step.AbstractStepContext` has been removed, see [[Migration]]
+ * Parital support for [NodeLabel Parameter Plugin](https://wiki.jenkins-ci.org/display/JENKINS/NodeLabel+Parameter+Plugin)
 * 1.25 (September 01 2014)
  * Dropped support for Java 5, Java 6 or later is required at runtime
  * Support for [Rake Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Rake+plugin)

--- a/docs/Job-DSL-Commands.md
+++ b/docs/Job-DSL-Commands.md
@@ -101,6 +101,7 @@ job(Map<String, ?> arguments = [:]) {
                     String description = null)
         textParam(String parameterName, String defaultValue = null,
                   String description = null)
+        nodeParam(parameterName, allowedSlaves, description, Closure closure) // See [[Job Reference]] for more detail
     }
     scm {
         baseClearCase(Closure closure) // since 1.24

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -1854,6 +1854,7 @@ job(type: Multijob) {
                 props(Map<String, String> map)
                 disableJob(boolean exposedScm = true) // since 1.25
                 killPhaseCondition(String killPhaseCondition) // since 1.25
+                nodeLabel(String paramName, String nodeLabel)
             }
         }
     }
@@ -1890,6 +1891,7 @@ job(type: Multijob) {
                 subversionRevision()
                 gitRevision()
                 prop('prop1', 'value1')
+                nodeLabel('lParam', 'my_nodes')
             }
         }
    }
@@ -2030,6 +2032,7 @@ downstreamParameterized(Closure downstreamClosure) {
         matrixSubset(String groovyFilter) // Restrict matrix execution to a subset
         subversionRevision() // Subversion Revision
         sameNode() //Run the next job on the same node
+        nodeLabel(String paramName, String nodeLabel) // Limit to node label selection
      }
 }
 ```
@@ -2064,6 +2067,7 @@ steps {
             predefinedProps('key4=value4\nkey5=value5') // Newline separated
             matrixSubset('label=="${TARGET}"') // Restrict matrix execution to a subset
             subversionRevision() // Subversion Revision
+            nodeLabel(String paramName, String nodeLabel) // Limit to node label selection
         }
         trigger('Project2') {
             currentBuild()
@@ -2453,6 +2457,7 @@ downstreamParameterized(Closure downstreamClosure) {
         predefinedProps(String predefinedProps) // Newline separated
         matrixSubset(String groovyFilter) // Restrict matrix execution to a subset
         subversionRevision() // Subversion Revision
+        nodeLabel(String paramName, String nodeLabel) // Limit to node label selection
      }
 }
 ```
@@ -2476,6 +2481,7 @@ publishers {
             predefinedProps('key4=value4\nkey5=value5') // Newline separated
             matrixSubset('label=="${TARGET}"') // Restrict matrix execution to a subset
             subversionRevision() // Subversion Revision
+            nodeLabel(String paramName, String nodeLabel) // Limit to node label selection
         }
         trigger('Project2') {
             currentBuild()
@@ -3067,6 +3073,7 @@ job {
                 predefinedProps(String predefinedProps)
                 matrixSubset(String groovyFilter)
                 subversionRevision()
+                nodeLabel(String paramName, String nodeLabel) // Limit to node label selection
             }
         }
     }
@@ -3652,4 +3659,45 @@ textParam("myParameterName", "my default textParam value")
 Full usage
 ```groovy
 textParam("myParameterName", "my default textParam value", "my description")
+```
+
+## Node parameter
+
+```groovy
+job {
+    parameters {
+        nodeParam(String name, List<String> allowedSlaves, String description = '') {
+            // The collection of default slaves on which this can be run. Defaults to all allowedSlaves.
+            defaultSlaves(List<String> defaultSlaves)
+            // trigger must be one of 'allCases', 'success', 'unstable', 'allowMultiSelectionForConcurrentBuilds', or 'multiSelectionDisallowed'.
+            // Defaults to allCases if not specified
+	    trigger(String trigger)
+            // eligibility options must be one of 'AllNodeEligibility', 'IgnoreOfflineNodeEligibility', 'IgnoreTempOfflineNodeEligibility'.
+            // Defaults to AllNodeEligibility if not specified.
+            eligibility(String eligibility)
+        }
+    }
+}
+```
+
+nodeParam has two usages: the simple usage (with no closure, using the default) and the extended usage (with a closure defining trigger, defaultSlaves, or eligibility)
+
+### Simple usage
+
+Simplest usage In this case `defaultSlaves` is `['node1', 'node2']`, `description` is empty,
+`trigger` is `multiSelectionDisallowed`, and `eligibility` is
+`AllNodeElegibility`
+Usage
+```groovy
+nodeParam("myParameterName", ['node1', 'node2'])
+```
+### Complex usage
+
+Usage
+```groovy
+nodeParam("myParameterName", ['node1', 'node2', 'node3'], 'my_description') {
+    defaultSlaves(['node1'])
+    trigger 'multiSelectionDisallowed'
+    eligibility 'IgnoreOfflineNodeEligibility'
+}
 ```

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/NodeParamContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/NodeParamContext.groovy
@@ -1,0 +1,57 @@
+package javaposse.jobdsl.dsl.helpers
+
+import static com.google.common.base.Preconditions.checkArgument
+import static com.google.common.base.Preconditions.checkNotNull
+
+class NodeParamContext implements Context {
+    List<String> pDefaultNodes = []
+    String pEligibility = 'AllNodeEligibility'
+    String pTrigger = 'allCases'
+    String pAllowMultiNodeSelection = 'true'
+    String pTriggerConcurrentBuilds = 'false'
+    final List<String> allowedNodes
+
+    NodeParamContext(List<String> allowedNodes) {
+        this.allowedNodes = allowedNodes
+        pDefaultNodes = allowedNodes
+    }
+
+    def defaultSlaves(List<String> nodes) {
+        checkNotNull(nodes)
+        checkArgument(nodes.size() > 0, 'at least one default node must be specified')
+        nodes.each {
+            checkArgument(it in allowedNodes, it + ' not an allowed slave')
+        }
+        pDefaultNodes = nodes
+    }
+
+    def eligibility(String elig) {
+        checkArgument(elig in ['AllNodeEligibility',
+                               'IgnoreOfflineNodeEligibility',
+                                'IgnoreTempOfflineNodeEligibility'],
+                      'eligibility ' + elig + ' is invalid')
+        pEligibility = elig
+    }
+
+    def trigger(String trigger) {
+        pTrigger = trigger
+        switch (trigger) {
+        case 'success':
+        case 'unstable':
+        case 'allCases':
+            pAllowMultiNodeSelection = 'true'
+            pTtriggerConcurrentBuilds = 'false'
+            break
+        case 'allowMultiSelectionForConcurrentBuilds':
+            pAllowMultiNodeSelection = 'true'
+            pTriggerConcurrentBuilds = 'true'
+            break
+        case 'multiSelectionDisallowed':
+            pAllowMultiNodeSelection = 'false'
+            pTriggerConcurrentBuilds = 'false'
+            break
+        default:
+            throw new IllegalArgumentException('trigger ' + trigger + ' is invalid')
+        }
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/DownstreamTriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/DownstreamTriggerContext.groovy
@@ -14,6 +14,8 @@ class DownstreamTriggerContext implements Context {
     String projects
     String condition
     String matrixSubsetFilter
+    String nodeLabelParam
+    String nodeLabel
     Map<String, Boolean> boolParams = [:]
 
     boolean triggerWithNoParameters
@@ -26,6 +28,7 @@ class DownstreamTriggerContext implements Context {
     boolean combineQueuedCommits = false
     boolean usingPredefined = false
     boolean usingMatrixSubset = false
+    boolean usingNodeLabel = false
     boolean sameNode = false
 
     def currentBuild() {
@@ -75,6 +78,12 @@ class DownstreamTriggerContext implements Context {
 
     def sameNode(boolean sameNode = true) {
         this.sameNode = sameNode
+    }
+
+    def nodeLabel(String paramName, String nodeLabel) {
+        usingNodeLabel = true
+        this.nodeLabelParam = paramName
+        this.nodeLabel = nodeLabel
     }
 
     def blockingThresholdsFromMap(Map<String, String> thresholdMap) {
@@ -133,6 +142,13 @@ class DownstreamTriggerContext implements Context {
             if (usingSubversionRevision) {
                 'hudson.plugins.parameterizedtrigger.SubversionRevisionBuildParameters' {
                     delegate.createNode('includeUpstreamParameters', includeUpstreamParameters)
+                }
+            }
+
+            if (usingNodeLabel) {
+                'org.jvnet.jenkins.plugins.nodelabelparameter.parameterizedtrigger.NodeLabelBuildParameter' {
+                    name nodeLabelParam
+                    nodeLabel nodeLabel
                 }
             }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/PhaseJobContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/PhaseJobContext.groovy
@@ -21,6 +21,8 @@ class PhaseJobContext implements Context {
     String matrixFilter
     Boolean subversionRevision
     Boolean gitRevision
+    String nodeLabelParam
+    String nodeLabel
     def props = []
     boolean disableJob = false
     String killPhaseCondition = 'FAILURE'
@@ -90,13 +92,20 @@ class PhaseJobContext implements Context {
         paramTrigger.predefinedProps(map)
     }
 
+    def nodeLabel(String paramName, String nodeLabel)  {
+        Preconditions.checkState(!this.nodeLabelParam, "nodeLabel parameter already set with ${this.nodeLabelParam}")
+        this.nodeLabelParam = paramName
+        this.nodeLabel = nodeLabel
+        paramTrigger.nodeLabel(paramName, nodeLabel)
+    }
+
     def configAsNode() {
         paramTrigger.createParametersNode()
     }
 
     def hasConfig() {
         !boolParams.isEmpty() || fileParam || nodeParam || matrixFilter || subversionRevision != null ||
-                gitRevision != null || !props.isEmpty()
+                gitRevision != null || !props.isEmpty() || nodeLabelParam
     }
 
     def disableJob(boolean disableJob = true) {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
@@ -897,6 +897,7 @@ class PublisherHelperSpec extends Specification {
                 boolParam('bParam', false)
                 boolParam('cParam', true)
                 sameNode()
+                nodeLabel('nodeParam', 'node_label')
             }
             trigger('Project2') {
                 currentBuild()
@@ -937,6 +938,11 @@ class PublisherHelperSpec extends Specification {
 
             def nodeNode = configs[0].'hudson.plugins.parameterizedtrigger.NodeParameters'[0]
             nodeNode != null
+
+            def nodeLabel = configs[0].
+                'org.jvnet.jenkins.plugins.nodelabelparameter.parameterizedtrigger.NodeLabelBuildParameter'[0]
+            nodeLabel.name[0].value() == 'nodeParam'
+            nodeLabel.nodeLabel[0].value() == 'node_label'
 
             block.isEmpty()
         }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepHelperSpec.groovy
@@ -792,6 +792,7 @@ class StepHelperSpec extends Specification {
                         prop3: 'value3',
                         prop4: 'value4'
                 ])
+                nodeLabel('nodeParam', 'node_label')
             }
         }
 
@@ -835,6 +836,11 @@ class StepHelperSpec extends Specification {
         propStr.contains('prop2=value2')
         propStr.contains('prop3=value3')
         propStr.contains('prop4=value4')
+
+        def nodeLabel = configsNode.
+            'org.jvnet.jenkins.plugins.nodelabelparameter.parameterizedtrigger.NodeLabelBuildParameter'[0]
+        nodeLabel.name[0].value() == 'nodeParam'
+        nodeLabel.nodeLabel[0].value() == 'node_label'
     }
 
     def 'call phases with multiple calls'() {
@@ -1214,6 +1220,7 @@ still-another-dsl.groovy'''
                 predefinedProps('key4=value4\nkey5=value5') // Newline separated
                 matrixSubset('label=="${TARGET}"') // Restrict matrix execution to a subset
                 subversionRevision() // Subversion Revision
+                nodeLabel('nodeParam', 'node_label') // Limit to node label selection
             }
             trigger('Project2') {
                 currentBuild()
@@ -1238,6 +1245,11 @@ still-another-dsl.groovy'''
             configs[0].'hudson.plugins.parameterizedtrigger.matrix.MatrixSubsetBuildParameters'[0].filter[0].value() ==
                     'label=="${TARGET}"'
             configs[0].'hudson.plugins.parameterizedtrigger.SubversionRevisionBuildParameters'[0] instanceof Node
+            configs[0].'org.jvnet.jenkins.plugins.nodelabelparameter.parameterizedtrigger.NodeLabelBuildParameter'[0].
+                name[0].value() == 'nodeParam'
+            configs[0].'org.jvnet.jenkins.plugins.nodelabelparameter.parameterizedtrigger.NodeLabelBuildParameter'[0].
+                nodeLabel[0].value() == 'node_label'
+
             block.size() == 1
             Node thresholds = block[0]
             thresholds.children().size() == 3


### PR DESCRIPTION
Building on https://github.com/jenkinsci/job-dsl-plugin/pull/238, I added support for nodeParam parameters for freestyle jobs.

This code review was prepared by starting from github.com/langers2k:nodelabelplugin. Afterwards, I rebased back to master.
## Implementation details

The only interesting implementation detail here is that there were several properties in the xml that were solely a function of one input parameter, the trigger.

``` xml
<triggerIfResult>multiSelectionDisallowed</triggerIfResult>
<allowMultiNodeSelection>false</allowMultiNodeSelection>
<triggerConcurrentBuilds>false</triggerConcurrentBuilds>
<ignoreOfflineNodes>false</ignoreOfflineNodes>
```

Using the GUI, I generated xml configs for each possible setting of `triggerIfResult` and hard coded this logic into a `switch`/`case` statement.
## Testing done

In addition to tests included in the diff, I monkey patched the function into `BuildParametersContext.metaClass.nodeParam`, generating a job with the new function. I verified that the configuration of the job looked right in the GUI and verified that I could select which node the build got run on (I verified that the plugin continued to work as expected).
