### PR TITLE
[JENKINS-24258] Fixed broken build timeout plugin implementation

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -23,6 +23,7 @@ And finally, if you want to get more involved, [here's how...](https://github.co
  * Added option to add classpath entries for Job DSL runs
  * Added localBranch option for Git SCM
  * Fixed workspace cleanup external delete command ([JENKINS-24231](https://issues.jenkins-ci.org/browse/JENKINS-24231))
+ * Fixed Build Timeout Plugin no activity timeout ([JENKINS-24258](https://issues.jenkins-ci.org/browse/JENKINS-24258))
 * 1.24 (July 05 2014)
  * Support for [Build Name Setter Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build+Name+Setter+Plugin)
  * Support for [RunDeck Plugin](https://wiki.jenkins-ci.org/display/JENKINS/RunDeck+Plugin)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/TimeoutContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/TimeoutContext.groovy
@@ -8,7 +8,7 @@ import javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext.Timeout
 /** Context to configure timeout */
 class TimeoutContext implements Context {
 
-    WrapperContext.Timeout type
+    Timeout type
     int limit = 3
 
     int percentage = 150
@@ -22,7 +22,7 @@ class TimeoutContext implements Context {
     String description = ''
     private final JobManagement jobManagement
 
-    TimeoutContext(WrapperContext.Timeout type, JobManagement jobManagement) {
+    TimeoutContext(Timeout type, JobManagement jobManagement) {
         this.jobManagement = jobManagement
         this.type = type
     }
@@ -58,6 +58,7 @@ class TimeoutContext implements Context {
     }
 
     def noActivity(int seconds = 180) {
+        jobManagement.requireMinimumPluginVersion('build-timeout', '1.13')
         type = Timeout.noActivity
         this.noActivitySeconds = seconds
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -148,7 +148,7 @@ class WrapperContext implements Context {
                     case Timeout.likelyStuck:
                         break
                     case Timeout.noActivity:
-                        delegate.timeout(ctx.noActivitySeconds)
+                        delegate.timeout(ctx.noActivitySeconds * 1000)
                         break
                     default:
                         Preconditions.checkArgument(false, 'Timeout type must be selected!')

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperHelperSpec.groovy
@@ -182,10 +182,11 @@ class WrapperHelperSpec extends Specification {
 
         then:
         def strategy = timeoutWrapper.strategy[0]
-        strategy.timeout[0].value() == 15
+        strategy.timeout[0].value() == 15000
         strategy.attribute('class') == Timeout.noActivity.className
         def list = timeoutWrapper.operationList[0]
         list.'hudson.plugins.build__timeout.operations.WriteDescriptionOperation'[0].description[0].value() == 'desc'
+        1 * mockJobManagement.requireMinimumPluginVersion('build-timeout', '1.13')
     }
 
     def 'likelyStuck timeout configuration working' () {


### PR DESCRIPTION
See [JENKINS-24258](https://issues.jenkins-ci.org/browse/JENKINS-24258) for details.
