### PR TITLE
build status

### DIFF
--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -1980,6 +1980,8 @@ conditionalSteps {
 
 See the [Run Condition Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Run+Condition+Plugin) for details on the run conditions - note that not all run conditions supported by the Run Condition Plugin are supported here yet.
 
+The worstResult and bestResult for status can be any of the following strings:
+"SUCCESS", "UNSTABLE", "FAILURE",  "NOT_BUILT", or "ABORTED".
 The runner can be any one of "Fail", "Unstable", "RunUnstable", "Run", "DontRun".
 
 Examples:
@@ -2015,7 +2017,7 @@ steps {
     conditionalSteps {
         condition {
             and {
-                time("9:00", "13:00", false)
+                status('ABORTED', 'FAILURE')
             } {
                 not {
                    fileExists('script.sh', BaseDir.WORKSPACE)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/RunConditionContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/RunConditionContext.groovy
@@ -10,6 +10,7 @@ import javaposse.jobdsl.dsl.helpers.step.condition.NotCondition
 import javaposse.jobdsl.dsl.helpers.step.condition.RunCondition
 import javaposse.jobdsl.dsl.helpers.step.condition.RunConditionFactory
 import javaposse.jobdsl.dsl.helpers.step.condition.SimpleCondition
+import javaposse.jobdsl.dsl.helpers.step.condition.StatusCondition
 
 class RunConditionContext implements Context {
 
@@ -52,9 +53,7 @@ class RunConditionContext implements Context {
     }
 
     def status(String worstResult, String bestResult) {
-        this.condition = new SimpleCondition(
-                name: 'Status',
-                args: ['worstResult': worstResult, 'bestResult': bestResult])
+	this.condition = new StatusCondition(worstResult, bestResult ?: worstResult)
     }
 
     def shell(String command) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/condition/StatusCondition.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/condition/StatusCondition.groovy
@@ -1,0 +1,51 @@
+package javaposse.jobdsl.dsl.helpers.step.condition
+
+import static com.google.common.base.Preconditions.checkArgument
+
+/**
+ * Generate config for a status condition.
+ *
+ * https://wiki.jenkins-ci.org/display/JENKINS/Run+Condition+Plugin
+ *
+ * <condition class="org.jenkins_ci.plugins.run_condition.core.StatusCondition">
+ *   <worstResult>
+ *     <ordinal>2</ordinal>
+ *   </worstResult>
+ *   <bestResult>
+ *     <ordinal>2</ordinal>
+ *   </bestResult>
+ * </condition>
+ */
+class StatusCondition extends SimpleCondition {
+
+    static statuses = [
+        'SUCCESS',
+        'UNSTABLE',
+        'FAILURE',
+        'NOT_BUILT',
+        'ABORTED',
+    ]
+
+    final String worstResult
+    final String bestResult
+
+    StatusCondition(String worstResult, String bestResult) {
+        this.name = 'Status'
+        this.worstResult = worstResult
+        this.bestResult = bestResult
+
+        checkArgument(statuses.contains(worstResult))
+        checkArgument(statuses.contains(bestResult))
+        checkArgument(statuses.findIndexOf { it == worstResult } >= statuses.findIndexOf { it == bestResult })
+    }
+
+    @Override
+    void addArgs(NodeBuilder builder) {
+        builder.worstResult {
+            ordinal statuses.findIndexOf { it == worstResult }
+        }
+        builder.bestResult {
+            ordinal statuses.findIndexOf { it == bestResult }
+        }
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepHelperSpec.groovy
@@ -1313,18 +1313,17 @@ still-another-dsl.groovy'''
 
         where:
         testCondition << [
-                'stringsMatch', 'alwaysRun', 'neverRun', 'booleanCondition', 'cause', 'expression', 'time', 'status'
+                'stringsMatch', 'alwaysRun', 'neverRun', 'booleanCondition', 'cause', 'expression', 'time'
         ]
         testConditionArgs << [
                 ['arg1': 'foo', 'arg2': 'bar', 'ignoreCase': false], [:], [:],
                 ['token': 'foo'], ['buildCause': 'foo', 'exclusiveCondition': true],
                 ['expression': 'some-expression', 'label': 'some-label'],
-                ['earliest': 'earliest-time', 'latest': 'latest-time', 'useBuildTime': false],
-                ['worstResult': 'Success', 'bestResult': 'Success']
+                ['earliest': 'earliest-time', 'latest': 'latest-time', 'useBuildTime': false]
         ]
         testConditionClass << [
                 'StringsMatchCondition', 'AlwaysRun', 'NeverRun', 'BooleanCondition', 'CauseCondition',
-                'ExpressionCondition', 'TimeCondition', 'StatusCondition'
+                'ExpressionCondition', 'TimeCondition'
         ]
     }
 
@@ -1499,6 +1498,28 @@ still-another-dsl.groovy'''
         condition.baseDir[0].attribute('class') == 'org.jenkins_ci.plugins.run_condition.common.BaseDirectory$Workspace'
     }
 
+    def 'status condition is added correctly'() {
+        when:
+        context.conditionalSteps {
+            condition {
+                status 'FAILURE', 'SUCCESS'
+            }
+            shell 'echo Test'
+        }
+
+        then:
+        Node step = context.stepNodes[0]
+        Node condition = step.condition[0]
+
+        condition.attribute('class') == 'org.jenkins_ci.plugins.run_condition.core.StatusCondition'
+        condition.children().size() == 2
+
+        condition.worstResult[0].children().size() == 1
+        condition.worstResult[0].ordinal[0].value() == 2
+        condition.bestResult[0].children().size() == 1
+        condition.bestResult[0].ordinal[0].value() == 0
+    }
+
     @Unroll
     def 'Logical Operation #dslOperation is added correctly'(String dslOperation, String operation) {
         when:
@@ -1575,8 +1596,6 @@ still-another-dsl.groovy'''
         'time'             | ['earliest', 'latest', true] | 'org.jenkins_ci.plugins.run_condition.core.TimeCondition'             | [earliest    : 'earliest',
                                                                                                                                      latest      : 'latest',
                                                                                                                                      useBuildTime: 'true']
-        'status'           | ['FAILED', 'STABLE']         | 'org.jenkins_ci.plugins.run_condition.core.StatusCondition'           | [worstResult: 'FAILED',
-                                                                                                                                     bestResult : 'STABLE']
     }
 
     @Unroll


### PR DESCRIPTION
As suggested by @daspilker for https://github.com/jenkinsci/job-dsl-plugin/pull/251, I split this into a separate pull request.
## Build Status Condition

The build status condition was previously built using a SimpleCondition. Unfortunately, this generated the wrong XML for the Run Condition Plugin version 1.0: it was generating blobs of the form:

```
<condition class="org.jenkins_ci.plugins.run_condition.core.StatusCondition">
  <worstResult>SUCCESS</worstResult>
  <bestResult>FAILURE</bestResult>
</condition>
```

Whereas using the gui to configure a job generated XML of the form:

```
<condition class="org.jenkins_ci.plugins.run_condition.core.StatusCondition" plugin="run-condition@1.0">
  <worstResult>
    <name>FAILURE</name>
    <ordinal>2</ordinal>
    <color>RED</color>
    <completeBuild>true</completeBuild>
  </worstResult>
  <bestResult>
     <name>SUCCESS</name>
     <ordinal>0</ordinal>
     <color>BLUE</color>
     <completeBuild>true</completeBuild>
  </bestResult>
</condition>
```

Through further experimentation, we found that the `ordinal` tag was necessary and sufficient for jenkins to correctly process the job. Unfortunately, this meant we couldn't use a `SimpleCondition` for build status anymore, as the testing infrastructure wasn't able to handle `SimpleCondition` nodes with children.
## Testing done

In addition to the included tests, we have been using this internally for a while via the following monkey patches:

```
        /*                                                                      
         * A condition that matches if the current build status is better than  
         * or equal to worstResult and worse than or equal to bestResult.       
         *                                                                      
         * Example - the following matches only successful builds.              
         *                                                                      
         *    condition {                                                       
         *        status 'SUCCESS', 'SUCCESS'                                   
         *    }                                                                 
         */                                                                     
        RunConditionContext.metaClass.status { String worstResult, String bestResult = null ->
            bestResult = bestResult ?: worstResult                              

            def statuses = [                                                    
                'SUCCESS',                                                         
                'UNSTABLE',                                                        
                'FAILURE',                                                         
                'NOT_BUILT',                                                       
                'ABORTED',                                                         
            ]                                                                      

            assert statuses.contains(worstResult)                                  
            assert statuses.contains(bestResult)                                   

            condition = new SimpleCondition(                                       
                name: 'Status',                                                    
                args: ['worstResult': {                                            
                    ordinal statuses.findIndexOf { it == worstResult }             
                }, 'bestResult': {                                                 
                    ordinal statuses.findIndexOf { it == bestResult }              
                }])                                                                
        }  
```
