### PR TITLE
Allow `additionalClasspath` to be specified for the `job-dsl-plugin`

### DIFF
--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -1993,6 +1993,7 @@ dsl {
     external (String... dslFilenames)      // one or more filenames/-paths in the workspace containing DSLs
     text (String dslSpecification)         // direct specification of DSL as String
     ignoreExisting(boolean ignoreExisting) // flag if to ignore existing jobs
+    additionalClasspath(String classpath)
 }
 
 /* equivalent calls as parameters instead of closure */
@@ -2009,6 +2010,7 @@ dsl {
     external 'some-dsl.groovy','some-other-dsl.groovy'
     external 'still-another-dsl.groovy'
     ignoreExisting true
+    additionalClasspath 'some/directory'
 }
 
 /* same definition using parameters instead of closure */

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/DslContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/DslContext.groovy
@@ -15,6 +15,7 @@ class DslContext implements Context {
     DslContext.RemovedJobAction removedJobAction = DslContext.RemovedJobAction.IGNORE
     List<String> externalScripts = []
     boolean ignoreExisting = false
+    String additionalClasspath = ''
 
     void text(String text) {
         this.scriptText = Preconditions.checkNotNull(text)
@@ -42,5 +43,9 @@ class DslContext implements Context {
         } catch (IllegalArgumentException iae) {
             throw new IllegalArgumentException("removeAction must be one of: ${DslContext.RemovedJobAction.values()}")
         }
+    }
+
+    void additionalClasspath(String classpath) {
+        this.additionalClasspath = classpath
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -174,6 +174,7 @@ class StepContext implements Context {
             scriptText context.scriptText
             ignoreExisting context.ignoreExisting
             removedJobAction context.removedJobAction.name()
+            additionalClasspath context.additionalClasspath
         }
 
         stepNodes << dslNode

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
@@ -1047,6 +1047,7 @@ class StepContextSpec extends Specification {
         dslStep.ignoreExisting[0].value() ==  false
         dslStep.removedJobAction[0].value() == 'IGNORE'
         dslStep.scriptText[0].value() == ''
+        dslStep.additionalClasspath[0].value() == ''
     }
 
     def 'call dsl method external script ignoring existing' () {
@@ -1187,6 +1188,26 @@ still-another-dsl.groovy'''
   }
 }
 '''
+    }
+
+    def 'call dsl method additional classpath' () {
+        when:
+        context.dsl {
+            external 'some-dsl.groovy'
+            additionalClasspath 'some/path'
+        }
+
+        then:
+        context.stepNodes != null
+        context.stepNodes.size() == 1
+        def dslStep = context.stepNodes[0]
+        dslStep.name() == 'javaposse.jobdsl.plugin.ExecuteDslScripts'
+        dslStep.targets[0].value() == 'some-dsl.groovy'
+        dslStep.usingScriptText[0].value() == false
+        dslStep.ignoreExisting[0].value() ==  false
+        dslStep.removedJobAction[0].value() == 'IGNORE'
+        dslStep.scriptText[0].value() == ''
+        dslStep.additionalClasspath[0].value() == 'some/path'
     }
 
     def 'call prerequisite method with single project'() {


### PR DESCRIPTION
Allow an additional classpath to be specified for the `dsl` step.