### PR TITLE
Fix the S3 publisher plugin

### DIFF
--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -3984,15 +3984,15 @@ job {
 
 Adds a S3 bucket publisher. Requires the [S3 Plugin](https://wiki.jenkins-ci.org/display/JENKINS/S3+Plugin).
 
-Valid values for region are `'GovCloud'`, `'US_EAST_1'`, `'US_WEST_1'`, `'US_WEST_2'`, `'EU_WEST_1'`,
-`'AP_SOUTHEAST_1'`, `'AP_SOUTHEAST_2'`, `'AP_NORTHEAST_1'`, `'SA_EAST_1'` or `'CN_NORTH_1'`. The storage class can be
+Valid values for region are `'us-east-1'`, `'us-west-1'`, `'us-west-2'`, `'eu-west-1'`,
+`'ap-southeast-1'`, `'ap-southeast-2'`, `'ap-northeast-2'`, `'sa-east-1'` or `'cn-north-1'`. The storage class can be
 either `'STANDARD'` or `'REDUCED_REDUNDANCY'`.
 
 ```groovy
 job {
     publishers {
         s3('myProfile') {
-            entry('foo', 'bar', 'EU_WEST_1') {
+            entry('foo', 'bar', 'eu-west-1') {
                 storageClass('REDUCED_REDUNDANCY')
                 noUploadOnFailure()
                 uploadFromSlave()

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1382,7 +1382,7 @@ class PublisherContext implements Context {
     void s3(String profile, @DslContext(S3BucketPublisherContext) Closure s3PublisherClosure) {
         checkArgument(!isNullOrEmpty(profile), 'profile must be specified')
 
-        S3BucketPublisherContext context = new S3BucketPublisherContext()
+        S3BucketPublisherContext context = new S3BucketPublisherContext(jobManagement)
         ContextHelper.executeInContext(s3PublisherClosure, context)
 
         publisherNodes << NodeBuilder.newInstance().'hudson.plugins.s3.S3BucketPublisher' {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -2764,12 +2764,12 @@ class PublisherContextSpec extends Specification {
 
         where:
         source | bucket | region
-        null   | 'test' | 'EU_WEST_1'
-        ''     | 'test' | 'EU_WEST_1'
-        'test' | null   | 'EU_WEST_1'
-        'test' | ''     | 'EU_WEST_1'
-        null   | null   | 'EU_WEST_1'
-        ''     | ''     | 'EU_WEST_1'
+        null   | 'test' | 'eu-west-1'
+        ''     | 'test' | 'eu-west-1'
+        'test' | null   | 'eu-west-1'
+        'test' | ''     | 'eu-west-1'
+        null   | null   | 'eu-west-1'
+        ''     | ''     | 'eu-west-1'
         'test' | 'test' | ''
         'test' | 'test' | null
     }
@@ -2777,7 +2777,7 @@ class PublisherContextSpec extends Specification {
     def 'call s3 with invalid storage class'(String storageClass) {
         when:
         context.s3('test') {
-            entry('foo', 'bar', 'EU_WEST_1') {
+            entry('foo', 'bar', 'eu-west-1') {
                 delegate.storageClass(storageClass)
             }
         }
@@ -2792,7 +2792,7 @@ class PublisherContextSpec extends Specification {
     def 'call s3 with some options'() {
         when:
         context.s3('profile') {
-            entry('foo', 'bar', 'US_EAST_1')
+            entry('foo', 'bar', 'us-east-1')
             metadata('key', 'value')
         }
 
@@ -2807,7 +2807,7 @@ class PublisherContextSpec extends Specification {
                 sourceFile[0].value() == 'foo'
                 bucket[0].value() == 'bar'
                 storageClass[0].value() == 'STANDARD'
-                selectedRegion[0].value() == 'US_EAST_1'
+                selectedRegion[0].value() == 'us-east-1'
                 noUploadOnFailure[0].value() == false
                 uploadFromSlave[0].value() == false
                 managedArtifacts[0].value() == false
@@ -2821,11 +2821,31 @@ class PublisherContextSpec extends Specification {
         }
     }
 
+    def 'call s3 with older version'() {
+        setup:
+        jobManagement.getPluginVersion('s3') >> new VersionNumber('0.6')
+
+        when:
+        context.s3('profile') {
+            entry('foo', 'bar', 'us-east-1')
+        }
+
+        then:
+        context.publisherNodes.size() == 1
+        with(context.publisherNodes[0]) {
+            entries.size() == 1
+            entries[0].'hudson.plugins.s3.Entry'.size() == 1
+            with(entries[0].'hudson.plugins.s3.Entry'[0]) {
+                selectedRegion[0].value() == 'US_EAST_1'
+            }
+        }
+    }
+
     def 'call s3 with more options'() {
         when:
         context.s3('profile') {
-            entry('foo', 'bar', 'EU_WEST_1')
-            entry('bar', 'baz', 'US_EAST_1') {
+            entry('foo', 'bar', 'eu-west-1')
+            entry('bar', 'baz', 'us-east-1') {
                 storageClass('REDUCED_REDUNDANCY')
                 noUploadOnFailure(true)
                 uploadFromSlave(true)
@@ -2845,7 +2865,7 @@ class PublisherContextSpec extends Specification {
                 sourceFile[0].value() == 'foo'
                 bucket[0].value() == 'bar'
                 storageClass[0].value() == 'STANDARD'
-                selectedRegion[0].value() == 'EU_WEST_1'
+                selectedRegion[0].value() == 'eu-west-1'
                 noUploadOnFailure[0].value() == false
                 uploadFromSlave[0].value() == false
                 managedArtifacts[0].value() == false
@@ -2854,7 +2874,7 @@ class PublisherContextSpec extends Specification {
                 sourceFile[0].value() == 'bar'
                 bucket[0].value() == 'baz'
                 storageClass[0].value() == 'REDUCED_REDUNDANCY'
-                selectedRegion[0].value() == 'US_EAST_1'
+                selectedRegion[0].value() == 'us-east-1'
                 noUploadOnFailure[0].value() == true
                 uploadFromSlave[0].value() == true
                 managedArtifacts[0].value() == true


### PR DESCRIPTION
The behavior of the S3 Publisher plugin was changed in the latest release (version 0.7). Previously, the AWS regions were specified as uppercase strings seperated by underscores. In version 0.7, the AWS regions are specified as lowercase strings seperated by dashes.

I believe that this behavior was changed in https://github.com/jenkinsci/s3-plugin/commit/4c58e1e3a8c178eb34de0cfb22003a7c2518a610#diff-9e8fd7b0f6318ba66481d3f2cbca9577L78.