### PR TITLE
Enhanced rudimentary support for custom config files

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -17,6 +17,7 @@ And finally, if you want to get more involved, [here's how...](https://github.co
 
 ## Release Notes
 * 1.27 (unreleased)
+ * Enhanced support for the [Config File Provider Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin)
  * Added support for the [Rbenv Plugin](https://wiki.jenkins-ci.org/display/JENKINS/rbenv+plugin)
  * Added support for the [NodeJS Plugin](https://wiki.jenkins-ci.org/display/JENKINS/NodeJS+Plugin)
  * Added support for the [Golang Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Go+Plugin)

--- a/docs/Job-DSL-Commands.md
+++ b/docs/Job-DSL-Commands.md
@@ -136,6 +136,7 @@ job(Map<String, ?> arguments = [:]) {
         buildName(String nameTemplate) // since 1.24
         buildUserVars() // since 1.26
         colorizeOutput(String colorMap = 'xterm')
+        configFile(Closure closure)
         deliveryPipelineVersion(String template, boolean setDisplayName = false) // since 1.26
         environmentVariables(Closure envClosure)
         exclusionResources(String... resourceNames) // since 1.24

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -1168,6 +1168,22 @@ Downloads the specified tools, if needed, and puts the path to each of them in t
 
 (since 1.21)
 
+## [Config Files](https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin)
+
+Makes an existing custom config file available to builds.
+
+```groovy
+job {
+    wrappers {
+        configFile {
+            fileName 'myCustomConfigFile'
+        }
+    }
+}
+```
+
+The configFile closure takes three arguments - fileName is mandatory, targetLocation and variable are optional. Requires that Jenkins has the config file provider plugin installed.
+
 ## Environment Variables
 ```groovy
 job {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/ConfigFileContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/ConfigFileContext.groovy
@@ -1,0 +1,37 @@
+package javaposse.jobdsl.dsl.helpers.wrapper
+
+import com.google.common.base.Preconditions
+import javaposse.jobdsl.dsl.ConfigFileType
+import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.helpers.Context
+
+/**
+ * @author Johannes Graf - graf.johannes@gmail.com
+ */
+class ConfigFileContext implements Context {
+
+    private final JobManagement jobManagement
+
+    String fileId
+    String targetLocation
+    String variable
+
+    ConfigFileContext(JobManagement jobManagement) {
+        this.jobManagement = jobManagement
+    }
+
+    def fileName(String fileName) {
+        String fileId = jobManagement.getConfigFileId(ConfigFileType.Custom, fileName)
+        Preconditions.checkNotNull fileId, "Custom config file with name '${fileName}' not found"
+
+        this.fileId = fileId
+    }
+
+    def targetLocation(String targetLocation) {
+        this.targetLocation = targetLocation
+    }
+
+    def variable(String variable) {
+        this.variable = variable
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -609,6 +609,33 @@ class WrapperContext implements Context {
     }
 
     /**
+     * <org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper>
+     *     <managedFiles>
+     *         <org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile>
+     *             <fileId></fileId>
+     *             <targetLocation></targetLocation>
+     *             <variable></variable>
+     *         </org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile>
+     *     </managedFiles>
+     * </org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper>
+     */
+    def configFile(Closure configFileClosure) {
+
+        ConfigFileContext configFileContext = new ConfigFileContext(jobManagement)
+        ContextHelper.executeInContext(configFileClosure, configFileContext)
+
+        wrapperNodes << new NodeBuilder().'org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper' {
+            managedFiles {
+                'org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile' {
+                    fileId configFileContext.fileId
+                    targetLocation configFileContext.targetLocation
+                    variable configFileContext.variable
+                }
+            }
+        }
+    }
+
+    /**
      * <org.jvnet.hudson.plugins.exclusion.IdAllocator>
      *     <ids>
      *         <org.jvnet.hudson.plugins.exclusion.DefaultIdType>


### PR DESCRIPTION
Enhanced support of [Config File Provider Plugin](https://wiki.jenkins-
ci.org/display/JENKINS/Config+File+Provider+Plugin) to enable custom
config files for build jobs.

``` groovy
job {
    wrapper {
        configFile {
            fileName 'myCustomConfigFile'
        }
    }
}

```
