### PR TITLE
Added option to add classpath entries for Job DSL runs

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -18,6 +18,7 @@ And finally, if you want to get more involved, [here's how...](https://github.co
 ## Release Notes
 * 1.25 (unreleased)
  * Dropped support for Java 5, Java 6 or later is required at runtime
+ * Added option to add classpath entries for Job DSL runs
 * 1.24 (July 05 2014)
  * Support for [Build Name Setter Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build+Name+Setter+Plugin)
  * Support for [RunDeck Plugin](https://wiki.jenkins-ci.org/display/JENKINS/RunDeck+Plugin)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -14,7 +14,6 @@ import org.codehaus.groovy.runtime.InvokerHelper;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.net.URL;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -44,7 +43,7 @@ public class DslScriptLoader {
         icz.addStaticStars("javaposse.jobdsl.dsl.helpers.common.MavenContext.LocalRepositoryLocation");
         config.addCompilationCustomizers(icz);
 
-        GroovyScriptEngine engine = new GroovyScriptEngine(new URL[]{scriptRequest.urlRoot}, cl);
+        GroovyScriptEngine engine = new GroovyScriptEngine(scriptRequest.urlRoots, cl);
 
         engine.setConfig(config);
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ScriptRequest.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ScriptRequest.java
@@ -4,13 +4,21 @@ import java.net.URL;
 
 public class ScriptRequest {
     public ScriptRequest(String location, String body, URL urlRoot) {
-        this(location, body, urlRoot, false);
+        this(location, body, new URL[]{urlRoot});
+    }
+
+    public ScriptRequest(String location, String body, URL[] urlRoots) {
+        this(location, body, urlRoots, false);
     }
 
     public ScriptRequest(String location, String body, URL urlRoot, boolean ignoreExisting) {
+        this(location, body, new URL[]{urlRoot}, ignoreExisting);
+    }
+
+    public ScriptRequest(String location, String body, URL[] urlRoots, boolean ignoreExisting) {
         this.location = location;
         this.body = body;
-        this.urlRoot = urlRoot;
+        this.urlRoots = urlRoots;
         this.ignoreExisting = ignoreExisting;
     }
 
@@ -22,7 +30,7 @@ public class ScriptRequest {
 
     // Where can we load objects from
     //ResourceConnector resourceConnector; // OR
-    public URL urlRoot; // file://. or http://server/ or workspace://JOBNAME/
+    public URL[] urlRoots; // file://. or http://server/ or workspace://JOBNAME/
 
     // Ignore existing jobs
     public boolean ignoreExisting;

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ScriptRequestGenerator.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ScriptRequestGenerator.groovy
@@ -6,6 +6,8 @@ import hudson.FilePath
 import hudson.model.AbstractBuild
 import javaposse.jobdsl.dsl.ScriptRequest
 
+import static javaposse.jobdsl.plugin.WorkspaceProtocol.createWorkspaceUrl
+
 class ScriptRequestGenerator {
 
     final AbstractBuild build
@@ -17,20 +19,26 @@ class ScriptRequestGenerator {
     }
 
     Set<ScriptRequest> getScriptRequests(String targets, boolean usingScriptText, String scriptText,
-                                         boolean ignoreExisting) throws IOException, InterruptedException {
+                                         boolean ignoreExisting,
+                                         String additionalClasspath) throws IOException, InterruptedException {
         Set<ScriptRequest> scriptRequests = Sets.newLinkedHashSet()
 
+        List<URL> classpath = []
+        if (additionalClasspath) {
+            String expandedClasspath = env.expand(additionalClasspath)
+            expandedClasspath.split('\n').each { classpath << createWorkspaceUrl(build, build.workspace.child(it)) }
+        }
         if (usingScriptText) {
-            URL workspaceUrl = WorkspaceProtocol.createWorkspaceUrl(build.project)
-            ScriptRequest request = new ScriptRequest(null, scriptText, workspaceUrl, ignoreExisting)
+            URL[] urlRoots = ([createWorkspaceUrl(build.project)] + classpath) as URL[]
+            ScriptRequest request = new ScriptRequest(null, scriptText, urlRoots, ignoreExisting)
             scriptRequests.add(request)
         } else {
             String targetsStr = env.expand(targets)
 
             FilePath[] filePaths =  build.workspace.list(targetsStr.replace('\n', ','))
             for (FilePath filePath : filePaths) {
-                URL relativeWorkspaceUrl = WorkspaceProtocol.createWorkspaceUrl(build, filePath.parent)
-                ScriptRequest request = new ScriptRequest(filePath.name, null, relativeWorkspaceUrl, ignoreExisting)
+                URL[] urlRoots = ([createWorkspaceUrl(build, filePath.parent)] + classpath) as URL[]
+                ScriptRequest request = new ScriptRequest(filePath.name, null, urlRoots, ignoreExisting)
                 scriptRequests.add(request)
             }
         }

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/config.jelly
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/config.jelly
@@ -25,5 +25,9 @@
         <f:entry title="Context to use for relative job names:" field="lookupStrategy">
             <f:select default="JENKINS_ROOT"/>
         </f:entry>
+
+        <f:entry title="Additional classpath" field="additionalClasspath">
+            <f:expandableTextbox/>
+        </f:entry>
     </f:advanced>
 </j:jelly>

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-additionalClasspath.html
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-additionalClasspath.html
@@ -1,0 +1,4 @@
+<div>
+    Newline separated list of additional classpath entries for the Job DSL scripts. All entries must be relative to the
+    workspace root, e.g. <em>build/classes/main</em>.
+</div>

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ScriptRequestGeneratorSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ScriptRequestGeneratorSpec.groovy
@@ -1,0 +1,251 @@
+package javaposse.jobdsl.plugin
+
+import hudson.EnvVars
+import hudson.model.AbstractBuild
+import javaposse.jobdsl.dsl.ScriptRequest
+import org.junit.Rule
+import org.jvnet.hudson.test.JenkinsRule
+import spock.lang.Specification
+
+class ScriptRequestGeneratorSpec extends Specification {
+    private static final String SCRIPT = 'my script'
+
+    @Rule
+    JenkinsRule jenkinsRule = new JenkinsRule()
+
+    def 'script text'() {
+        setup:
+        AbstractBuild build = jenkinsRule.buildAndAssertSuccess(jenkinsRule.createFreeStyleProject('foo'))
+        EnvVars env = new EnvVars()
+        ScriptRequestGenerator generator = new ScriptRequestGenerator(build, env)
+
+        when:
+        List<ScriptRequest> requests = generator.getScriptRequests(null, true, SCRIPT, false, null).toList()
+
+        then:
+        requests.size() == 1
+        requests[0].location == null
+        requests[0].body == SCRIPT
+        requests[0].urlRoots.length == 1
+        requests[0].urlRoots[0].toString() == 'workspace://foo/'
+        !requests[0].ignoreExisting
+    }
+
+    def 'script text ignore existing'() {
+        setup:
+        AbstractBuild build = jenkinsRule.buildAndAssertSuccess(jenkinsRule.createFreeStyleProject('foo'))
+        EnvVars env = new EnvVars()
+        ScriptRequestGenerator generator = new ScriptRequestGenerator(build, env)
+
+        when:
+        List<ScriptRequest> requests = generator.getScriptRequests(null, true, SCRIPT, true, null).toList()
+
+        then:
+        requests.size() == 1
+        requests[0].location == null
+        requests[0].body == SCRIPT
+        requests[0].urlRoots.length == 1
+        requests[0].urlRoots[0].toString() == 'workspace://foo/'
+        requests[0].ignoreExisting
+    }
+
+    def 'script text with additional classpath entry'() {
+        setup:
+        AbstractBuild build = jenkinsRule.buildAndAssertSuccess(jenkinsRule.createFreeStyleProject('foo'))
+        EnvVars env = new EnvVars()
+        ScriptRequestGenerator generator = new ScriptRequestGenerator(build, env)
+
+        when:
+        List<ScriptRequest> requests = generator.getScriptRequests(null, true, SCRIPT, false, 'classes').toList()
+
+        then:
+        requests.size() == 1
+        requests[0].location == null
+        requests[0].body == SCRIPT
+        requests[0].urlRoots.length == 2
+        requests[0].urlRoots[0].toString() == 'workspace://foo/'
+        requests[0].urlRoots[1].toString() == 'workspace://foo/classes/'
+        !requests[0].ignoreExisting
+    }
+
+    def 'script text with additional classpath entry with variable expansion'() {
+        setup:
+        AbstractBuild build = jenkinsRule.buildAndAssertSuccess(jenkinsRule.createFreeStyleProject('foo'))
+        EnvVars env = new EnvVars([FOO: 'test'])
+        ScriptRequestGenerator generator = new ScriptRequestGenerator(build, env)
+
+        when:
+        List<ScriptRequest> requests = generator.getScriptRequests(null, true, SCRIPT, false, '${FOO}/classes').toList()
+
+        then:
+        requests.size() == 1
+        requests[0].location == null
+        requests[0].body == SCRIPT
+        requests[0].urlRoots.length == 2
+        requests[0].urlRoots[0].toString() == 'workspace://foo/'
+        requests[0].urlRoots[1].toString() == 'workspace://foo/test/classes/'
+        !requests[0].ignoreExisting
+    }
+
+    def 'script text with additional classpath entries'() {
+        setup:
+        AbstractBuild build = jenkinsRule.buildAndAssertSuccess(jenkinsRule.createFreeStyleProject('foo'))
+        EnvVars env = new EnvVars()
+        ScriptRequestGenerator generator = new ScriptRequestGenerator(build, env)
+
+        when:
+        List<ScriptRequest> requests = generator.getScriptRequests(
+                null, true, SCRIPT, false, 'classes\noutput'
+        ).toList()
+
+        then:
+        requests.size() == 1
+        requests[0].location == null
+        requests[0].body == SCRIPT
+        requests[0].urlRoots.length == 3
+        requests[0].urlRoots[0].toString() == 'workspace://foo/'
+        requests[0].urlRoots[1].toString() == 'workspace://foo/classes/'
+        requests[0].urlRoots[2].toString() == 'workspace://foo/output/'
+        !requests[0].ignoreExisting
+    }
+
+    def 'single target'() {
+        setup:
+        AbstractBuild build = jenkinsRule.buildAndAssertSuccess(jenkinsRule.createFreeStyleProject('foo'))
+        build.workspace.child('test.groovy').write(SCRIPT, 'UTF-8')
+        EnvVars env = new EnvVars()
+        ScriptRequestGenerator generator = new ScriptRequestGenerator(build, env)
+
+        when:
+        List<ScriptRequest> requests = generator.getScriptRequests('test.groovy', false, null, false, null).toList()
+
+        then:
+        requests.size() == 1
+        requests[0].location == 'test.groovy'
+        requests[0].body == null
+        requests[0].urlRoots.length == 1
+        requests[0].urlRoots[0].toString() == 'workspace://foo/'
+        !requests[0].ignoreExisting
+    }
+
+    def 'single target with variable'() {
+        setup:
+        AbstractBuild build = jenkinsRule.buildAndAssertSuccess(jenkinsRule.createFreeStyleProject('foo'))
+        build.workspace.child('test.groovy').write(SCRIPT, 'UTF-8')
+        EnvVars env = new EnvVars([FOO: 'test'])
+        ScriptRequestGenerator generator = new ScriptRequestGenerator(build, env)
+
+        when:
+        List<ScriptRequest> requests = generator.getScriptRequests('${FOO}.groovy', false, null, false, null).toList()
+
+        then:
+        requests.size() == 1
+        requests[0].location == 'test.groovy'
+        requests[0].body == null
+        requests[0].urlRoots.length == 1
+        requests[0].urlRoots[0].toString() == 'workspace://foo/'
+        !requests[0].ignoreExisting
+    }
+
+    def 'single target ignore existing'() {
+        setup:
+        AbstractBuild build = jenkinsRule.buildAndAssertSuccess(jenkinsRule.createFreeStyleProject('foo'))
+        build.workspace.child('test.groovy').write(SCRIPT, 'UTF-8')
+        EnvVars env = new EnvVars()
+        ScriptRequestGenerator generator = new ScriptRequestGenerator(build, env)
+
+        when:
+        List<ScriptRequest> requests = generator.getScriptRequests('test.groovy', false, null, true, null).toList()
+
+        then:
+        requests.size() == 1
+        requests[0].location == 'test.groovy'
+        requests[0].body == null
+        requests[0].urlRoots.length == 1
+        requests[0].urlRoots[0].toString() == 'workspace://foo/'
+        requests[0].ignoreExisting
+    }
+
+    def 'multiple target'() {
+        setup:
+        AbstractBuild build = jenkinsRule.buildAndAssertSuccess(jenkinsRule.createFreeStyleProject('foo'))
+        build.workspace.child('a.groovy').write(SCRIPT, 'UTF-8')
+        build.workspace.child('b.groovy').write(SCRIPT, 'UTF-8')
+        EnvVars env = new EnvVars()
+        ScriptRequestGenerator generator = new ScriptRequestGenerator(build, env)
+
+        when:
+        List<ScriptRequest> requests = generator.getScriptRequests(
+                'a.groovy\nb.groovy', false, null, false, null
+        ).toList()
+
+        then:
+        requests.size() == 2
+        requests[0].location == 'a.groovy'
+        requests[0].body == null
+        requests[0].urlRoots.length == 1
+        requests[0].urlRoots[0].toString() == 'workspace://foo/'
+        !requests[0].ignoreExisting
+        requests[1].location == 'b.groovy'
+        requests[1].body == null
+        requests[1].urlRoots.length == 1
+        requests[1].urlRoots[0].toString() == 'workspace://foo/'
+        !requests[1].ignoreExisting
+    }
+
+    def 'multiple target with wildcard'() {
+        setup:
+        AbstractBuild build = jenkinsRule.buildAndAssertSuccess(jenkinsRule.createFreeStyleProject('foo'))
+        build.workspace.child('a.groovy').write(SCRIPT, 'UTF-8')
+        build.workspace.child('b.groovy').write(SCRIPT, 'UTF-8')
+        EnvVars env = new EnvVars()
+        ScriptRequestGenerator generator = new ScriptRequestGenerator(build, env)
+
+        when:
+        List<ScriptRequest> requests = generator.getScriptRequests('*.groovy', false, null, false, null).toList()
+
+        then:
+        requests.size() == 2
+        requests[0].location == 'a.groovy'
+        requests[0].body == null
+        requests[0].urlRoots.length == 1
+        requests[0].urlRoots[0].toString() == 'workspace://foo/'
+        !requests[0].ignoreExisting
+        requests[1].location == 'b.groovy'
+        requests[1].body == null
+        requests[1].urlRoots.length == 1
+        requests[1].urlRoots[0].toString() == 'workspace://foo/'
+        !requests[1].ignoreExisting
+    }
+
+    def 'multiple target with additional classpath entries'() {
+        setup:
+        AbstractBuild build = jenkinsRule.buildAndAssertSuccess(jenkinsRule.createFreeStyleProject('foo'))
+        build.workspace.child('a.groovy').write(SCRIPT, 'UTF-8')
+        build.workspace.child('b.groovy').write(SCRIPT, 'UTF-8')
+        EnvVars env = new EnvVars()
+        ScriptRequestGenerator generator = new ScriptRequestGenerator(build, env)
+
+        when:
+        List<ScriptRequest> requests = generator.getScriptRequests(
+                'a.groovy\nb.groovy', false, null, false, 'classes\noutput'
+        ).toList()
+
+        then:
+        requests.size() == 2
+        requests[0].location == 'a.groovy'
+        requests[0].body == null
+        requests[0].urlRoots.length == 3
+        requests[0].urlRoots[0].toString() == 'workspace://foo/'
+        requests[0].urlRoots[1].toString() == 'workspace://foo/classes/'
+        requests[0].urlRoots[2].toString() == 'workspace://foo/output/'
+        !requests[0].ignoreExisting
+        requests[1].location == 'b.groovy'
+        requests[1].body == null
+        requests[1].urlRoots.length == 3
+        requests[1].urlRoots[0].toString() == 'workspace://foo/'
+        requests[1].urlRoots[1].toString() == 'workspace://foo/classes/'
+        requests[1].urlRoots[2].toString() == 'workspace://foo/output/'
+        !requests[1].ignoreExisting
+    }
+}


### PR DESCRIPTION
This new option allows helper classes to be in a different directory than the job scripts. E.g. job scripts are located in a `jobs` directory and helper classes are compiled to `build/classes/main`, then you set the script location to `jobs/*.groovy` and the classpath to `build/classes/main`.
