### PR TITLE
[FIXED JENKINS-25266] added support for the forcePush option in the git publisher

### DIFF
--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -3244,6 +3244,7 @@ job {
         git {
             pushOnlyIfSuccess(boolean pushOnlyIfSuccess = true)
             pushMerge(boolean pushMerge = true)
+            forcePush(boolean forcePush = true)
             tag(String targetRepoName, String tagName) {
                 message(String message)
                 create(boolean create = true)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/GitPublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/GitPublisherContext.groovy
@@ -9,6 +9,7 @@ import static com.google.common.base.Strings.isNullOrEmpty
 class GitPublisherContext implements Context {
     boolean pushOnlyIfSuccess
     boolean pushMerge
+    boolean forcePush
     List<Node> tags = []
     List<Node> branches = []
 
@@ -18,6 +19,10 @@ class GitPublisherContext implements Context {
 
     void pushMerge(boolean pushMerge = true) {
         this.pushMerge = pushMerge
+    }
+
+    void forcePush(boolean forcePush = true) {
+        this.forcePush = forcePush
     }
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1063,6 +1063,7 @@ class PublisherContext implements Context {
      *         <configVersion>2</configVersion>
      *         <pushMerge>false</pushMerge>
      *         <pushOnlyIfSuccess>true</pushOnlyIfSuccess>
+     *         <forcePush>false</forcePush>
      *         <tagsToPush>
      *             <hudson.plugins.git.GitPublisher_-TagToPush>
      *                 <targetRepoName>origin</targetRepoName>
@@ -1089,6 +1090,7 @@ class PublisherContext implements Context {
             configVersion(2)
             pushMerge(context.pushMerge)
             pushOnlyIfSuccess(context.pushOnlyIfSuccess)
+            forcePush(context.forcePush)
             tagsToPush(context.tags)
             branchesToPush(context.branches)
         }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -1981,6 +1981,7 @@ class PublisherContextSpec extends Specification {
         context.publisherNodes[0].configVersion[0].value() == 2
         context.publisherNodes[0].pushMerge[0].value() == false
         context.publisherNodes[0].pushOnlyIfSuccess[0].value() == false
+        context.publisherNodes[0].forcePush[0].value() == false
     }
 
     def 'call git with all options'() {
@@ -1988,6 +1989,7 @@ class PublisherContextSpec extends Specification {
         context.git {
             pushOnlyIfSuccess()
             pushMerge()
+            forcePush()
             tag('origin', 'test') {
                 message('test tag')
                 create()
@@ -2003,6 +2005,7 @@ class PublisherContextSpec extends Specification {
             configVersion[0].value() == 2
             pushMerge[0].value() == true
             pushOnlyIfSuccess[0].value() == true
+            forcePush[0].value() == true
             tagsToPush.size() == 1
             tagsToPush[0].'hudson.plugins.git.GitPublisher_-TagToPush'.size() == 1
             with(tagsToPush[0].'hudson.plugins.git.GitPublisher_-TagToPush'[0]) {
@@ -2034,6 +2037,7 @@ class PublisherContextSpec extends Specification {
             configVersion[0].value() == 2
             pushMerge[0].value() == false
             pushOnlyIfSuccess[0].value() == false
+            forcePush[0].value() == false
             tagsToPush.size() == 1
             tagsToPush[0].'hudson.plugins.git.GitPublisher_-TagToPush'.size() == 1
             with(tagsToPush[0].'hudson.plugins.git.GitPublisher_-TagToPush'[0]) {


### PR DESCRIPTION
This pull request adds support for the forcePush option in the Git publisher section (since [Git Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin) 2.2.6).

The syntax is: 

```
job {
  ...
  publishers {
    git {
      forcePush()
      ...
    }
  }
}
```
