### PR TITLE
Adding sameNode() option on downstreamParameterized documentation from J...

### DIFF
--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -1908,6 +1908,7 @@ downstreamParameterized(Closure downstreamClosure) {
         predefinedProps(String predefinedProps) // Newline separated
         matrixSubset(String groovyFilter) // Restrict matrix execution to a subset
         subversionRevision() // Subversion Revision
+        sameNode() //Run the next job on the same node
      }
 }
 ```


### PR DESCRIPTION
Adding sameNode() option on downstreamParameterized documentation from Job-reference.
For me was not clear this option on downstreamParameterized, I only figured out this on test code.
