### PR TITLE
Update GHPRB docs to match code

### DIFF
--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -719,7 +719,7 @@ gerrit {
 
 ```groovy
 pullRequest {
-    admins(String admin) // add admin
+    admin(String admin) // add admin
     admins(Iterable<String> admins) // add admins
     userWhitelist(String user) // add user to whitelist
     userWhitelist(Iterable<String> users) // add users to whitelist


### PR DESCRIPTION
Came across this when adding github pull request to one of job dsl scripts.  The documentation didn't match the code.  Tracked it down that it should be "admin" instead of "admins" for the referenced method in PullRequestBuilderContext.groovy.  Recommending the doc should be updated, but you could also change the method name to be admins.
