### PR TITLE
Fix `copyArtifact`

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -446,7 +446,6 @@ class StepContext implements Context {
     /**
      * Upstream build that triggered this job
      * <hudson.plugins.copyartifact.CopyArtifact>
-     *     <projectName>jryan-odin-test</projectName>
      *     <filter>*ivy-locked.xml</filter>
      *     <target>target/</target>
      *     <selector class="hudson.plugins.copyartifact.TriggeredBuildSelector"/>
@@ -521,8 +520,7 @@ class StepContext implements Context {
 
         NodeBuilder nodeBuilder = NodeBuilder.newInstance()
         Node copyArtifactNode = nodeBuilder.'hudson.plugins.copyartifact.CopyArtifact' {
-            projectName jobName // Older name for field
-            project jobName // Newer name for field
+            project jobName
             filter includeGlob
             target targetPath ?: ''
 


### PR DESCRIPTION
The `copyArtifact` step is currently broken for matrix projects. The reason for this is that the presence of the `projectName` attributes triggers the `CopyArtifact` plugin to behave differently, as demonstrated below:

```
private boolean upgradeIfNecessary(AbstractProject<?,?> job) throws IOException {
    if (isUpgradeNeeded()) {
        int i = projectName.lastIndexOf('/');
        if (i != -1 && projectName.indexOf('=', i) != -1 && /* not matrix */Jenkins.getInstance().getItem(projectName, job.getParent(), Job.class) == null) {
            project = projectName.substring(0, i);
            parameters = projectName.substring(i + 1);
        } else {
            project = projectName;
            parameters = null;
        }
        LOGGER.log(Level.INFO, "Split {0} into {1} with parameters {2}", new Object[] {projectName, project, parameters});
        projectName = null;
        job.save();
        return true;
    } else {
        return false;
    }
}
```
