### PR TITLE
Added strategy option for Git Plugin

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -17,6 +17,8 @@ And finally, if you want to get more involved, [here's how...](https://github.co
 
 ## Release Notes
 * 1.29 (unreleased)
+ * Added strategy option for the [Git Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin)
+ * Added strategy build chooser for the [Gerrit Trigger](https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Trigger)
 * 1.28 (January 01 2015)
  * Added support for the [Credentials Binding Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Binding+Plugin)
  * Added support for the [HTTP Request Plugin](https://wiki.jenkins-ci.org/display/JENKINS/HTTP+Request+Plugin)

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -566,6 +566,11 @@ git {
         stash(String url) // URL to the Stash repository, optional
     }
     configure(Closure configure) // optional configure block, the GitSCM node is passed in
+    strategy { // since 1.29
+        inverse()
+        ancestry(int maxAge /* days */, String commit)
+        gerritTrigger()
+    }
 }
 
 git(String url, String branch = null, Closure configure = null)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitContext.groovy
@@ -56,6 +56,18 @@ class GitContext implements Context {
         }
     }
 
+    void wipeWorkspace() {
+        extensions << NodeBuilder.newInstance().'hudson.plugins.git.extensions.impl.WipeWorkspace' {
+        }
+    }
+    void strategy(Closure strategyClosure) {
+        StrategyContext strategyContext = new StrategyContext(withXmlActions)
+        executeInContext(strategyClosure, strategyContext)
+        strategyContext.settings.each {
+            extensions << it
+        }
+    }
+
     void mergeOptions(String remote = null, String branch) {
         if (jobManagement.getPluginVersion('git')?.isOlderThan(new VersionNumber('2.0.0'))) {
             mergeOptions = NodeBuilder.newInstance().'userMergeOptions' {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/StrategyContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/StrategyContext.groovy
@@ -1,0 +1,53 @@
+package javaposse.jobdsl.dsl.helpers.scm
+
+import javaposse.jobdsl.dsl.WithXmlAction
+import javaposse.jobdsl.dsl.Context
+
+class StrategyContext implements Context {
+    private final List<WithXmlAction> withXmlActions
+
+    List<Node> settings = []
+
+    StrategyContext(List<WithXmlAction> withXmlActions) {
+        this.withXmlActions = withXmlActions
+    }
+/*
+    <extensions>
+      <hudson.plugins.git.extensions.impl.BuildChooserSetting>
+        <buildChooser
+            class="com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTriggerBuildChooser"
+            plugin="gerrit-trigger@2.12.0">
+          <separator>#</separator>
+        </buildChooser>
+      </hudson.plugins.git.extensions.impl.BuildChooserSetting>
+      <hudson.plugins.git.extensions.impl.BuildChooserSetting>
+        <buildChooser class="hudson.plugins.git.util.InverseBuildChooser"/>
+      </hudson.plugins.git.extensions.impl.BuildChooserSetting>
+    </extensions>
+
+ */
+    void gerritTrigger() {
+        settings << NodeBuilder.newInstance().'hudson.plugins.git.extensions.impl.BuildChooserSetting' {
+            buildChooser(
+                class: 'com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTriggerBuildChooser',
+                plugin: 'gerrit-trigger@2.12.0') {
+                separator('#')
+            }
+        }
+    }
+
+    void inverse() {
+        settings << NodeBuilder.newInstance().'hudson.plugins.git.extensions.impl.BuildChooserSetting' {
+            buildChooser(class: 'hudson.plugins.git.util.InverseBuildChooser')
+        }
+    }
+
+    void ancestry(int maxAge /* days */, String commit) {
+        settings << NodeBuilder.newInstance().'hudson.plugins.git.extensions.impl.BuildChooserSetting' {
+            buildChooser(class: 'hudson.plugins.git.util.AncestryBuildChooser') {
+                maximumAgeInDays(maxAge)
+                ancestorCommitSha1(commit)
+            }
+        }
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
@@ -700,6 +700,49 @@ class ScmContextSpec extends Specification {
         }
     }
 
+    def 'call git scm with complex buildStrategy, plugin version 2.x'() {
+        setup:
+        mockJobManagement.getPluginVersion('git') >> new VersionNumber('2.0.0')
+
+        when:
+        context.git {
+            remote {
+                url('https://github.com/jenkinsci/job-dsl-plugin.git')
+                refspec 'master'
+            }
+            wipeWorkspace()
+            strategy {
+                gerritTrigger()
+                inverse()
+                ancestry(5, 'sha1')
+            }
+        }
+
+        then:
+        context.scmNode != null
+        context.scmNode.extensions.size() == 1
+        context.scmNode.extensions[0].'hudson.plugins.git.extensions.impl.BuildChooserSetting'.size() == 3
+        with(context.scmNode.extensions[0].'hudson.plugins.git.extensions.impl.BuildChooserSetting'[0]) {
+            buildChooser.size() == 1
+            buildChooser[0].attribute('class') ==
+                    'com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTriggerBuildChooser'
+            buildChooser[0].separator.size() == 1
+            buildChooser[0].separator[0].text() == '#'
+        }
+        with(context.scmNode.extensions[0].'hudson.plugins.git.extensions.impl.BuildChooserSetting'[1]) {
+            buildChooser.size() == 1
+            buildChooser[0].attribute('class') == 'hudson.plugins.git.util.InverseBuildChooser'
+        }
+        with(context.scmNode.extensions[0].'hudson.plugins.git.extensions.impl.BuildChooserSetting'[2]) {
+            buildChooser.size() == 1
+            buildChooser[0].attribute('class') == 'hudson.plugins.git.util.AncestryBuildChooser'
+            buildChooser[0].maximumAgeInDays.size() == 1
+            buildChooser[0].maximumAgeInDays[0].text() == '5'
+            buildChooser[0].ancestorCommitSha1.size() == 1
+            buildChooser[0].ancestorCommitSha1[0].text() == 'sha1'
+        }
+    }
+
     def 'call git scm with credentials'() {
         setup:
         mockJobManagement.getCredentialsId('ci-user') >> '0815'


### PR DESCRIPTION
Added strategy option for the [Git Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin): inverse, ancestor
Added strategy build chooser for the [Gerrit Trigger](https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Trigger)
