### PR TITLE
Renaming of Jobs by Pattern

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -17,6 +17,7 @@ And finally, if you want to get more involved, [here's how...](https://github.co
 
 ## Release Notes
 * 1.29 (unreleased)
+ * Added support for renaming existing Jobs based on a regular expression
 * 1.28 (January 01 2015)
  * Added support for the [Credentials Binding Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Binding+Plugin)
  * Added support for the [HTTP Request Plugin](https://wiki.jenkins-ci.org/display/JENKINS/HTTP+Request+Plugin)

--- a/docs/Job-DSL-Commands.md
+++ b/docs/Job-DSL-Commands.md
@@ -78,6 +78,7 @@ job(Map<String, ?> arguments = [:]) {
                int artifactNumToKeep = -1)
     notifications(Closure notificationClosure) // since 1.26
     priority(int value)
+    previousNames(String regex) // since 1.29
     quietPeriod(int seconds = 5)
     throttleConcurrentBuilds(Closure throttleClosure)
     authorization {

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -50,6 +50,15 @@ label(String labelStr)
 
 Label which specifies which nodes this job can run on, e.g. 'X86&&Ubuntu'
 
+## Previous Names
+```groovy
+previousNames(String regex)
+```
+
+Is used by the Plugin when the jobs configuration is updated. If exactly one jobs exists matching this regular expression
+then it is renamed to the name of the current job before the configuration is updated.
+The regular expression needs to match the full name of the job, i.e. with folders included.
+
 ## Disable
 
 ```groovy

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
@@ -25,8 +25,8 @@ abstract class AbstractJobManagement implements JobManagement {
     /**
      * Map if variables that should be available to the script.
      */
-     @Override
-     Map<String, String> getParameters() {
+    @Override
+    Map<String, String> getParameters() {
         [:]
     }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -101,7 +101,7 @@ public class DslScriptLoader {
         return generatedItems;
     }
 
-    private static Set<GeneratedJob> extractGeneratedJobs(JobParent jp, boolean ignoreExisting) {
+    private static Set<GeneratedJob> extractGeneratedJobs(JobParent jp, boolean ignoreExisting) throws IOException {
         // Iterate jobs which were setup, save them, and convert to a serializable form
         Set<GeneratedJob> generatedJobs = Sets.newLinkedHashSet();
         if (jp != null) {
@@ -110,6 +110,12 @@ public class DslScriptLoader {
             for (Item job : referencedItems) {
                 String xml = job.getXml();
                 LOGGER.log(Level.FINE, String.format("Saving job %s as %s", job.getName(), xml));
+                if (job instanceof Job) {
+                    Job realJob = (Job) job;
+                    if (realJob.getPreviousNamesRegex() != null) {
+                        jp.getJm().renameJobMatching(realJob.getPreviousNamesRegex(), realJob.getName());
+                    }
+                }
                 jp.getJm().createOrUpdateConfig(job.getName(), xml, ignoreExisting);
                 String templateName = job instanceof Job ? ((Job) job).getTemplateName() : null;
                 generatedJobs.add(new GeneratedJob(templateName, job.getName()));

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
@@ -18,6 +18,20 @@ class FileJobManagement extends AbstractJobManagement {
      * Environment variables.
      */
     protected Map params = [:]
+    private final RenameHelper renameHelper = new RenameHelper() {
+        @Override
+        Set<String> allJobNames() {
+            root.listFiles()*.name
+        }
+
+        @Override
+        void renameJob(String from, String to) throws IOException {
+            boolean renamed = new File(root, from).renameTo(new File(root, to))
+            if (!renamed) {
+                throw new IOException("Could not rename Job file ${from} to ${to}")
+            }
+        }
+    }
 
     FileJobManagement(File root) {
         this.root = root
@@ -60,6 +74,11 @@ class FileJobManagement extends AbstractJobManagement {
     @Override
     String createOrUpdateConfigFile(ConfigFile configFile, boolean ignoreExisting) {
         throw new UnsupportedOperationException()
+    }
+
+    @Override
+    void renameJobMatching(String previousNames, String destination) throws IOException {
+        renameHelper.renameJobMatching(previousNames, destination)
     }
 
     @Override

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
@@ -59,6 +59,11 @@ class Job extends Item {
         }
     }
 
+    /**
+     * Renames jobs matching the regular expression (fullName) to the name of
+     * this job before the configuration is updated.
+     * This can be useful to keep the build history.
+     */
     void previousNames(String regex) {
         this.previousNamesRegex = regex
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
@@ -27,6 +27,7 @@ class Job extends Item {
 
     String templateName = null // Optional
     JobType type = null // Required
+    String previousNamesRegex = null // Optional
 
     Job(JobManagement jobManagement, Map<String, Object> arguments=[:]) {
         this.jobManagement = jobManagement
@@ -56,6 +57,10 @@ class Job extends Item {
             Node node = methodMissing('description', descriptionString)
             project / node
         }
+    }
+
+    void previousNames(String regex) {
+        this.previousNamesRegex = regex
     }
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
@@ -46,6 +46,19 @@ interface JobManagement {
     String createOrUpdateConfigFile(ConfigFile configFile, boolean ignoreExisting)
 
     /**
+     * Renames a Job with name matching previousNames to the destination name.
+     * Does not support Jobs which are not directly below the seed job.
+     *
+     * If destination matches the currently found job name, then nothing happens.
+     *
+     * @param previousNames a regular Expression how the job was called earlier
+     * @param destination the new name of the job
+     * @throws IOException if renaming failed
+     * @throws IllegalArgumentException if there are multiple jobs matching the previousNames
+     */
+    void renameJobMatching(String previousNames, String destination) throws IOException
+
+    /**
      * Queue a job to run. Useful for running jobs after they've been created.
      */
     void queueJob(String jobName) throws NameNotProvidedException

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
@@ -47,11 +47,11 @@ interface JobManagement {
 
     /**
      * Renames a Job with name matching previousNames to the destination name.
-     * Does not support Jobs which are not directly below the seed job.
      *
      * If destination matches the currently found job name, then nothing happens.
      *
-     * @param previousNames a regular Expression how the job was called earlier
+     * @param previousNames a regular Expression how the job was called earlier.
+     *        Needs to match the full Name (with path) of the job.
      * @param destination the new name of the job
      * @throws IOException if renaming failed
      * @throws IllegalArgumentException if there are multiple jobs matching the previousNames

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/RenameHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/RenameHelper.groovy
@@ -1,0 +1,22 @@
+package javaposse.jobdsl.dsl
+
+abstract class RenameHelper {
+    void renameJobMatching(String fromRegex, String destination) throws IOException {
+        Set<String> matchingJobs = allJobNames().findAll { it ==~ fromRegex }
+        if (matchingJobs.size() > 1) {
+            throw new IllegalArgumentException("Multiple jobs to rename found: ${matchingJobs}")
+        }
+        if (matchingJobs.empty) {
+            return
+        }
+        String sourceName = matchingJobs.iterator().next()
+
+        if (sourceName != destination) {
+            renameJob(sourceName, destination)
+        }
+    }
+
+    abstract Set<String> allJobNames()
+
+    abstract void renameJob(String source, String destination) throws IOException
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
@@ -90,6 +90,11 @@ class AbstractJobManagementSpec extends Specification {
         }
 
         @Override
+        void renameJobMatching(String previousNames, String destination) throws IOException {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
         void requireMinimumPluginVersion(String pluginShortName, String version) {
             throw new UnsupportedOperationException()
         }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslScriptLoaderSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslScriptLoaderSpec.groovy
@@ -93,6 +93,25 @@ job {
           x << [1..25]
     }
 
+    def 'run engine renaming existing jobs'() {
+        setup:
+        def scriptStr = '''job {
+    name '5-project'
+    previousNames '\\\\d-project'
+}
+'''
+        ScriptRequest request = new ScriptRequest(null, scriptStr, resourcesDir, false)
+        StringJobManagement jm = Spy(StringJobManagement)
+        jm.availableFiles += ['4-project': '']
+
+        when:
+        DslScriptLoader.runDslEngine(request, jm)
+
+        then:
+        1 * jm.renameJobMatching(/\d-project/, '5-project')
+
+    }
+
     def 'run engine that uses static import'() {
         setup:
         def scriptStr = '''job(type: Maven) {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/StringJobManagement.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/StringJobManagement.groovy
@@ -15,6 +15,19 @@ class StringJobManagement extends AbstractJobManagement {
     Map<String, String> params = [:]
     List<String> jobScheduled = []
 
+    private final RenameHelper renameHelper = new RenameHelper() {
+        @Override
+        Set<String> allJobNames() {
+            availableConfigs.keySet()
+        }
+
+        @Override
+        void renameJob(String from, String to) throws IOException {
+            availableConfigs[to] = availableConfigs[from]
+            availableConfigs.remove(from)
+        }
+    }
+
     StringJobManagement(PrintStream out) {
         super(out)
     }
@@ -54,6 +67,11 @@ class StringJobManagement extends AbstractJobManagement {
     String createOrUpdateConfigFile(ConfigFile configFile, boolean ignoreExisting) {
         validateNameArg(configFile.name)
         UUID.randomUUID().toString()
+    }
+
+    @Override
+    void renameJobMatching(String previousNames, String destination) throws IOException {
+        renameHelper.renameJobMatching(previousNames, destination)
     }
 
     @Override

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -57,7 +57,7 @@ jpi {
 dependencies {
     compile project(':job-dsl-core')
     forceInclude "org.codehaus.groovy:groovy-all:${groovyVersion}"
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins:cloudbees-folder:4.2@jar'
+    optionalJenkinsPlugins 'org.jenkins-ci.plugins:cloudbees-folder:4.4@jar'
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:credentials:1.9.4@jar'
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:vsphere-cloud:1.1.11@jar'
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.7@jar'

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
@@ -119,6 +119,18 @@ class JenkinsJobManagementSpec extends Specification {
         e.message == 'Could not create view, unknown parent path in "nonexistingfolder/view"'
     }
 
+    def 'rename job'() {
+        setup:
+        jenkinsRule.createFreeStyleProject('oldName')
+
+        when:
+        jobManagement.renameJobMatching('oldName', 'newName')
+
+        then:
+        jenkinsRule.jenkins.getItemByFullName('newName') != null
+        jenkinsRule.jenkins.getItemByFullName('oldName') == null
+    }
+
     def 'createOrUpdateConfig relative to folder'() {
         setup:
         Folder folder = jenkinsRule.jenkins.createProject(Folder, 'folder')

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
@@ -131,6 +131,20 @@ class JenkinsJobManagementSpec extends Specification {
         jenkinsRule.jenkins.getItemByFullName('oldName') == null
     }
 
+    def 'move Job to other Folder'() {
+        setup:
+        Folder oldFolder = jenkinsRule.jenkins.createProject(Folder, 'oldFolder')
+        jenkinsRule.jenkins.createProject(Folder, 'newFolder')
+        oldFolder.createProject(FreeStyleProject, 'oldName')
+
+        when:
+        jobManagement.renameJobMatching('oldFolder/oldName', 'newFolder/newName')
+
+        then:
+        jenkinsRule.jenkins.getItemByFullName('newFolder/newName') != null
+        jenkinsRule.jenkins.getItemByFullName('oldFolder/oldName') == null
+    }
+
     def 'createOrUpdateConfig relative to folder'() {
         setup:
         Folder folder = jenkinsRule.jenkins.createProject(Folder, 'folder')


### PR DESCRIPTION
Implementation of the possibility to configure a job so that on rename the existing Job is also renamed.

We give our job some index numbers to have a better ordering in the UI. These index number change when jobs are added or removed. In order not to loose the build history and not having to decide what to do with the old jobs this feature would be really handy.

Please comment if I tried implementing it the right way. If it is OK, then I would add some documentation.