### PR TITLE
Added entries method to publishScp closure

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -18,6 +18,7 @@ And finally, if you want to get more involved, [here's how...](https://github.co
 ## Release Notes
 * 1.27 (unreleased)
  * Improved build step console output
+ * added `entries` method in `publishScp` closure to add multiple entries
  * `pattern` method in `archiveArtifacts` closure can be called multiple times to collect patterns
 * 1.26 (October 04 2014)
  * Support for "Pipeline starts with parameters" for [Build Pipeline Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build+Pipeline+Plugin)

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -2461,14 +2461,31 @@ publishJabber(String target, String strategyName, String channelNotificationName
 Supports <a href="https://wiki.jenkins-ci.org/display/JENKINS/Jabber+Plugin">Jabber Plugin</a>. A few arguments can be specified in the method call or in the closure.
 
 ## SCP Publisher
+
 ```groovy
-publishScp(String site, Closure scpClosure) {
-    entry(String source, String destination = '', boolean keepHierarchy = false)
+job {
+    publishers {
+        publishScp(String site) {
+            entry(String source, String destination = '', boolean keepHierarchy = false)
+            entries(Iterable<String> sources, String destination = '', boolean keepHierarchy = false) // since 1.27
+        }
+    }
 }
 ```
 
-Supports <a href="https://wiki.jenkins-ci.org/display/JENKINS/SCP+plugin">SCP Plugin</a>. First arg, site, is specified globally by the plugin. Each entry is
-individually specified in the closure block, e.g. entry can be called multiple times.
+The `site` is specified in the global Jenkins configuration. Each entry is individually specified in the closure block,
+e.g. entry can be called multiple times. Requires the
+[SCP Plugin](https://wiki.jenkins-ci.org/display/JENKINS/SCP+plugin).
+
+```groovy
+job {
+    publishers {
+        publishScp('docs.acme.org') {
+            entry('build/docs/**', 'project-a', true)
+        }
+    }
+}
+```
 
 ## CloneWorkspace Publisher
 ```groovy

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -451,26 +451,25 @@ class PublisherContext implements Context {
     def validJabberChannelNotificationNames = ['Default', 'SummaryOnly', 'BuildParameters', 'PrintFailingTests']
 
     /**
-     <be.certipost.hudson.plugin.SCPRepositoryPublisher>
-     <siteName>javadoc</siteName>
-     <entries>
-     <be.certipost.hudson.plugin.Entry>
-     <filePath/>
-     <sourceFile>api-sdk/*</sourceFile>
-     <keepHierarchy>true</keepHierarchy>
-     </be.certipost.hudson.plugin.Entry>
-     </entries>
-     </be.certipost.hudson.plugin.SCPRepositoryPublisher>
+     * <be.certipost.hudson.plugin.SCPRepositoryPublisher>
+     *     <siteName>javadoc</siteName>
+     *     <entries>
+     *         <be.certipost.hudson.plugin.Entry>
+     *             <filePath/>
+     *             <sourceFile>api-sdk/*</sourceFile>
+     *             <keepHierarchy>true</keepHierarchy>
+     *         </be.certipost.hudson.plugin.Entry>
+     *     </entries>
+     * </be.certipost.hudson.plugin.SCPRepositoryPublisher>
      */
     def publishScp(String site, Closure scpClosure) {
         ScpContext scpContext = new ScpContext()
         AbstractContextHelper.executeInContext(scpClosure, scpContext)
 
         // Validate values
-        assert !scpContext.entries.isEmpty(), 'Scp publish requires at least one entry'
+        assert !scpContext.entries.empty, 'Scp publish requires at least one entry'
 
-        def nodeBuilder = NodeBuilder.newInstance()
-        def publishNode = nodeBuilder.'be.certipost.hudson.plugin.SCPRepositoryPublisher' {
+        publisherNodes << NodeBuilder.newInstance().'be.certipost.hudson.plugin.SCPRepositoryPublisher' {
             siteName site
             entries {
                 scpContext.entries.each { ScpContext.ScpEntry entry ->
@@ -482,7 +481,6 @@ class PublisherContext implements Context {
                 }
             }
         }
-        publisherNodes << publishNode
     }
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/ScpContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/ScpContext.groovy
@@ -3,10 +3,16 @@ package javaposse.jobdsl.dsl.helpers.publisher
 import javaposse.jobdsl.dsl.helpers.Context
 
 class ScpContext implements Context {
-    private final List<ScpEntry> entries = []
+    final List<ScpEntry> entries = []
 
-    def entry(String source, String destination = '', boolean keepHierarchy = false) {
+    void entry(String source, String destination = '', boolean keepHierarchy = false) {
         entries << new ScpEntry(source: source, destination: destination, keepHierarchy: keepHierarchy)
+    }
+
+    void entries(Iterable<String> sources, String destination = '', boolean keepHierarchy = false) {
+        sources.each { source ->
+            entry(source, destination, keepHierarchy)
+        }
     }
 
     static class ScpEntry {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherHelperSpec.groovy
@@ -863,6 +863,50 @@ class PublisherHelperSpec extends Specification {
         entryNode2.keepHierarchy[0].value() == 'true'
     }
 
+    def 'call scp publish with collection of sources'() {
+        when:
+        context.publishScp('javadoc') {
+            entries(['api-sdk/**/*', 'docs/**/*'])
+        }
+
+        then:
+        Node publisherNode = context.publisherNodes[0]
+        publisherNode.name() == 'be.certipost.hudson.plugin.SCPRepositoryPublisher'
+        publisherNode.siteName[0].value() == 'javadoc'
+        publisherNode.entries[0].children().size() == 2
+        with(publisherNode.entries[0].'be.certipost.hudson.plugin.Entry'[0]) {
+            filePath[0].value() == ''
+            sourceFile[0].value() == 'api-sdk/**/*'
+            keepHierarchy[0].value() == 'false'
+        }
+        with(publisherNode.entries[0].'be.certipost.hudson.plugin.Entry'[1]) {
+            filePath[0].value() == ''
+            sourceFile[0].value() == 'docs/**/*'
+            keepHierarchy[0].value() == 'false'
+        }
+
+        when:
+        context.publishScp('javadoc') {
+            entries(['build/javadocs/**/*', 'build/groovydoc/**/*'], 'javadoc', true)
+        }
+
+        then:
+        Node publisherNode2 = context.publisherNodes[1]
+        publisherNode2.name() == 'be.certipost.hudson.plugin.SCPRepositoryPublisher'
+        publisherNode2.siteName[0].value() == 'javadoc'
+        publisherNode2.entries[0].children().size() == 2
+        with(publisherNode2.entries[0].'be.certipost.hudson.plugin.Entry'[0]) {
+            filePath[0].value() == 'javadoc'
+            sourceFile[0].value() == 'build/javadocs/**/*'
+            keepHierarchy[0].value() == 'true'
+        }
+        with(publisherNode2.entries[0].'be.certipost.hudson.plugin.Entry'[1]) {
+            filePath[0].value() == 'javadoc'
+            sourceFile[0].value() == 'build/groovydoc/**/*'
+            keepHierarchy[0].value() == 'true'
+        }
+    }
+
     def 'call trigger downstream without args'() {
         when:
         context.downstream('THE-JOB')


### PR DESCRIPTION
The new `entries` method in the `publishScp` closure allows to define multiple entries at once.
