### PR TITLE
Support for Managed Maven Settings

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.java
@@ -82,6 +82,11 @@ public abstract class AbstractJobManagement implements JobManagement {
         return null;
     }
 
+    @Override
+    public String getMavenSettingsId(String settingsName) {
+        return null;
+    }
+
     protected void validateUpdateArgs(String jobName, String config) {
         validateNameArg(jobName);
         validateConfigArg(config);

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
@@ -88,4 +88,11 @@ interface JobManagement {
      * @return hash of the vSphere cloud or <code>null</code> if a cloud with the given name does not exist
      */
     Integer getVSphereCloudHash(String name)
+
+    /**
+     * Return the config ID of the Maven settings with the given name.
+     * @param settingsName name of the Maven settings
+     * @return the config ID of the Maven settings or <code>null</code> if no Maven settings can be found
+     */
+    String getMavenSettingsId(String settingsName)
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/MavenHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/MavenHelper.groovy
@@ -156,4 +156,14 @@ class MavenHelper extends AbstractHelper implements MavenContext {
         }
     }
 
+    def providedSettings(String settingsName) {
+        String settingsId = jobManagement.getMavenSettingsId(settingsName)
+        checkNotNull settingsId, "Managed Maven settings with name '${settingsName}' not found"
+
+        execute { Node node ->
+            node / settings(class: 'org.jenkinsci.plugins.configfiles.maven.job.MvnSettingsProvider') {
+                settingsConfigId(settingsId)
+            }
+        }
+    }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/MavenContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/MavenContext.groovy
@@ -35,6 +35,12 @@ interface MavenContext extends Context {
      */
     def mavenInstallation(String name)
 
+    /**
+     * Specifies the managed Maven settings to be used.
+     * @param settings name of the managed Maven settings
+     */
+    def providedSettings(String settings)
+
     enum LocalRepositoryLocation {
         LocalToExecutor('hudson.maven.local_repo.PerExecutorLocalRepositoryLocator'),
         LocalToWorkspace('hudson.maven.local_repo.PerJobLocalRepositoryLocator')

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/AbstractStepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/AbstractStepContext.groovy
@@ -336,7 +336,7 @@ class AbstractStepContext implements Context {
      * </hudson.tasks.Maven>
      */
     def maven(Closure closure) {
-        MavenContext mavenContext = new MavenContext()
+        MavenContext mavenContext = new MavenContext(jobManagement)
         AbstractContextHelper.executeInContext(closure, mavenContext)
 
         Node mavenNode = new NodeBuilder().'hudson.tasks.Maven' {
@@ -350,6 +350,11 @@ class AbstractStepContext implements Context {
                 pom mavenContext.rootPOM
             }
             usePrivateRepository mavenContext.localRepositoryLocation == LocalToWorkspace ? 'true' : 'false'
+            if (mavenContext.providedSettingsId) {
+                settings(class: 'org.jenkinsci.plugins.configfiles.maven.job.MvnSettingsProvider') {
+                    settingsConfigId(mavenContext.providedSettingsId)
+                }
+            }
         }
 
         // Apply Context

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MavenContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MavenContext.groovy
@@ -1,8 +1,12 @@
 package javaposse.jobdsl.dsl.helpers.step
 
+import com.google.common.base.Preconditions
+import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.helpers.common.MavenContext.LocalRepositoryLocation
 
 class MavenContext implements javaposse.jobdsl.dsl.helpers.common.MavenContext {
+    private final JobManagement jobManagement
+
     String rootPOM
     List<String> goals = []
     List<String> mavenOpts = []
@@ -10,6 +14,11 @@ class MavenContext implements javaposse.jobdsl.dsl.helpers.common.MavenContext {
     LocalRepositoryLocation localRepositoryLocation
     String mavenInstallation = '(Default)'
     Closure configureBlock
+    String providedSettingsId
+
+    MavenContext(JobManagement jobManagement) {
+        this.jobManagement = jobManagement
+    }
 
     @Override
     def rootPOM(String rootPOM) {
@@ -34,6 +43,14 @@ class MavenContext implements javaposse.jobdsl.dsl.helpers.common.MavenContext {
     @Override
     def mavenInstallation(String name) {
         this.mavenInstallation = name
+    }
+
+    @Override
+    def providedSettings(String settingsName) {
+        String settingsId = jobManagement.getMavenSettingsId(settingsName)
+        Preconditions.checkNotNull settingsId, "Managed Maven settings with name '${settingsName}' not found"
+
+        this.providedSettingsId = settingsId
     }
 
     def configure(Closure closure) {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
@@ -82,6 +82,17 @@ class AbstractJobManagementSpec extends Specification {
         thrown(UnsupportedOperationException)
     }
 
+    def 'maven settings id is always null'() {
+        setup:
+        AbstractJobManagement jobManagement = new TestJobManagement()
+
+        when:
+        String id = jobManagement.getMavenSettingsId('foo')
+
+        then:
+        id == null
+    }
+
     static class TestJobManagement extends AbstractJobManagement {
         TestJobManagement() {
             super()

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/MavenHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/MavenHelperSpec.groovy
@@ -361,4 +361,33 @@ class MavenHelperSpec extends Specification {
         root.mavenName.size() == 1
         root.mavenName[0].value() == 'test'
     }
+
+    def 'call maven method with unknown provided settings'() {
+        setup:
+        String settingsName = 'lalala'
+
+        when:
+        helper.providedSettings(settingsName)
+
+        then:
+        Exception e = thrown(NullPointerException)
+        e.message.contains(settingsName)
+    }
+
+    def 'call maven method with provided settings'() {
+        setup:
+        String settingsName = 'maven-proxy'
+        String settingsId = '123123415'
+        jobManagement.getMavenSettingsId(settingsName) >> settingsId
+
+        when:
+        def action = helper.providedSettings(settingsName)
+        action.execute(root)
+
+        then:
+        root.settings.size() == 1
+        root.settings[0].attribute('class') == 'org.jenkinsci.plugins.configfiles.maven.job.MvnSettingsProvider'
+        root.settings[0].children().size() == 1
+        root.settings[0].settingsConfigId[0].value() == settingsId
+    }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepHelperSpec.groovy
@@ -266,6 +266,47 @@ class StepHelperSpec extends Specification {
         mavenStep.mavenName[0].value() == '(Default)'
     }
 
+    def 'call maven method with unknown provided settings'() {
+        setup:
+        String settingsName = 'lalala'
+
+        when:
+        context.maven {
+            providedSettings(settingsName)
+        }
+
+        then:
+        Exception e = thrown(NullPointerException)
+        e.message.contains(settingsName)
+    }
+
+    def 'call maven method with provided settings'() {
+        setup:
+        String settingsName = 'maven-proxy'
+        String settingsId = '123123415'
+        jobManagement.getMavenSettingsId(settingsName) >> settingsId
+
+        when:
+        context.maven {
+            providedSettings(settingsName)
+        }
+
+        then:
+        context.stepNodes != null
+        context.stepNodes.size() == 1
+        with(context.stepNodes[0]) {
+            name() == 'hudson.tasks.Maven'
+            children().size() == 5
+            targets[0].value() == ''
+            jvmOptions[0].value() == ''
+            usePrivateRepository[0].value() == 'false'
+            mavenName[0].value() == '(Default)'
+            settings[0].attribute('class') == 'org.jenkinsci.plugins.configfiles.maven.job.MvnSettingsProvider'
+            settings[0].children().size() == 1
+            settings[0].settingsConfigId[0].value() == settingsId
+        }
+    }
+
     def 'call ant methods'() {
         when:
         context.ant()

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:cloudbees-folder:4.2@jar'
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:credentials:1.9.4@jar'
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:vsphere-cloud:1.1.11@jar'
+    optionalJenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.7@jar'
     jenkinsTest 'org.jenkins-ci.plugins:ant:1.2@jar' // see JENKINS-17129
     jenkinsTest 'org.jenkins-ci.main:maven-plugin:1.480@jar'
     jenkinsTest 'org.jenkins-ci.plugins:javadoc:1.1@jar'

--- a/job-dsl-plugin/pom.xml
+++ b/job-dsl-plugin/pom.xml
@@ -41,6 +41,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>config-file-provider</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -8,6 +8,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Sets;
 import hudson.EnvVars;
+import hudson.ExtensionList;
 import hudson.FilePath;
 import hudson.Plugin;
 import hudson.XmlFile;
@@ -32,6 +33,10 @@ import jenkins.model.Jenkins;
 import jenkins.model.ModifiableTopLevelItemGroup;
 import org.custommonkey.xmlunit.Diff;
 import org.custommonkey.xmlunit.XMLUnit;
+import org.jenkinsci.lib.configprovider.ConfigProvider;
+import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig;
+import org.jenkinsci.plugins.configfiles.maven.job.MvnSettingsProvider;
 import org.jenkinsci.plugins.vSphereCloud;
 
 import javax.xml.transform.Source;
@@ -51,6 +56,7 @@ import java.util.logging.Logger;
 import static hudson.model.Result.UNSTABLE;
 import static hudson.model.View.createViewFromXML;
 import static hudson.security.ACL.SYSTEM;
+import static org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig.MavenSettingsConfigProvider;
 
 /**
  * Manages Jenkins jobs, providing facilities to retrieve and create / update.
@@ -235,6 +241,22 @@ public final class JenkinsJobManagement extends AbstractJobManagement {
             for (Cloud cloud : jenkins.clouds) {
                 if (cloud instanceof vSphereCloud && ((vSphereCloud) cloud).getVsDescription().equals(name)) {
                     return ((vSphereCloud) cloud).getHash();
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String getMavenSettingsId(String settingsName) {
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins.getPlugin("config-file-provider") != null) {
+            ExtensionList<MavenSettingsConfigProvider> configProviders = jenkins.getExtensionList(MavenSettingsConfigProvider.class);
+            if (!configProviders.isEmpty()) {
+                for (Config config : configProviders.get(0).getAllConfigs()) {
+                    if (config.name.equals(settingsName)) {
+                        return config.id;
+                    }
                 }
             }
         }

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
@@ -208,4 +208,12 @@ class JenkinsJobManagementSpec extends Specification {
         then:
         result == 'hello'
     }
+
+    def 'get Maven settings without config files provider plugin'() {
+        when:
+        String id = jobManagement.getMavenSettingsId('test')
+
+        then:
+        id == null
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>config-file-provider</artifactId>
+                <version>2.7</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>credentials</artifactId>
                 <version>1.9.4</version>
             </dependency>


### PR DESCRIPTION
This add initial support for the [Config File Provider Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin):

``` groovy
job {
    steps {
        maven {
            providedSettings 'company-settings'
        }
    }
}

job(type: Maven) {
    providedSettings 'company-settings'
}
```
