### PR TITLE
Support for creating/updating config files

### DIFF
--- a/docs/Job-DSL-Commands.md
+++ b/docs/Job-DSL-Commands.md
@@ -11,7 +11,7 @@ job {
 }
 ```
 
-There are similar methods to create Jenkins views and folders:
+There are similar methods to create Jenkins views, folders and config files:
 
 ```groovy
 view {
@@ -21,10 +21,14 @@ view {
 folder {
     name 'my-folder'
 }
+
+configFile {
+    name 'my-config'
+}
 ```
 
-The name is treated as absolute to the Jenkins root by default, but the seed job can be configured to interpret names
-relative to the seed job. (since 1.24)
+When defining jobs, views or folders the name is treated as absolute to the Jenkins root by default, but the seed job
+can be configured to interpret names relative to the seed job. (since 1.24)
 
 In the closure provided to `job` there are a few top level methods, like `label` and `chucknorris`. Others are nested
 deeper in blocks which represent their role in Jenkins, e.g. the `publishers` block contains all the publisher actions.
@@ -381,10 +385,16 @@ folder { // since 1.23
     // common options
     displayName(String displayName)
 }
+
+configFile(Map<String, Object> arguments = [:]) { // since 1.25
+    name(String name)
+    comment(String comment)
+    content(String content)
+}
 ```
 
 The plugin tries to provide DSL methods to cover "common use case" scenarios as simple method calls. When these methods
-fail you, you can always generate the XML yourself via [[The Configure Block]]. Sometimes, a DSL
+fail you, you can always generate the underlying XML yourself via [[The Configure Block]]. Sometimes, a DSL
 method will provide a configure block of its own, which will set the a good context to help modify a few fields. 
 This gives native access to the job config XML, which is typically very straight forward to understand.
 
@@ -475,6 +485,32 @@ view {
 
 folder {
   name 'project-a/testing'
+}
+```
+
+# Config File
+
+```groovy
+configFile(Map<String, Object> attributes = [:], Closure closure)
+```
+
+The `configFile` method behaves like the `job` method explained above and will return a _ConfigFile_ object.
+
+A config file can have optional attributes. Currently only a `type` attribute with value of `Custom` or `MavenSettings`
+is supported. When no type is specified, a custom config file will be generated.
+
+Config files will be created before jobs to ensure that the file exists before it is referenced.
+
+```groovy
+configFile {
+  name 'my-config'
+  comment 'My important configuration'
+  content '<some-xml/>'
+}
+
+configFile(type: MavenSettings) {
+  name 'central-mirror'
+  content readFileFromWorkspace('maven-settings/central-mirror.xml')
 }
 ```
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ConfigFile.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ConfigFile.groovy
@@ -1,0 +1,30 @@
+package javaposse.jobdsl.dsl
+
+import com.google.common.base.Preconditions
+
+class ConfigFile {
+    final ConfigFileType type
+    String name
+    String comment = ''
+    String content = ''
+
+    ConfigFile(ConfigFileType type) {
+        this.type = type
+    }
+
+    void name(String name) {
+        this.name = name
+    }
+
+    void comment(String comment) {
+        Preconditions.checkArgument(comment != null, 'comment must not be null')
+
+        this.comment = comment
+    }
+
+    void content(String content) {
+        Preconditions.checkArgument(content != null, 'content must not be null')
+
+        this.content = content
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ConfigFileType.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ConfigFileType.groovy
@@ -1,0 +1,12 @@
+package javaposse.jobdsl.dsl
+
+enum ConfigFileType {
+    Custom(ConfigFile),
+    MavenSettings(ConfigFile)
+
+    final Class<? extends ConfigFile> configFileClass
+
+    ConfigFileType(Class<? extends ConfigFile> configFileClass) {
+        this.configFileClass = configFileClass
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslException.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslException.groovy
@@ -1,0 +1,7 @@
+package javaposse.jobdsl.dsl
+
+class DslException extends RuntimeException {
+    DslException(String message) {
+        super(message)
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
@@ -11,6 +11,10 @@ interface DslFactory {
 
     Folder folder(Closure closure)
 
+    ConfigFile configFile(Closure closure)
+
+    ConfigFile configFile(Map<String, Object> arguments, Closure closure)
+
     /**
      * Schedule a job to be run later. Validation of the job name isn't done until after the DSL has run.
      * @param jobName the name of the job to be queued

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.groovy
@@ -26,6 +26,7 @@ class DslScriptLoader {
         ImportCustomizer icz = new ImportCustomizer()
         icz.addStaticStars('javaposse.jobdsl.dsl.JobType')
         icz.addStaticStars('javaposse.jobdsl.dsl.ViewType')
+        icz.addStaticStars('javaposse.jobdsl.dsl.ConfigFileType')
         icz.addStaticStars('javaposse.jobdsl.dsl.helpers.common.MavenContext.LocalRepositoryLocation')
         config.addCompilationCustomizers(icz)
 
@@ -74,6 +75,7 @@ class DslScriptLoader {
         LOGGER.log(Level.FINE, String.format('Ran script and got back %s', jp))
 
         GeneratedItems generatedItems = new GeneratedItems()
+        generatedItems.configFiles = extractGeneratedConfigFiles(jp, scriptRequest.ignoreExisting)
         generatedItems.jobs = extractGeneratedJobs(jp, scriptRequest.ignoreExisting)
         generatedItems.views = extractGeneratedViews(jp, scriptRequest.ignoreExisting)
 
@@ -107,6 +109,16 @@ class DslScriptLoader {
             generatedViews.add(gv)
         }
         generatedViews
+    }
+
+    private static Set<GeneratedConfigFile> extractGeneratedConfigFiles(JobParent jp, boolean ignoreExisting) {
+        Set<GeneratedConfigFile> generatedConfigFiles = []
+        jp.referencedConfigFiles.each { ConfigFile configFile ->
+            LOGGER.log(Level.FINE, "Saving config file ${configFile.name}")
+            String id = jp.jm.createOrUpdateConfigFile(configFile, ignoreExisting)
+            generatedConfigFiles.add(new GeneratedConfigFile(id, configFile.name))
+        }
+        generatedConfigFiles
     }
 
     static void scheduleJobsToRun(List<String> jobNames, JobManagement jobManagement) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
@@ -58,6 +58,11 @@ class FileJobManagement extends AbstractJobManagement {
     }
 
     @Override
+    String createOrUpdateConfigFile(ConfigFile configFile, boolean ignoreExisting) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
     Map<String, String> getParameters() {
         params
     }
@@ -92,9 +97,7 @@ class FileJobManagement extends AbstractJobManagement {
     }
 
     @Override
-    String getMavenSettingsId(String settingsName) {
+    String getConfigFileId(ConfigFileType type, String name) {
         null
     }
-
 }
-

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedConfigFile.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedConfigFile.java
@@ -1,0 +1,44 @@
+package javaposse.jobdsl.dsl;
+
+public class GeneratedConfigFile {
+    private final String id;
+    private final String name;
+
+    public GeneratedConfigFile(String id, String name) {
+        if (id == null || name == null) {
+            throw new IllegalArgumentException();
+        }
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GeneratedConfigFile)) return false;
+
+        GeneratedConfigFile that = (GeneratedConfigFile) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public String toString() {
+        return "GeneratedConfigFile{" +
+                "id='" + id + "'," +
+                "name='" + name + "'" +
+                "}";
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedItems.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedItems.groovy
@@ -3,4 +3,5 @@ package javaposse.jobdsl.dsl
 class GeneratedItems {
     Set<GeneratedJob> jobs
     Set<GeneratedView> views
+    Set<GeneratedConfigFile> configFiles
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
@@ -38,6 +38,14 @@ interface JobManagement {
             throws NameNotProvidedException, ConfigurationMissingException
 
     /**
+     * Creates or updates the managed config file.
+     * @param configFile the config file to create or update
+     * @param ignoreExisting do not update existing config files
+     * @return the id of the created or updated config file
+     */
+    String createOrUpdateConfigFile(ConfigFile configFile, boolean ignoreExisting)
+
+    /**
      * Queue a job to run. Useful for running jobs after they've been created.
      */
     void queueJob(String jobName) throws NameNotProvidedException
@@ -90,9 +98,12 @@ interface JobManagement {
     Integer getVSphereCloudHash(String name)
 
     /**
-     * Return the config ID of the Maven settings with the given name.
-     * @param settingsName name of the Maven settings
-     * @return the config ID of the Maven settings or <code>null</code> if no Maven settings can be found
+     * Return the id of the config file with the given type and name.
+     *
+     * @param type type of the config file
+     * @param name name of the config file
+     * @return the config ID of the config file or <code>null</code> if no config file with the given type and name can
+     *         be found
      */
-    String getMavenSettingsId(String settingsName)
+    String getConfigFileId(ConfigFileType type, String name)
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
@@ -13,11 +13,13 @@ abstract class JobParent extends Script implements DslFactory {
     JobManagement jm
     Set<Item> referencedJobs
     Set<View> referencedViews
+    Set<ConfigFile> referencedConfigFiles
     List<String> queueToBuild
 
     protected JobParent() {
         referencedJobs = Sets.newLinkedHashSet()
         referencedViews = Sets.newLinkedHashSet()
+        referencedConfigFiles = Sets.newLinkedHashSet()
         queueToBuild = Lists.newArrayList()
     }
 
@@ -53,6 +55,16 @@ abstract class JobParent extends Script implements DslFactory {
         folder.with(closure)
         referencedJobs << folder
         folder
+    }
+
+    @Override
+    ConfigFile configFile(Map<String, Object> arguments=[:], Closure closure) {
+        ConfigFileType configFileType = arguments['type'] as ConfigFileType ?: ConfigFileType.Custom
+        ConfigFile configFile = configFileType.configFileClass.newInstance(configFileType)
+        configFile.with(closure)
+        referencedConfigFiles << configFile
+
+        configFile
     }
 
     @Override

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/MavenHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/MavenHelper.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.dsl.helpers
 
+import javaposse.jobdsl.dsl.ConfigFileType
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.JobType
 import javaposse.jobdsl.dsl.WithXmlAction
@@ -157,7 +158,7 @@ class MavenHelper extends AbstractHelper implements MavenContext {
     }
 
     def providedSettings(String settingsName) {
-        String settingsId = jobManagement.getMavenSettingsId(settingsName)
+        String settingsId = jobManagement.getConfigFileId(ConfigFileType.MavenSettings, settingsName)
         checkNotNull settingsId, "Managed Maven settings with name '${settingsName}' not found"
 
         execute { Node node ->

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MavenContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MavenContext.groovy
@@ -1,6 +1,7 @@
 package javaposse.jobdsl.dsl.helpers.step
 
 import com.google.common.base.Preconditions
+import javaposse.jobdsl.dsl.ConfigFileType
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.helpers.common.MavenContext.LocalRepositoryLocation
 
@@ -47,7 +48,7 @@ class MavenContext implements javaposse.jobdsl.dsl.helpers.common.MavenContext {
 
     @Override
     def providedSettings(String settingsName) {
-        String settingsId = jobManagement.getMavenSettingsId(settingsName)
+        String settingsId = jobManagement.getConfigFileId(ConfigFileType.MavenSettings, settingsName)
         Preconditions.checkNotNull settingsId, "Managed Maven settings with name '${settingsName}' not found"
 
         this.providedSettingsId = settingsId

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
@@ -85,6 +85,11 @@ class AbstractJobManagementSpec extends Specification {
         }
 
         @Override
+        String createOrUpdateConfigFile(ConfigFile configFile, boolean ignoreExisting) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
         void requireMinimumPluginVersion(String pluginShortName, String version) {
             throw new UnsupportedOperationException()
         }
@@ -105,7 +110,7 @@ class AbstractJobManagementSpec extends Specification {
         }
 
         @Override
-        String getMavenSettingsId(String settingsName) {
+        String getConfigFileId(ConfigFileType type, String name) {
             null
         }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/ConfigFileSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/ConfigFileSpec.groovy
@@ -1,0 +1,55 @@
+package javaposse.jobdsl.dsl
+
+import spock.lang.Specification
+
+class ConfigFileSpec extends Specification {
+    private final ConfigFile configFile = new ConfigFile(ConfigFileType.Custom)
+
+    def 'get type'() {
+        when:
+        ConfigFile configFile = new ConfigFile(ConfigFileType.Custom)
+
+        then:
+        configFile.type == ConfigFileType.Custom
+    }
+
+    def 'set name'() {
+        when:
+        configFile.name('foo')
+
+        then:
+        configFile.name == 'foo'
+    }
+
+    def 'set comment'() {
+        when:
+        configFile.comment('lorem ipsum')
+
+        then:
+        configFile.comment == 'lorem ipsum'
+    }
+
+    def 'set comment with null value'() {
+        when:
+        configFile.comment(null)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'set content'() {
+        when:
+        configFile.content('<test/>')
+
+        then:
+        configFile.content == '<test/>'
+    }
+
+    def 'set content with null value'() {
+        when:
+        configFile.content(null)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslScriptLoaderTest.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslScriptLoaderTest.groovy
@@ -268,4 +268,16 @@ folder {
         jobs.any { it.jobName == 'folder-a' }
         jobs.any { it.jobName == 'folder-b' }
     }
+
+    def 'generate config files'() {
+        setup:
+        ScriptRequest request = new ScriptRequest('configfiles.dsl', null, resourcesDir, false)
+
+        when:
+        List<GeneratedConfigFile> files = DslScriptLoader.runDslEngine(request, jm).configFiles.toList()
+
+        then:
+        files.size() == 1
+        files[0].name == 'foo'
+    }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/FileJobManagementSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/FileJobManagementSpec.groovy
@@ -1,0 +1,18 @@
+package javaposse.jobdsl.dsl
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class FileJobManagementSpec extends Specification {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    def 'createOrUpdateConfigFile is not supported'() {
+        when:
+        new FileJobManagement(temporaryFolder.newFolder()).createOrUpdateConfigFile(Mock(ConfigFile), false)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/GeneratedConfigFileSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/GeneratedConfigFileSpec.groovy
@@ -1,0 +1,51 @@
+package javaposse.jobdsl.dsl
+
+import spock.lang.Specification
+
+class GeneratedConfigFileSpec extends Specification {
+    def 'id is null'() {
+        when:
+        new GeneratedConfigFile(null, 'foo')
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'name is null'() {
+        when:
+        new GeneratedConfigFile('235421345', null)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'get name and id'() {
+        when:
+        GeneratedConfigFile configFile = new GeneratedConfigFile('235421345', 'foo')
+
+        then:
+        configFile.id == '235421345'
+        configFile.name == 'foo'
+    }
+
+    def 'only id is relevant for hashCode and equals'() {
+        when:
+        GeneratedConfigFile configFile1 = new GeneratedConfigFile('235421345', 'foo')
+        GeneratedConfigFile configFile2 = new GeneratedConfigFile('235421345', 'new name')
+        GeneratedConfigFile configFile3 = new GeneratedConfigFile('235421346', 'other')
+
+        then:
+        configFile1.hashCode() == configFile2.hashCode()
+        configFile2.hashCode() != configFile3.hashCode()
+        configFile1 == configFile2
+        configFile2 != configFile3
+    }
+
+    def 'test toString'() {
+        when:
+        GeneratedConfigFile configFile = new GeneratedConfigFile('235421345', 'foo')
+
+        then:
+        configFile.toString() == "GeneratedConfigFile{id='235421345',name='foo'}"
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobParentSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobParentSpec.groovy
@@ -85,6 +85,42 @@ class JobParentSpec extends Specification {
         parent.referencedJobs.contains(folder)
     }
 
+    def 'default config file'() {
+        when:
+        ConfigFile configFile = parent.configFile {
+            name 'test'
+        }
+
+        then:
+        configFile.name == 'test'
+        configFile.type == ConfigFileType.Custom
+        parent.referencedConfigFiles.contains(configFile)
+    }
+
+    def 'custom config file'() {
+        when:
+        ConfigFile configFile = parent.configFile(type: ConfigFileType.Custom) {
+            name 'test'
+        }
+
+        then:
+        configFile.name == 'test'
+        configFile.type == ConfigFileType.Custom
+        parent.referencedConfigFiles.contains(configFile)
+    }
+
+    def 'Maven settings config file'() {
+        when:
+        ConfigFile configFile = parent.configFile(type: ConfigFileType.MavenSettings) {
+            name 'test'
+        }
+
+        then:
+        configFile.name == 'test'
+        configFile.type == ConfigFileType.MavenSettings
+        parent.referencedConfigFiles.contains(configFile)
+    }
+
     def 'readFileInWorkspace from seed job'() {
         jobManagement.readFileInWorkspace('foo.txt') >> 'hello'
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/StringJobManagement.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/StringJobManagement.groovy
@@ -51,6 +51,12 @@ class StringJobManagement extends AbstractJobManagement {
     }
 
     @Override
+    String createOrUpdateConfigFile(ConfigFile configFile, boolean ignoreExisting) {
+        validateNameArg(configFile.name)
+        UUID.randomUUID().toString()
+    }
+
+    @Override
     Map<String, String> getParameters() {
         params
     }
@@ -94,7 +100,7 @@ class StringJobManagement extends AbstractJobManagement {
     }
 
     @Override
-    String getMavenSettingsId(String settingsName) {
+    String getConfigFileId(ConfigFileType type, String name) {
         null
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/MavenHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/MavenHelperSpec.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.dsl.helpers
 
+import javaposse.jobdsl.dsl.ConfigFileType
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.JobType
 import javaposse.jobdsl.dsl.WithXmlAction
@@ -378,7 +379,7 @@ class MavenHelperSpec extends Specification {
         setup:
         String settingsName = 'maven-proxy'
         String settingsId = '123123415'
-        jobManagement.getMavenSettingsId(settingsName) >> settingsId
+        jobManagement.getConfigFileId(ConfigFileType.MavenSettings, settingsName) >> settingsId
 
         when:
         def action = helper.providedSettings(settingsName)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepHelperSpec.groovy
@@ -1,6 +1,7 @@
 package javaposse.jobdsl.dsl.helpers.step
 
 import hudson.util.VersionNumber
+import javaposse.jobdsl.dsl.ConfigFileType
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.JobType
 import javaposse.jobdsl.dsl.WithXmlAction
@@ -285,7 +286,7 @@ class StepHelperSpec extends Specification {
         setup:
         String settingsName = 'maven-proxy'
         String settingsId = '123123415'
-        jobManagement.getMavenSettingsId(settingsName) >> settingsId
+        jobManagement.getConfigFileId(ConfigFileType.MavenSettings, settingsName) >> settingsId
 
         when:
         context.maven {

--- a/job-dsl-core/src/test/resources/configfiles.dsl
+++ b/job-dsl-core/src/test/resources/configfiles.dsl
@@ -1,0 +1,5 @@
+configFile {
+    name('foo')
+    comment('lorem ipsum')
+    content('<test/>')
+}

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ConfigFileProviderHelper.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ConfigFileProviderHelper.groovy
@@ -1,0 +1,44 @@
+package javaposse.jobdsl.plugin
+
+import hudson.ExtensionList
+import javaposse.jobdsl.dsl.ConfigFile
+import javaposse.jobdsl.dsl.ConfigFileType
+import jenkins.model.Jenkins
+import org.jenkinsci.lib.configprovider.ConfigProvider
+import org.jenkinsci.lib.configprovider.model.Config
+import org.jenkinsci.plugins.configfiles.custom.CustomConfig
+import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig
+
+class ConfigFileProviderHelper {
+    private static final Map<ConfigFileType, Class<? extends ConfigProvider>> CONFIG_PROVIDERS = [
+            (ConfigFileType.Custom)       : CustomConfig.CustomConfigProvider,
+            (ConfigFileType.MavenSettings): MavenSettingsConfig.MavenSettingsConfigProvider,
+    ]
+
+    static Config findConfig(ConfigProvider configProvider, String name) {
+        configProvider.allConfigs.find { it.name == name }
+    }
+
+    static ConfigProvider findConfigProvider(ConfigFileType configFileType) {
+        Jenkins jenkins = Jenkins.instance
+        ExtensionList<ConfigProvider> extensionList = jenkins.getExtensionList(CONFIG_PROVIDERS[configFileType])
+        extensionList.empty ? null : extensionList[0]
+    }
+
+    static Config createNewConfig(Config oldConfig, ConfigFile configFile) {
+        switch (configFile.type) {
+            case ConfigFileType.Custom:
+                return new Config(oldConfig.id, configFile.name, configFile.comment, configFile.content)
+            case ConfigFileType.MavenSettings:
+                return new MavenSettingsConfig(
+                        oldConfig.id,
+                        configFile.name,
+                        configFile.comment,
+                        configFile.content,
+                        null
+                )
+            default:
+                return null
+        }
+    }
+}

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/GeneratedConfigFilesAction.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/GeneratedConfigFilesAction.java
@@ -1,0 +1,52 @@
+package javaposse.jobdsl.plugin;
+
+import com.google.common.collect.Sets;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import javaposse.jobdsl.dsl.GeneratedConfigFile;
+
+import java.util.Set;
+
+import static com.google.common.collect.Sets.newLinkedHashSet;
+
+public class GeneratedConfigFilesAction implements Action {
+    AbstractProject<?, ?> project;
+
+    public GeneratedConfigFilesAction(AbstractProject<?, ?> project) {
+        this.project = project;
+    }
+
+    public String getIconFileName() {
+        return null;
+    }
+
+    public String getDisplayName() {
+        return null;
+    }
+
+    public String getUrlName() {
+        return "generatedConfigFiles";
+    }
+
+    public Set<GeneratedConfigFile> findLastGeneratedConfigFiles() {
+        for (AbstractBuild<?, ?> b = project.getLastBuild(); b != null; b = b.getPreviousBuild()) {
+            GeneratedConfigFilesBuildAction action = b.getAction(GeneratedConfigFilesBuildAction.class);
+            if (action != null && action.getModifiedConfigFiles() != null) {
+                return newLinkedHashSet(action.getModifiedConfigFiles());
+            }
+        }
+        return newLinkedHashSet();
+    }
+
+    public Set<GeneratedConfigFile> findAllGeneratedConfigFiles() {
+        Set<GeneratedConfigFile> allGeneratedConfigFiles = Sets.newLinkedHashSet();
+        for (AbstractBuild build : project.getBuilds()) {
+            GeneratedConfigFilesBuildAction ret = build.getAction(GeneratedConfigFilesBuildAction.class);
+            if (ret != null && ret.getModifiedConfigFiles() != null) {
+                allGeneratedConfigFiles.addAll(ret.getModifiedConfigFiles());
+            }
+        }
+        return allGeneratedConfigFiles;
+    }
+}

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/GeneratedConfigFilesBuildAction.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/GeneratedConfigFilesBuildAction.java
@@ -1,0 +1,32 @@
+package javaposse.jobdsl.plugin;
+
+import com.google.common.collect.Sets;
+import hudson.model.Action;
+import javaposse.jobdsl.dsl.GeneratedConfigFile;
+
+import java.util.Collection;
+import java.util.Set;
+
+public class GeneratedConfigFilesBuildAction implements Action {
+    public final Set<GeneratedConfigFile> modifiedConfigFiles;
+
+    public GeneratedConfigFilesBuildAction(Collection<GeneratedConfigFile> modifiedConfigFiles) {
+        this.modifiedConfigFiles = Sets.newLinkedHashSet(modifiedConfigFiles);
+    }
+
+    public String getIconFileName() {
+        return null;
+    }
+
+    public String getDisplayName() {
+        return "Generated Config Files";
+    }
+
+    public String getUrlName() {
+        return "generatedConfigFiles";
+    }
+
+    public Collection<GeneratedConfigFile> getModifiedConfigFiles() {
+        return modifiedConfigFiles;
+    }
+}

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/GeneratedJobsAction.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/GeneratedJobsAction.java
@@ -9,11 +9,10 @@ import javaposse.jobdsl.dsl.GeneratedJob;
 
 import java.util.Set;
 
-
 public class GeneratedJobsAction implements Action {
+    AbstractProject<?, ?> project;
 
-    AbstractProject<?,?> project;
-    public GeneratedJobsAction(AbstractProject<?,?> project) {
+    public GeneratedJobsAction(AbstractProject<?, ?> project) {
         this.project = project;
     }
 
@@ -33,7 +32,6 @@ public class GeneratedJobsAction implements Action {
      * Search for all jobs which were created by the child builds
      */
     public Set<GeneratedJob> findLastGeneratedJobs() {
-
         AbstractBuild<?, ?> b;
         for (b = project.getLastBuild(); b != null; b = b.getPreviousBuild()) {
             GeneratedJobsBuildAction ret = b.getAction(GeneratedJobsBuildAction.class);
@@ -49,10 +47,8 @@ public class GeneratedJobsAction implements Action {
      */
     @Deprecated
     public Set<GeneratedJob> findAllGeneratedJobs() {
-
-        AbstractBuild<?, ?> b;
         Set<GeneratedJob> allGeneratedJobs = Sets.newLinkedHashSet();
-        for(AbstractBuild build: project.getBuilds()) {
+        for (AbstractBuild build : project.getBuilds()) {
             GeneratedJobsBuildAction ret = build.getAction(GeneratedJobsBuildAction.class);
             if (ret != null && ret.getModifiedJobs() != null) {
                 allGeneratedJobs.addAll(ret.getModifiedJobs());

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/GeneratedViewsBuildAction.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/GeneratedViewsBuildAction.java
@@ -23,8 +23,8 @@ public class GeneratedViewsBuildAction implements RunAction {
     private transient AbstractBuild owner;
     private LookupStrategy lookupStrategy = LookupStrategy.JENKINS_ROOT;
 
-    public GeneratedViewsBuildAction(Collection<GeneratedView> modifiedJobs, LookupStrategy lookupStrategy) {
-        this.modifiedViews = Sets.newLinkedHashSet(modifiedJobs);
+    public GeneratedViewsBuildAction(Collection<GeneratedView> modifiedViews, LookupStrategy lookupStrategy) {
+        this.modifiedViews = Sets.newLinkedHashSet(modifiedViews);
         this.lookupStrategy = lookupStrategy;
     }
 

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/GeneratedConfigFilesAction/jobMain.jelly
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/GeneratedConfigFilesAction/jobMain.jelly
@@ -1,0 +1,19 @@
+<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson">
+    <j:set var="allConfigFiles" value="${it.findAllGeneratedConfigFiles()}"/>
+    <j:if test="${!allConfigFiles.isEmpty()}">
+        <table style="margin-top: 1em; margin-left:1em;">
+            <t:summary icon="../../plugin/config-file-provider/images/cfg_logo.png">
+                Generated Config Files:
+                <ul class="folderList">
+                    <j:forEach items="${allConfigFiles}" var="configFile">
+                        <li>
+                            <a href="${rootURL}/configfiles/editConfig?id=${configFile.id}" class="tl-tr">
+                                ${configFile.name}
+                            </a>
+                        </li>
+                    </j:forEach>
+                </ul>
+            </t:summary>
+        </table>
+    </j:if>
+</j:jelly>

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/GeneratedConfigFilesBuildAction/summary.jelly
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/GeneratedConfigFilesBuildAction/summary.jelly
@@ -1,0 +1,17 @@
+<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson">
+    <j:set var="allConfigFiles" value="${it.modifiedConfigFiles}"/>
+    <j:if test="${!allConfigFiles.isEmpty()}">
+        <t:summary icon="../../plugin/config-file-provider/images/cfg_logo.png">
+            Generated Config Files:
+            <ul class="folderList">
+                <j:forEach items="${allConfigFiles}" var="configFile">
+                    <li>
+                        <a href="${rootURL}/configfiles/editConfig?id=${configFile.id}" class="tl-tr">
+                            ${configFile.name}
+                        </a>
+                    </li>
+                </j:forEach>
+            </ul>
+        </t:summary>
+    </j:if>
+</j:jelly>

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/Messages.properties
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/Messages.properties
@@ -4,3 +4,9 @@ ReadFileFromWorkspace.WorkspaceNotFound=\
   Could not read file "%s" from workspace of job "%s" because the workspace does not exist
 ReadFileFromWorkspace.JobNotFound=\
   Could not read file "%s" from workspace of job "%s" because the job does not exist
+CreateOrUpdateConfigFile.PluginNotInstalled=\
+  Could not create or update config file, Config File Provider plugin not installed
+CreateOrUpdateConfigFile.ConfigProviderNotFound=\
+  Could not create or update config file, config provider for config file type "%s" not found
+CreateOrUpdateConfigFile.UnknownConfigFileType=\
+  Could not create or update config file, unknown config file type "%s"

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ExecuteDslScriptsSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ExecuteDslScriptsSpec.groovy
@@ -15,8 +15,9 @@ class ExecuteDslScriptsSpec extends Specification {
 
         then:
         actions != null
-        actions.size() == 2
+        actions.size() == 3
         actions[0] instanceof GeneratedJobsAction
         actions[1] instanceof GeneratedViewsAction
+        actions[2] instanceof GeneratedConfigFilesAction
     }
 }

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
@@ -8,7 +8,10 @@ import hudson.model.Failure
 import hudson.model.FreeStyleBuild
 import hudson.model.FreeStyleProject
 import hudson.util.VersionNumber
+import javaposse.jobdsl.dsl.ConfigFile
+import javaposse.jobdsl.dsl.ConfigFileType
 import javaposse.jobdsl.dsl.ConfigurationMissingException
+import javaposse.jobdsl.dsl.DslException
 import javaposse.jobdsl.dsl.NameNotProvidedException
 import org.junit.Rule
 import org.jvnet.hudson.test.JenkinsRule
@@ -209,11 +212,34 @@ class JenkinsJobManagementSpec extends Specification {
         result == 'hello'
     }
 
-    def 'get Maven settings without config files provider plugin'() {
+    def 'get config file id without config files provider plugin'() {
         when:
-        String id = jobManagement.getMavenSettingsId('test')
+        String id = jobManagement.getConfigFileId(ConfigFileType.MavenSettings, 'test')
 
         then:
         id == null
+    }
+
+    def 'create config file without config files provider plugin'() {
+        setup:
+        ConfigFile configFile = Mock(ConfigFile)
+        configFile.name >> 'foo'
+
+        when:
+        jobManagement.createOrUpdateConfigFile(configFile, false)
+
+        then:
+        thrown(DslException)
+    }
+
+    def 'create config file without name'() {
+        setup:
+        ConfigFile configFile = Mock(ConfigFile)
+
+        when:
+        jobManagement.createOrUpdateConfigFile(configFile, false)
+
+        then:
+        thrown(NameNotProvidedException)
     }
 }


### PR DESCRIPTION
Added support to create and update config files for the Config File Provider plugin.

New DSL syntax:

``` groovy
configFile {
    name 'my-config'
    comment 'My important configuration'
    content '<some-xml/>'
}

configFile(type: MavenSettings) {
    name 'central-mirror'
    content readFileFromWorkspace('maven-settings/central-mirror.xml')
}
```
