### PR TITLE
Replaced Short Names in GerritEventContext by DSL methods

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -21,6 +21,7 @@ And finally, if you want to get more involved, [here's how...](https://github.co
  * Support for [Delivery Pipeline Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Delivery+Pipeline+Plugin)
  * Allow to merge more than one branch with Git SCM
  * Support for [S3 Plugin](https://wiki.jenkins-ci.org/display/JENKINS/S3+Plugin)
+ * Short names in the Gerrit trigger event closure have been replaced by DSL methods, see [[Migration]]
 * 1.25 (September 01 2014)
  * Dropped support for Java 5, Java 6 or later is required at runtime
  * Support for [Rake Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Rake+plugin)

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -730,7 +730,16 @@ Enables the job to be started whenever a change is pushed to a github repository
 
 ```groovy
 gerrit {
-    events(Closure eventClosure)                          // free form listing of event names
+    events {
+        changeAbandoned() // since 1.26
+        changeMerged()    // since 1.26
+        changeRestored()  // since 1.26
+        commentAdded()    // since 1.26
+        draftPublished()  // since 1.26
+        patchsetCreated() // since 1.26
+        refUpdated()      // since 1.26
+        // free form listing of event names is deprecated since 1.26
+    }
     project(String projectName, List<String> branches)    // can be called multiple times
     project(String projectName, String branches)          // can be called multiple times
     buildStarted(Integer verified, Integer codeReview)    // updates the Gerrit report values for the build started event, use null to keep the default value
@@ -743,11 +752,9 @@ gerrit {
 ```
 
 Polls Gerrit for changes. This DSL method works slightly differently by exposing most of its functionality in its own
-block. This is accommodating how the plugin can be pointed to multiple projects and trigger on many events. The events
-block takes the "short name" of an event. When looking at the raw config.xml for a job which uses the Gerrit trigger,
-you'll see multiple class names in the triggerOnEvents element. The DSL method will take the names in the events block
-and prepend it with 'com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.Plugin' and append 'Event',
-meaning that shorter names like ChangeMerged and DraftPublished can be used.
+block. This is accommodating how the plugin can be pointed to multiple projects and trigger on many events.
+
+The usage "short names" in the event closure is deprecated since 1.26.
 
 Requires the [Gerrit Trigger Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Trigger).
 
@@ -756,8 +763,8 @@ Example:
 ```groovy
 gerrit {
     events {
-        ChangeMerged
-        DraftPublished
+        changeMerged()
+        draftPublished()
     }
     project('reg_exp:myProject', ['ant:feature-branch', 'plain:origin/refs/mybranch'])
     project('test-project', '**')

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -1,3 +1,49 @@
+## Migrating to 1.26
+
+### Gerrit Trigger
+
+The usage "short names" in the event closure is deprecated and has been replaced by explicit DSL methods for each event.
+
+DSL prior to 1.26
+```groovy
+job {
+    triggers {
+        gerrit {
+            events {
+                ChangeAbandoned
+                ChangeMerged
+                ChangeRestored
+                CommentAdded
+                DraftPublished
+                PatchsetCreated
+                RefUpdated
+            }
+        }
+    }
+}
+```
+
+DSL since 1.26
+```groovy
+job {
+    triggers {
+        gerrit {
+            events {
+                changeAbandoned()
+                changeMerged()
+                changeRestored()
+                commentAdded()
+                draftPublished()
+                patchsetCreated()
+                refUpdated()
+            }
+        }
+    }
+}
+```
+
+See the [[Job Reference]] for further details.
+
 ## Migrating to 1.24
 
 ### Build Timeout

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
@@ -46,7 +46,7 @@ class Job extends Item {
         helperAuthorization = new AuthorizationContextHelper(withXmlActions, type)
         helperScm = new ScmContextHelper(withXmlActions, type, jobManagement)
         helperMultiscm = new MultiScmContextHelper(withXmlActions, type, jobManagement)
-        helperTrigger = new TriggerContextHelper(withXmlActions, type)
+        helperTrigger = new TriggerContextHelper(withXmlActions, type, jobManagement)
         helperWrapper = new WrapperContextHelper(withXmlActions, type, jobManagement)
         helperStep = new StepContextHelper(withXmlActions, type, jobManagement)
         helperPublisher = new PublisherContextHelper(withXmlActions, type, jobManagement)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GerritContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GerritContext.groovy
@@ -1,12 +1,17 @@
 package javaposse.jobdsl.dsl.helpers.triggers
 
+import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.helpers.AbstractContextHelper
 import javaposse.jobdsl.dsl.helpers.Context
 
 class GerritContext implements Context {
-    GerritEventContext eventContext = new GerritEventContext()
+    GerritEventContext eventContext
     Closure configureClosure
     def projects = []
+
+    GerritContext(JobManagement jobManagement) {
+        this.eventContext = new GerritEventContext(jobManagement)
+    }
 
     Integer startedCodeReview = null
     Integer startedVerified = null

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GerritEventContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GerritEventContext.groovy
@@ -1,11 +1,46 @@
 package javaposse.jobdsl.dsl.helpers.triggers
 
+import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.helpers.Context
 
 class GerritEventContext implements Context {
-    def eventShortNames = []
+    private final JobManagement jobManagement
+    final List<String> eventShortNames = []
+
+    GerritEventContext(JobManagement jobManagement) {
+        this.jobManagement = jobManagement
+    }
+
+    def changeAbandoned() {
+        eventShortNames << 'ChangeAbandoned'
+    }
+
+    def changeMerged() {
+        eventShortNames << 'ChangeMerged'
+    }
+
+    def changeRestored() {
+        eventShortNames << 'ChangeRestored'
+    }
+
+    def commentAdded() {
+        eventShortNames << 'CommentAdded'
+    }
+
+    def draftPublished() {
+        eventShortNames << 'DraftPublished'
+    }
+
+    def patchsetCreated() {
+        eventShortNames << 'PatchsetCreated'
+    }
+
+    def refUpdated() {
+        eventShortNames << 'RefUpdated'
+    }
 
     def propertyMissing(String shortName) {
+        jobManagement.logDeprecationWarning()
         eventShortNames << shortName
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
@@ -1,6 +1,7 @@
 package javaposse.jobdsl.dsl.helpers.triggers
 
 import com.google.common.base.Preconditions
+import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.JobType
 import javaposse.jobdsl.dsl.WithXmlAction
 import javaposse.jobdsl.dsl.helpers.AbstractContextHelper
@@ -10,11 +11,13 @@ import javaposse.jobdsl.dsl.helpers.triggers.GerritContext.GerritSpec
 class TriggerContext implements Context {
     private final List<WithXmlAction> withXmlActions
     private final JobType jobType
+    private final JobManagement jobManagement
     final List<Node> triggerNodes = []
 
-    TriggerContext(List<WithXmlAction> withXmlActions, JobType jobType) {
+    TriggerContext(List<WithXmlAction> withXmlActions, JobType jobType, JobManagement jobManagement) {
         this.withXmlActions = withXmlActions
         this.jobType = jobType
+        this.jobManagement = jobManagement
     }
 
     /**
@@ -190,7 +193,7 @@ class TriggerContext implements Context {
      */
     def gerrit(Closure contextClosure = null) {
         // See what they set up in the contextClosure before generating xml
-        GerritContext gerritContext = new GerritContext()
+        GerritContext gerritContext = new GerritContext(jobManagement)
         AbstractContextHelper.executeInContext(contextClosure, gerritContext)
 
         def nodeBuilder = new NodeBuilder()

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextHelper.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.dsl.helpers.triggers
 
+import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.JobType
 import javaposse.jobdsl.dsl.WithXmlAction
 import javaposse.jobdsl.dsl.helpers.AbstractContextHelper
@@ -8,9 +9,11 @@ import javaposse.jobdsl.dsl.helpers.AbstractContextHelper
  triggers {scm(String cronString)
  cron(String cronString)}*/
 class TriggerContextHelper extends AbstractContextHelper<TriggerContext> {
+    private final JobManagement jobManagement
 
-    TriggerContextHelper(List<WithXmlAction> withXmlActions, JobType jobType) {
+    TriggerContextHelper(List<WithXmlAction> withXmlActions, JobType jobType, JobManagement jobManagement) {
         super(withXmlActions, jobType)
+        this.jobManagement = jobManagement
     }
 
     /**
@@ -18,7 +21,7 @@ class TriggerContextHelper extends AbstractContextHelper<TriggerContext> {
      * @return
      */
     def triggers(Closure closure) {
-        execute(closure, new TriggerContext(withXmlActions, type))
+        execute(closure, new TriggerContext(withXmlActions, type, jobManagement))
     }
 
     Closure generateWithXmlClosure(TriggerContext context) {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerHelperSpec.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.dsl.helpers.triggers
 
+import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.JobType
 import javaposse.jobdsl.dsl.WithXmlAction
 import javaposse.jobdsl.dsl.WithXmlActionSpec
@@ -8,8 +9,9 @@ import spock.lang.Specification
 class TriggerHelperSpec extends Specification {
 
     List<WithXmlAction> mockActions = Mock()
-    TriggerContextHelper helper = new TriggerContextHelper(mockActions, JobType.Freeform)
-    TriggerContext context = new TriggerContext(mockActions, JobType.Freeform)
+    JobManagement mockJobManagement = Mock(JobManagement)
+    TriggerContextHelper helper = new TriggerContextHelper(mockActions, JobType.Freeform, mockJobManagement)
+    TriggerContext context = new TriggerContext(mockActions, JobType.Freeform, mockJobManagement)
 
     def 'call github trigger methods'() {
         when:
@@ -423,6 +425,51 @@ class TriggerHelperSpec extends Specification {
         }
     }
 
+    def 'call gerrit trigger with events'(String event) {
+        when:
+        context.gerrit {
+            events {
+                delegate."${event}"()
+            }
+        }
+
+        then:
+        String xmlEvent = event.capitalize()
+        with(context.triggerNodes[0].triggerOnEvents[0]) {
+            children().size() == 1
+            children()[0].name() ==
+                    "com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.Plugin${xmlEvent}Event"
+        }
+
+        where:
+        event << [
+                'changeAbandoned', 'changeMerged', 'changeRestored', 'commentAdded', 'draftPublished',
+                'patchsetCreated', 'refUpdated'
+        ]
+    }
+
+    def 'call gerrit trigger with deprecated events'(String event) {
+        when:
+        context.gerrit {
+            events {
+                delegate."${event}"
+            }
+        }
+
+        then:
+        with(context.triggerNodes[0].triggerOnEvents[0]) {
+            children().size() == 1
+            children()[0].name() ==
+                    "com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.Plugin${event}Event"
+        }
+
+        where:
+        event << [
+                'ChangeAbandoned', 'ChangeMerged', 'ChangeRestored', 'CommentAdded', 'DraftPublished',
+                'PatchsetCreated', 'RefUpdated'
+        ]
+    }
+
     def 'call gerrit trigger and verify build status value settings'() {
         when:
         context.gerrit {
@@ -498,7 +545,7 @@ class TriggerHelperSpec extends Specification {
 
     def 'execute withXml Action'() {
         Node root = new XmlParser().parse(new StringReader(WithXmlActionSpec.XML))
-        TriggerContext triggerContext = new TriggerContext([], JobType.Freeform)
+        TriggerContext triggerContext = new TriggerContext([], JobType.Freeform, mockJobManagement)
         triggerContext.scm('2 3 * * * *')
 
         when:
@@ -519,7 +566,7 @@ class TriggerHelperSpec extends Specification {
 
     def 'call snapshotDependencies for Maven job succeeds'() {
         when:
-        TriggerContext context = new TriggerContext([], JobType.Maven)
+        TriggerContext context = new TriggerContext([], JobType.Maven, mockJobManagement)
         context.snapshotDependencies(false)
 
         then:


### PR DESCRIPTION
Deprecated syntax:

``` groovy
job {
    triggers {
        gerrit {
            events {
                ChangeAbandoned
                ChangeMerged
                ChangeRestored
                CommentAdded
                DraftPublished
                PatchsetCreated
                RefUpdated
            }
        }
    }
}
```

New syntax:

``` groovy
job {
    triggers {
        gerrit {
            events {
                changeAbandoned()
                changeMerged()
                changeRestored()
                commentAdded()
                draftPublished()
                patchsetCreated()
                refUpdated()
            }
        }
    }
}
```

Replaces #139.
