### PR TITLE
[FIXED JENKINS-16355] Enable codemirror

### DIFF
--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/config.jelly
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/config.jelly
@@ -2,8 +2,8 @@
 
     <f:radioBlock name="scriptLocation" value="true" title="Use the provided DSL script" checked="${instance.isUsingScriptText()}">
         <f:entry title='DSL Script' field='scriptText'>
-            <!-- TODO CodeMirror support for text/x-groovy. It was unclear how do it from a .groovy stapler script -->
-            <f:textarea style="width:100%; height:10em"/>
+            <f:textarea codemirror-mode="groovy"
+                        codemirror-config="mode: 'text/x-groovy', lineNumbers: true, matchBrackets: true, onBlur: function(editor){editor.save()}"/>
         </f:entry>
     </f:radioBlock>
 


### PR DESCRIPTION
Adapted from https://github.com/jenkinsci/groovy-plugin/blob/groovy-1.24/src/main/resources/hudson/plugins/groovy/StringScriptSource/config.jelly.

This PR introduces https://github.com/jenkinsci/jenkins/pull/1460 issue. Can be easily made bigger and happen only when the radio button is not preselected.