### PR TITLE
Fix JENKINS-25961

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/DescriptorImpl.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/DescriptorImpl.java
@@ -3,13 +3,15 @@ package javaposse.jobdsl.plugin;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import hudson.Extension;
+import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
 import hudson.tasks.Builder;
+import hudson.tasks.BuildStepDescriptor;
 import hudson.util.ListBoxModel;
 import jenkins.YesNoMaybe;
 
 @Extension(dynamicLoadable = YesNoMaybe.YES)
-public class DescriptorImpl extends Descriptor<Builder> {
+public class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
     private Multimap<String, SeedReference> templateJobMap; // K=templateName, V=Seed
 
@@ -49,4 +51,9 @@ public class DescriptorImpl extends Descriptor<Builder> {
         }
         return items;
     }
+    
+    @Override
+    public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+		return true;
+	}
 }


### PR DESCRIPTION
Make it possible for the job-dsl-plugin to appears as a valid builder in the Conditional BuildStep plugin. See https://issues.jenkins-ci.org/browse/JENKINS-25961
