### PR TITLE
throw exception when calling getProperties from item context.

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Item.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Item.groovy
@@ -34,5 +34,10 @@ abstract class Item {
         xmlOutput.toString()
     }
 
+    Map getProperties() {
+        // see JENKINS-22708
+        throw new UnsupportedOperationException()
+    }
+
     abstract Node getNode()
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslScriptLoaderTest.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslScriptLoaderTest.groovy
@@ -178,7 +178,6 @@ def jobA = job {
 queue jobA
 queue 'JobB'
 '''
-        JobManagement jm = new StringJobManagement()
         ScriptRequest request = new ScriptRequest(null, scriptStr, resourcesDir, false)
 
         when:
@@ -279,5 +278,24 @@ folder {
         then:
         files.size() == 1
         files[0].name == 'foo'
+    }
+
+    def 'getProperties throws exception'() { // JENKINS-22708
+        setup:
+        String script = '''
+            job {
+                name "Test"
+                configure { root ->
+                    (properties / 'hudson.plugins.disk__usage.DiskUsageProperty').@plugin="disk-usage@0.23"
+                }
+            }
+        '''
+        ScriptRequest request = new ScriptRequest(null, script, resourcesDir, false)
+
+        when:
+        DslScriptLoader.runDslEngine request, jm
+
+        then:
+        thrown UnsupportedOperationException
     }
 }


### PR DESCRIPTION
Fixes JENKINS-22708. If a context closure contains the getProperties() method, there is a stack overflow. Overriding the getProperties method fixes the issue.
