### PR TITLE
Loosened S3BucketPublisherContext's coupling with its corresponding plugin config

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/S3BucketPublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/S3BucketPublisherContext.groovy
@@ -8,10 +8,6 @@ import static com.google.common.base.Preconditions.checkArgument
 import static com.google.common.base.Strings.isNullOrEmpty
 
 class S3BucketPublisherContext implements Context {
-    private static final List<String> REGIONS = [
-            'GovCloud', 'US_EAST_1', 'US_WEST_1', 'US_WEST_2', 'EU_WEST_1', 'AP_SOUTHEAST_1', 'AP_SOUTHEAST_2',
-            'AP_NORTHEAST_1', 'SA_EAST_1', 'CN_NORTH_1'
-    ]
 
     List<Node> entries = []
     List<Node> metadata = []
@@ -19,7 +15,7 @@ class S3BucketPublisherContext implements Context {
     void entry(String source, String bucketName, String region, @DslContext(S3EntryContext) Closure closure = null) {
         checkArgument(!isNullOrEmpty(source), 'source must be specified')
         checkArgument(!isNullOrEmpty(bucketName), 'bucket must be specified')
-        checkArgument(REGIONS.contains(region), "region must be one of ${REGIONS.join(', ')}")
+        checkArgument(!isNullOrEmpty(region), 'region must be specified')
 
         S3EntryContext context = new S3EntryContext()
         ContextHelper.executeInContext(closure, context)


### PR DESCRIPTION
This is a small change to fix a bug where you cannot use the S3 bucket publisher plugin with the DSL.  

Basically the DSL enforces that you set the region in caps with underscores, like `AP_SOUTHEAST_2`, whereas the S3 bucket publisher plugin's configuration expects a region in lower case with hyphens, like `ap-southeast-2`.  To work around this we had to use a configure block, which is a bit ugly.  

This fix loosens the checking that occurs on the DSL's parameters, so that in future if the S3 bucket publisher changes the nature of its region configuration, the Job DSL should not need to also change.  It simply enforces that the region parameter is necessary.  