### PR TITLE
Fix noActivity(seconds) wrapper for build-timeout plugin 1.14+

### DIFF
--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -961,7 +961,7 @@ Configures the job to prepare a Ruby environment controlled by RVM for the build
 ```groovy
 timeout {
     elastic(int percentage = 150, int numberOfBuilds = 3, int minutesDefault = 60)
-    noActivity(int seconds = 180)
+    noActivity(int seconds = 180)              // requires version 1.14 or later
     absolute(int minutes = 3)                  // default
     likelyStuck()
     failBuild(boolean fail = true)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/TimeoutContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/TimeoutContext.groovy
@@ -58,7 +58,7 @@ class TimeoutContext implements Context {
     }
 
     def noActivity(int seconds = 180) {
-        jobManagement.requireMinimumPluginVersion('build-timeout', '1.13')
+        jobManagement.requireMinimumPluginVersion('build-timeout', '1.14')
         type = Timeout.noActivity
         this.noActivitySeconds = seconds
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -145,7 +145,7 @@ class WrapperContext implements Context {
                     case Timeout.likelyStuck:
                         break
                     case Timeout.noActivity:
-                        delegate.timeout(ctx.noActivitySeconds * 1000)
+                        delegate.timeoutSecondsString(ctx.noActivitySeconds)
                         break
                 }
             }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperHelperSpec.groovy
@@ -193,11 +193,11 @@ class WrapperHelperSpec extends Specification {
 
         then:
         def strategy = timeoutWrapper.strategy[0]
-        strategy.timeout[0].value() == 15000
+        strategy.timeoutSecondsString[0].value() == 15
         strategy.attribute('class') == Timeout.noActivity.className
         def list = timeoutWrapper.operationList[0]
         list.'hudson.plugins.build__timeout.operations.WriteDescriptionOperation'[0].description[0].value() == 'desc'
-        1 * mockJobManagement.requireMinimumPluginVersion('build-timeout', '1.13')
+        1 * mockJobManagement.requireMinimumPluginVersion('build-timeout', '1.14')
     }
 
     def 'likelyStuck timeout configuration working' () {


### PR DESCRIPTION
The build-timeout plugin recently changed the serialization format for the noActivity wrapper; the wrapper now serializes the timeout
to an element named `<timeoutSecondsString>` with a value in whole seconds, not `<timeout>` with a value of milliseconds.

For example, consider this DSL snippet:

``` groovy
wrappers {
  /**
   *  Kill any build that has run for 10 minutes with no output
   */
  timeout{
    noActivity(600)
  }
}
```

v1.25 of the job-dsl plugin generates this XML

``` xml
<hudson.plugins.build__timeout.BuildTimeoutWrapper>
    <strategy class="hudson.plugins.build_timeout.impl.NoActivityTimeOutStrategy">
        <timeout>600000</timeout>
    </strategy>
    <operationList/>
</hudson.plugins.build__timeout.BuildTimeoutWrapper>
```

Once you update to the build-timeout plugin v1.14, this config sets the no activity timeout for no activity to be `0` in the web-ui, which seems to behave with a timeout of 3 or maybe 5 minutes (I couldn't verify this in the build-timeout code yet).

If you update the timeout via the Jenkins web ui, this XML is created:

``` xml
<hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.14">
  <strategy class="hudson.plugins.build_timeout.impl.NoActivityTimeOutStrategy">
    <timeoutSecondsString>600</timeoutSecondsString>
  </strategy>
  <operationList/>
</hudson.plugins.build__timeout.BuildTimeoutWrapper>
```

This change uses the correct serialization format for the latest version of the plugin.  (I'm not sure if this change breaks backwards compatibility for build-timeout v1.13 users, as I don't think `<timeout>` was ever fully supported.  There may be a bug in the build-timeout plugin for what is used during a build vs what is shown in the job config ui.)

See also [build-plugin v1.1.4 NoActivityTimeOutStrategy.java#L77-L88](https://github.com/jenkinsci/build-timeout-plugin/blob/build-timeout-1.14/src/main/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategy.java#L77-L88)
