### PR TITLE
Support for Nested View Plugin

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -23,6 +23,7 @@ And finally, if you want to get more involved, [here's how...](https://github.co
  * Support for [vSphere Cloud Plugin](https://wiki.jenkins-ci.org/display/JENKINS/vSphere+Cloud+Plugin)
  * Support for [Sectioned View Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Sectioned+View+Plugin)
  * Support for [M2 Release Plugin](https://wiki.jenkins-ci.org/display/JENKINS/M2+Release+Plugin)
+ * Support for [Nested View Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Nested+View+Plugin)
  * Added option to add classpath entries for Job DSL runs
  * Added localBranch option for Git SCM
  * Added method to read a file from any job's workspace

--- a/docs/Job-DSL-Commands.md
+++ b/docs/Job-DSL-Commands.md
@@ -360,6 +360,15 @@ view(Map<String, Object> arguments = [:]) { // since 1.21
     sections {
         listView(Closure listNiewSectionClosure)
     }
+
+    // NestedView options, since 1.25
+    views {
+        view(Map<String, Object> arguments = [:], Closure viewClosure)
+    }
+    columns {
+        status()
+        weather()
+    }
 }
 
 folder { // since 1.23
@@ -420,8 +429,8 @@ view(Map<String, Object> attributes = [:], Closure closure)
 
 The `view` method behaves like the `job` method explained above and will return a _View_ object.
 
-Currently only a `type` attribute with value of `ListView`, `BuildPipelineView` or `SectionedView` is supported. When no
-type is specified, a list view will be generated.
+Currently only a `type` attribute with value of `ListView`, `BuildPipelineView`, `SectionedView` or `NestedView` is
+supported. When no type is specified, a list view will be generated.
 
 ```groovy
 view(type: ListView) {

--- a/docs/View-Reference.md
+++ b/docs/View-Reference.md
@@ -154,6 +154,56 @@ view(type: SectionedView) {
 }
 ```
 
+## Nested View
+
+```groovy
+view(type: NestedView) {  // since 1.25
+    // common options
+    name(String name)
+    description(String description)
+    filterBuildQueue(boolean filterBuildQueue = true)
+    filterExecutors(boolean filterExecutors = true)
+    configure(Closure configureBlock)
+
+    // sections view options
+    views {
+        view(Map<String, Object> arguments = [:], Closure viewClosure)
+    }
+    columns {
+        status()
+        weather()
+    }
+}
+```
+
+Create a view that allows grouping views into multiple levels. Details about the options can be found below. Requires
+the [Nested View Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Nested+View+Plugin).
+
+```groovy
+view(type: NestedView) {
+    name('project-a')
+    views {
+        view {
+            name('overview')
+            jobs {
+                regex('project-A-.*')
+            }
+            columns {
+                status()
+                weather()
+                name()
+                lastSuccess()
+                lastFailure()
+            }
+        }
+        view(type: BuildPipelineView) {
+            name('pipeline')
+            selectedJob('project-a-compile')
+        }
+    }
+}
+```
+
 ## Common View Options
 
 ### Name
@@ -446,3 +496,51 @@ view(type: SectionedView) {
     }
 }
 ```
+
+## Nested View Options
+
+### Views
+
+```groovy
+view(type: NestedView) {
+    views {
+        view(Map<String, Object> arguments = [:], Closure viewClosure)
+    }
+}
+```
+
+Creates the nested views. The view methods works like the top-level view method.
+
+```groovy
+view(type: NestedView) {
+    views {
+        view {
+            name('overview')
+            jobs {
+                regex('project-A-.*')
+            }
+            columns {
+                status()
+                name()
+            }
+        }
+        view(type: BuildPipelineView) {
+            name('pipeline')
+            selectedJob('project-a-compile')
+        }
+    }
+}
+```
+
+### Columns
+
+```groovy
+view(type: NestedView) {
+    columns {
+        status()
+        weather()
+    }
+}
+```
+
+Adds columns to the view. Only the status and weather column are supported.

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
@@ -3,21 +3,12 @@ package javaposse.jobdsl.dsl
 import com.google.common.base.Preconditions
 import com.google.common.collect.Lists
 import com.google.common.collect.Sets
-import javaposse.jobdsl.dsl.views.BuildPipelineView
-import javaposse.jobdsl.dsl.views.ListView
-import javaposse.jobdsl.dsl.views.SectionedView
 
 import java.util.logging.Level
 import java.util.logging.Logger
 
 abstract class JobParent extends Script implements DslFactory {
     private static final Logger LOGGER = Logger.getLogger(JobParent.name)
-    private static final Map<ViewType, Class<? extends View>> VIEW_TYPE_MAPPING = [
-            (null): ListView,
-            (ViewType.ListView): ListView,
-            (ViewType.SectionedView): SectionedView,
-            (ViewType.BuildPipelineView): BuildPipelineView,
-    ]
 
     JobManagement jm
     Set<Item> referencedJobs
@@ -47,8 +38,8 @@ abstract class JobParent extends Script implements DslFactory {
 
     @Override
     View view(Map<String, Object> arguments=[:], Closure closure) {
-        Class<? extends View> viewClass = VIEW_TYPE_MAPPING[arguments['type'] as ViewType]
-        View view = viewClass.newInstance()
+        ViewType viewType = arguments['type'] as ViewType ?: ViewType.ListView
+        View view = viewType.viewClass.newInstance()
         view.with(closure)
         referencedViews << view
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ViewType.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ViewType.groovy
@@ -1,7 +1,14 @@
 package javaposse.jobdsl.dsl
 
 enum ViewType {
-    ListView,
-    SectionedView,
-    BuildPipelineView
+    ListView(javaposse.jobdsl.dsl.views.ListView),
+    SectionedView(javaposse.jobdsl.dsl.views.SectionedView),
+    NestedView(javaposse.jobdsl.dsl.views.NestedView),
+    BuildPipelineView(javaposse.jobdsl.dsl.views.BuildPipelineView)
+
+    final Class<? extends View> viewClass
+
+    ViewType(Class<? extends View> viewClass) {
+        this.viewClass = viewClass
+    }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/NestedView.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/NestedView.groovy
@@ -1,0 +1,44 @@
+package javaposse.jobdsl.dsl.views
+
+import javaposse.jobdsl.dsl.View
+
+import static javaposse.jobdsl.dsl.helpers.AbstractContextHelper.executeInContext
+
+class NestedView extends View {
+    void views(Closure viewsClosure) {
+        NestedViewsContext context = new NestedViewsContext()
+        executeInContext(viewsClosure, context)
+
+        execute {
+            for (View view : context.views) {
+                Node viewNode = view.node
+                viewNode.appendNode('name', view.name)
+                viewNode.appendNode('owner', [class: 'hudson.plugins.nested_view.NestedView', reference: '../../..'])
+                it / 'views' << viewNode
+            }
+        }
+    }
+
+    void columns(Closure columnsClosure) {
+        NestedViewColumnsContext context = new NestedViewColumnsContext()
+        executeInContext(columnsClosure, context)
+
+        execute {
+            for (Node columnNode : context.columnNodes) {
+                it / 'columns' / 'columns' << columnNode
+            }
+        }
+    }
+
+    @Override
+    protected String getTemplate() {
+        '''<?xml version='1.0' encoding='UTF-8'?>
+<hudson.plugins.nested__view.NestedView>
+    <name>nested</name>
+    <filterExecutors>false</filterExecutors>
+    <filterQueue>false</filterQueue>
+    <properties class="hudson.model.View$PropertyList"/>
+    <views/>
+</hudson.plugins.nested__view.NestedView>'''
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/NestedViewColumnsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/NestedViewColumnsContext.groovy
@@ -1,0 +1,15 @@
+package javaposse.jobdsl.dsl.views
+
+import javaposse.jobdsl.dsl.helpers.Context
+
+class NestedViewColumnsContext implements Context {
+    List<Node> columnNodes = []
+
+    void status() {
+        columnNodes << new Node(null, 'hudson.views.StatusColumn')
+    }
+
+    void weather() {
+        columnNodes << new Node(null, 'hudson.views.WeatherColumn')
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/NestedViewsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/NestedViewsContext.groovy
@@ -1,0 +1,16 @@
+package javaposse.jobdsl.dsl.views
+
+import javaposse.jobdsl.dsl.View
+import javaposse.jobdsl.dsl.ViewType
+import javaposse.jobdsl.dsl.helpers.Context
+
+class NestedViewsContext implements Context {
+    List<View> views = []
+
+    void view(Map<String, Object> arguments = [:], Closure closure) {
+        ViewType viewType = arguments['type'] as ViewType ?: ViewType.ListView
+        View view = viewType.viewClass.newInstance()
+        view.with(closure)
+        views << view
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobParentSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobParentSpec.groovy
@@ -2,6 +2,7 @@ package javaposse.jobdsl.dsl
 
 import javaposse.jobdsl.dsl.views.BuildPipelineView
 import javaposse.jobdsl.dsl.views.ListView
+import javaposse.jobdsl.dsl.views.NestedView
 import javaposse.jobdsl.dsl.views.SectionedView
 import spock.lang.Specification
 
@@ -58,6 +59,18 @@ class JobParentSpec extends Specification {
         then:
         view.name == 'test'
         view instanceof SectionedView
+        parent.referencedViews.contains(view)
+    }
+
+    def 'nested view'() {
+        when:
+        View view = parent.view(type: ViewType.NestedView) {
+            name 'test'
+        }
+
+        then:
+        view.name == 'test'
+        view instanceof NestedView
         parent.referencedViews.contains(view)
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/NestedViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/NestedViewSpec.groovy
@@ -1,0 +1,102 @@
+package javaposse.jobdsl.dsl.views
+
+import javaposse.jobdsl.dsl.ViewType
+import spock.lang.Specification
+
+import static org.custommonkey.xmlunit.XMLUnit.compareXML
+import static org.custommonkey.xmlunit.XMLUnit.setIgnoreWhitespace
+
+class NestedViewSpec extends Specification {
+    NestedView view = new NestedView()
+
+    def setup() {
+        setIgnoreWhitespace(true)
+    }
+
+    def 'defaults'() {
+        when:
+        String xml = view.xml
+
+        then:
+        compareXML(defaultXml, xml).similar()
+    }
+
+    def 'nested view columns'() {
+        when:
+        view.columns {
+            status()
+            weather()
+        }
+
+        then:
+        compareXML(nestedViewColumnsXml, view.xml).similar()
+    }
+
+    def 'nested view views'() {
+        when:
+        view.views {
+            delegate.view {
+                name('foo')
+            }
+            delegate.view(type: ViewType.SectionedView) {
+                name('bar')
+            }
+        }
+
+        then:
+        compareXML(nestedViewViewsXml, view.xml).similar()
+    }
+
+    def defaultXml = '''<?xml version='1.0' encoding='UTF-8'?>
+<hudson.plugins.nested__view.NestedView>
+    <name>nested</name>
+    <filterExecutors>false</filterExecutors>
+    <filterQueue>false</filterQueue>
+    <properties class='hudson.model.View$PropertyList'></properties>
+    <views></views>
+</hudson.plugins.nested__view.NestedView>'''
+
+    def nestedViewColumnsXml = '''<?xml version='1.0' encoding='UTF-8'?>
+<hudson.plugins.nested__view.NestedView>
+    <name>nested</name>
+    <filterExecutors>false</filterExecutors>
+    <filterQueue>false</filterQueue>
+    <properties class='hudson.model.View$PropertyList'></properties>
+    <views></views>
+    <columns>
+        <columns>
+            <hudson.views.StatusColumn></hudson.views.StatusColumn>
+            <hudson.views.WeatherColumn></hudson.views.WeatherColumn>
+        </columns>
+    </columns>
+</hudson.plugins.nested__view.NestedView>'''
+
+    def nestedViewViewsXml = '''<hudson.plugins.nested__view.NestedView>
+    <name>nested</name>
+    <filterExecutors>false</filterExecutors>
+    <filterQueue>false</filterQueue>
+    <properties class='hudson.model.View$PropertyList'></properties>
+    <views>
+        <hudson.model.ListView>
+            <filterExecutors>false</filterExecutors>
+            <filterQueue>false</filterQueue>
+            <properties class='hudson.model.View$PropertyList'></properties>
+            <jobNames class='tree-set'>
+                <comparator class='hudson.util.CaseInsensitiveComparator'></comparator>
+            </jobNames>
+            <jobFilters></jobFilters>
+            <columns></columns>
+            <name>foo</name>
+            <owner class='hudson.plugins.nested_view.NestedView' reference='../../..'></owner>
+        </hudson.model.ListView>
+        <hudson.plugins.sectioned__view.SectionedView>
+            <filterExecutors>false</filterExecutors>
+            <filterQueue>false</filterQueue>
+            <properties class='hudson.model.View$PropertyList'></properties>
+            <sections></sections>
+            <name>bar</name>
+            <owner class='hudson.plugins.nested_view.NestedView' reference='../../..'></owner>
+        </hudson.plugins.sectioned__view.SectionedView>
+    </views>
+</hudson.plugins.nested__view.NestedView>'''
+}


### PR DESCRIPTION
New DSL syntax example:

``` groovy
view(type: NestedView) {
    name('project-a')
    views {
        view {
            name('overview')
            jobs {
                regex('project-A-.*')
            }
            columns {
                status()
                weather()
                name()
                lastSuccess()
                lastFailure()
            }
        }
        view(type: BuildPipelineView) {
            name('pipeline')
            selectedJob('project-a-compile')
        }
    }
}
```

Replaces #175
