### PR TITLE
Added possibility to disable creation of a dedicated xvnc authority file

### DIFF
--- a/docs/Job-DSL-Commands.md
+++ b/docs/Job-DSL-Commands.md
@@ -154,7 +154,7 @@ job(Map<String, ?> arguments = [:]) {
         timeout(Integer timeoutInMinutes, Boolean shouldFailBuild = true) // deprecated
         timestamps()
         toolenv(String... tools)
-        xvnc(boolean takeScreenshot = false)
+        xvnc(boolean takeScreenshot = false, boolean useXauthority = true)
     }
     steps {
         ant(Closure antClosure = null)

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -1111,7 +1111,7 @@ Renders ANSI escape sequences, including color, to Console Output.
 ```groovy
 job {
     wrappers {
-        xvnc(boolean takeScreenshot = false)
+        xvnc(boolean takeScreenshot = false, boolean useXauthority = true)
     }
 }
 ```

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -295,6 +295,7 @@ class WrapperContext implements Context {
      *     <buildWrappers>
      *         <hudson.plugins.xvnc.Xvnc>
      *             <takeScreenshot>false</takeScreenshot>
+     *             <useXauthority>true</useXauthority>
      *         </hudson.plugins.xvnc.Xvnc>
      *     </buildWrappers>
      * </project>
@@ -302,11 +303,13 @@ class WrapperContext implements Context {
      *
      * Runs build under XVNC.
      * @param takeScreenshotAtEndOfBuild If a screenshot should be taken at the end of the build
+     * @param createXauthorityFilePerBuild If a dedicated Xauthority file per build should be created
      */
-    def xvnc(boolean takeScreenshotAtEndOfBuild = false) {
+    def xvnc(boolean takeScreenshotAtEndOfBuild = false, boolean createXauthorityFilePerBuild = true) {
         def nodeBuilder = new NodeBuilder()
         wrapperNodes << nodeBuilder.'hudson.plugins.xvnc.Xvnc' {
             takeScreenshot(takeScreenshotAtEndOfBuild)
+            useXauthority(createXauthorityFilePerBuild)
         }
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperHelperSpec.groovy
@@ -326,8 +326,9 @@ class WrapperHelperSpec extends Specification {
         executeHelperActionsOnRootNode()
 
         then:
-        def wrapper = root.buildWrappers[0].'hudson.plugins.xvnc.Xvnc'.takeScreenshot
-        wrapper[0].value() == false
+        def wrapper = root.buildWrappers[0].'hudson.plugins.xvnc.Xvnc'
+        wrapper.takeScreenshot[0].value() == false
+        wrapper.useXauthority[0].value() == true
     }
 
     def 'xvnc with takeScreenshot arg' () {
@@ -338,8 +339,22 @@ class WrapperHelperSpec extends Specification {
         executeHelperActionsOnRootNode()
 
         then:
-        def wrapper = root.buildWrappers[0].'hudson.plugins.xvnc.Xvnc'.takeScreenshot
-        wrapper[0].value() == true
+        def wrapper = root.buildWrappers[0].'hudson.plugins.xvnc.Xvnc'
+        wrapper.takeScreenshot[0].value() == true
+        wrapper.useXauthority[0].value() == true
+    }
+
+    def 'xvnc without useXauthority arg' () {
+        when:
+        helper.wrappers {
+            xvnc(false, false)
+        }
+        executeHelperActionsOnRootNode()
+
+        then:
+        def wrapper = root.buildWrappers[0].'hudson.plugins.xvnc.Xvnc'
+        wrapper.takeScreenshot[0].value() == false
+        wrapper.useXauthority[0].value() == false
     }
 
     def 'toolenv' () {


### PR DESCRIPTION
The latest version of the xvnc-plugin introduced a feature to create a dedicated authority file per build. It's enabled by default. However, this feature breaks builds under certain circumstances. This commit allows to disable it.

Cheers,
Michel
