### PR TITLE
Updated Jenkins core to 1.554.2 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ subprojects {
     targetCompatibility = 1.6
 
     dependencies {
-        compile 'org.codehaus.groovy:groovy-all:1.8.6'
+        compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
         compile 'com.google.guava:guava:14.0.1'
         testCompile 'org.spockframework:spock-core:0.7-groovy-1.8'
         testCompile 'junit:junit-dep:4.10'
@@ -66,12 +66,12 @@ project(':job-dsl-core') {
     mainClassName = 'javaposse.jobdsl.Run'
 
     dependencies {
-        astCompile 'org.codehaus.groovy:groovy-all:1.8.6'
+        astCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
         compile 'commons-codec:commons-codec:1.8' // for Perforce
         compile 'org.apache.ivy:ivy:2.2.0' // Groovy optional dependency, needed for @Grab
         compile 'xmlunit:xmlunit:1.4' // for runtime use, not just for testing
         compile 'org.jenkins-ci:version-number:1.1'
-        compile 'org.jvnet.hudson:xstream:1.4.4-jenkins-3'
+        compile 'org.jvnet.hudson:xstream:1.4.7-jenkins-1'
     }
 
     jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 version=1.29-SNAPSHOT
+groovyVersion=1.8.9

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -2,7 +2,7 @@ package javaposse.jobdsl.dsl.helpers.publisher
 
 import com.google.common.base.Preconditions
 import com.google.common.base.Strings
-import com.thoughtworks.xstream.io.xml.XmlFriendlyReplacer
+import com.thoughtworks.xstream.io.xml.XmlFriendlyNameCoder
 import hudson.util.VersionNumber
 import javaposse.jobdsl.dsl.Context
 import javaposse.jobdsl.dsl.ContextHelper
@@ -1256,7 +1256,10 @@ class PublisherContext implements Context {
                     condition(class: context.condition.conditionClass) {
                         context.condition.addArgs(delegate)
                     }
-                    publisher(class: new XmlFriendlyReplacer().unescapeName(action.name().toString()), action.value())
+                    publisher(
+                            class: new XmlFriendlyNameCoder().decodeAttribute(action.name().toString()),
+                            action.value()
+                    )
                     runner(class: 'org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail')
                 }
             }

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'org.jenkins-ci.jpi'
 description = 'Jenkins plugin to leverage job-dsl-core to programmatic create jobs from inside Jenkins.'
 
 jenkinsPlugin {
-    coreVersion = '1.509.3'
+    coreVersion = '1.554.2'
     displayName = 'Job DSL'
     url = 'https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin'
     gitHubUrl = 'https://github.com/jenkinsci/job-dsl-plugin'
@@ -46,14 +46,23 @@ jenkinsPlugin {
     }
 }
 
+configurations {
+    forceInclude {}
+}
+
+jpi {
+    classpath += configurations.forceInclude
+}
+
 dependencies {
     compile project(':job-dsl-core')
+    forceInclude "org.codehaus.groovy:groovy-all:${groovyVersion}"
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:cloudbees-folder:4.2@jar'
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:credentials:1.9.4@jar'
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:vsphere-cloud:1.1.11@jar'
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.7@jar'
     jenkinsTest 'org.jenkins-ci.plugins:ant:1.2@jar' // see JENKINS-17129
-    jenkinsTest 'org.jenkins-ci.main:maven-plugin:1.509.3@jar'
+    jenkinsTest 'org.jenkins-ci.main:maven-plugin:2.0@jar'
     jenkinsTest 'org.jenkins-ci.plugins:javadoc:1.1@jar'
     jenkinsTest 'org.jenkins-ci.plugins:mailer:1.1@jar'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
-                <version>1.8.6</version>
+                <version>1.8.9</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci</groupId>
@@ -52,12 +52,12 @@
             <dependency>
                 <groupId>org.jenkins-ci.main</groupId>
                 <artifactId>jenkins-core</artifactId>
-                <version>1.509.3</version>
+                <version>1.554.2</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.main</groupId>
                 <artifactId>jenkins-test-harness</artifactId>
-                <version>1.509.3</version>
+                <version>1.554.2</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
@@ -82,7 +82,7 @@
             <dependency>
                 <groupId>org.jvnet.hudson</groupId>
                 <artifactId>xstream</artifactId>
-                <version>1.4.4-jenkins-3</version>
+                <version>1.4.7-jenkins-1</version>
             </dependency>
             <dependency>
                 <groupId>org.objenesis</groupId>


### PR DESCRIPTION
I also updated the third-party libraries to the level of 1.554.2.

With this update Jenkins kindly reminds you of [JENKINS-4409](https://issues.jenkins-ci.org/browse/JENKINS-4409) when your dev machine runs Windows. Temp files also leaked in previous releases, but now an exception is logged as well...