### PR TITLE
Updated gradle-git plugin

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,7 @@ userName=yourUsername
 password=IHeartJenkins
 ```
 * Deploy: _./gradlew uploadArchives_
-* Publish the docs: _./gradlew publishDocs_
+* Publish the docs: _./gradlew publishGhPages_
 * Tag the source as it is: _git tag -a job-dsl-1.14 -m "Staging 1.14"_
 * Increment the version in gradle.properties and append "-SNAPSHOT": _echo "version=1.15-SNAPSHOT">gradle.properties_
 * Update the release notes, add the next version: `* 1.15 (unreleased)`

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.github.rholder:gradle-one-jar:1.0.3'
-        classpath 'org.ajoberstar:gradle-git:0.6.5'
+        classpath 'org.ajoberstar:gradle-git:0.9.0'
     }
 }
 
@@ -139,6 +139,7 @@ task wrapper(type: Wrapper) {
 apply plugin: 'github-pages'
 
 githubPages {
+    commitMessage = "updated wiki for $version"
     repoUri = 'git@github.com:jenkinsci/job-dsl-plugin.wiki.git'
     targetBranch = 'master'
     workingPath = "$buildDir/wiki"
@@ -146,8 +147,3 @@ githubPages {
         from 'docs'
     }
 }
-
-commitGhPages.message = "updated wiki for $version"
-
-// note: deleting pages is currently not supported
-task publishDocs(dependsOn: publishGhPages)


### PR DESCRIPTION
Updated gradle-git plugin to get rid of a build warning and a workaround. An update to version 0.10.0 or later would require Gradle 2.x.
