### PR TITLE
Add support for Bitbucker pull request builder plugin

### DIFF
--- a/docs/Job-DSL-Commands.md
+++ b/docs/Job-DSL-Commands.md
@@ -127,6 +127,7 @@ job(Map<String, ?> arguments = [:]) {
         gerrit(Closure gerritClosure = null)
         githubPush()
         pullRequest(Closure pullRequestClosure) // since 1.22
+        bitbucketPullRequest(Closure pullRequestClosure)    // since ...
         scm(String cron)
         snapshotDependencies(boolean checkSnapshotDependencies)
         urlTrigger(String cronString = null, Closure urlTriggerClosure)

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -908,6 +908,50 @@ job {
 }
 ```
 
+## Bitbucket Pull Request Trigger
+
+```groovy
+bitbucketPullRequest {
+    cron(String cron) // set cron schedule, defaults to 'H/5 * * * *'
+    username(String username)   // set Bitbucket username
+    password(String password)   // set Bitbucket password
+    repositoryOwner(String repositoryOwner) // set Bitbucket repository owner
+    repositoryName(String repositoryName)   // set Bitbucket repository name
+    ciSkipPhases(String ciSkipPhases)   // set ci skip phases
+    checkDestinationCommit(boolean checkDestinationCommit = false)  // rebuild if destination branch changes, defaults to false if not specified
+}
+```
+
+Builds pull requests from Bitbucket and will report the results directly to the pull request. Requires the [Bitbucket pull request builder plugin](https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+pullrequest+builder+plugin). (Available since 1.509.4)
+
+The Bitbucket pull request builder plugin requires a special Git SCM configuration, see the plugin documentation for details.
+
+```groovy
+job {
+    ...
+    scm {
+        git {
+            remote {
+                url('git@bitbucket.org:\${repositoryOwner}/\${repositoryName}.git')
+                credentials('Bitbucket Credentials')
+            }
+            branch('*/\${sourceBranch}')
+        }
+    }
+    triggers {
+        bitbucketPullRequest {
+            cron('H/5 * * * *')
+            username('bitbucketUsername')
+            password('bitbucketPassword')
+            repositoryOwner('bitbucketRepositoryOwner')
+            repositoryName('bitbucketRepositoryName')
+            ciSkipPhases('.*\\[skip\\W+ci\\].*')
+            checkDestinationCommit(true)
+        }
+    }
+}
+```
+
 ## URL Trigger
 
 The URL trigger plugin checks one or more specified URLs and starts a build when a change is detected. (Since 1.16)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/BitbucketPullRequestBuilderContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/BitbucketPullRequestBuilderContext.groovy
@@ -1,0 +1,42 @@
+package javaposse.jobdsl.dsl.helpers.triggers
+
+import javaposse.jobdsl.dsl.Context
+
+class BitbucketPullRequestBuilderContext implements Context {
+
+    String cron = 'H/5 * * * *'
+    String username = ''
+    String password = ''
+    String repositoryOwner = ''
+    String repositoryName = ''
+    String ciSkipPhases = ''
+    boolean checkDestinationCommit = false
+
+    void cron(String cron) {
+        this.cron = cron
+    }
+
+    void username(String username) {
+        this.username = username
+    }
+
+    void password(String password) {
+        this.password = password
+    }
+
+    void repositoryOwner(String repositoryOwner) {
+        this.repositoryOwner = repositoryOwner
+    }
+
+    void repositoryName(String repositoryName) {
+        this.repositoryName = repositoryName
+    }
+
+    void ciSkipPhases(String ciSkipPhases) {
+        this.ciSkipPhases = ciSkipPhases
+    }
+
+    void checkDestinationCommit(boolean checkDestinationCommit = false) {
+        this.checkDestinationCommit = checkDestinationCommit
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
@@ -294,4 +294,36 @@ class TriggerContext implements Context {
             it.appendNode 'ignoreUpstremChanges', !checkSnapshotDependencies
         }
     }
+
+    /**
+     *  Configures the Jenkins Bitbucket pull request builder plugin
+     *  Depends on the git plugin
+     *
+     *  <bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketBuildTrigger>
+     *      <spec></spec>
+     *      <cron></cron>
+     *      <username></username>
+     *      <password></password>
+     *      <repositoryOwner></repositoryOwner>
+     *      <repositoryName></repositoryName>
+     *      <ciSkipPhases></ciSkipPhases>
+     *      <checkDestinationCommit>false</checkDestinationCommit>
+     *  </bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketBuildTrigger>
+     */
+    void bitbucketPullRequest(@DslContext(BitbucketPullRequestBuilderContext) Closure contextClosure) {
+        BitbucketPullRequestBuilderContext pullRequestBuilderContext = new BitbucketPullRequestBuilderContext()
+        ContextHelper.executeInContext(contextClosure, pullRequestBuilderContext)
+
+        NodeBuilder nodeBuilder = new NodeBuilder()
+        triggerNodes << nodeBuilder.'bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketBuildTrigger' {
+            delegate.cron(pullRequestBuilderContext.cron)
+            spec pullRequestBuilderContext.cron
+            username pullRequestBuilderContext.username
+            password pullRequestBuilderContext.password
+            repositoryOwner pullRequestBuilderContext.repositoryOwner
+            repositoryName pullRequestBuilderContext.repositoryName
+            ciSkipPhases pullRequestBuilderContext.ciSkipPhases
+            checkDestinationCommit pullRequestBuilderContext.checkDestinationCommit
+        }
+    }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
@@ -547,4 +547,50 @@ class TriggerContextSpec extends Specification {
         context.withXmlActions != null
         context.withXmlActions.size() == 1
     }
+
+    def 'call bitbucket pull request trigger with no args'() {
+        when:
+        context.bitbucketPullRequest()
+
+        then:
+        def pullRequestNode = context.triggerNodes[0]
+        with(pullRequestNode) {
+            name() == 'bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketBuildTrigger'
+            cron[0].value() == 'H/5 * * * *'
+            spec[0].value() == 'H/5 * * * *'
+            username[0].value() == ''
+            password[0].value() == ''
+            repositoryOwner[0].value() == ''
+            repositoryName[0].value() == ''
+            ciSkipPhases[0].value() == ''
+            checkDestinationCommit[0].value() == false
+        }
+    }
+
+    def 'call bitbucket pull request trigger with all args'() {
+        when:
+        context.bitbucketPullRequest {
+            cron('H/10 * * * *')
+            username('bitbucketUsername')
+            password('bitbucketPassword')
+            repositoryOwner('bitbucketRepositoryOwner')
+            repositoryName('bitbucketRepositoryName')
+            ciSkipPhases('.*\\[skip\\W+ci\\].*')
+            checkDestinationCommit(true)
+        }
+
+        then:
+        def pullRequestNode = context.triggerNodes[0]
+        with(pullRequestNode) {
+            name() == 'bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketBuildTrigger'
+            cron[0].value() == 'H/10 * * * *'
+            spec[0].value() == 'H/10 * * * *'
+            username[0].value() == 'bitbucketUsername'
+            password[0].value() == 'bitbucketPassword'
+            repositoryOwner[0].value() == 'bitbucketRepositoryOwner'
+            repositoryName[0].value() == 'bitbucketRepositoryName'
+            ciSkipPhases[0].value() == '.*\\[skip\\W+ci\\].*'
+            checkDestinationCommit[0].value() == true
+        }
+    }
 }


### PR DESCRIPTION
Add support for [Bitbucket pull request builder plugin](https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+pullrequest+builder+plugin). 
Code is very similar to support got [GitHub pull request builder](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin).

Related to the following JIRA ticket: https://issues.jenkins-ci.org/browse/JENKINS-26488.
And to this [Google Group question](https://groups.google.com/forum/#!topic/job-dsl-plugin/9fOk3dF1mSo).