### PR TITLE
deprecated perModuleEmail

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -28,6 +28,7 @@ And finally, if you want to get more involved, [here's how...](https://github.co
  * Fixed support for JARs in the "Additional classpath" option of the "Process Job DSLs" build step
  * Allow Ant-style patterns in the "Additional classpath" option of the "Process Job DSLs" build step
  * Support for the `@Grab` and `@Grapes` annotations is deprecated, see [[Migration]]
+ * Deprecated `perModuleEmail` option for Maven jobs ([JENKINS-26284](https://issues.jenkins-ci.org/browse/JENKINS-26284))
  * Removed deprecated build timeout methods, see [[Migration|Migration#migrating-to-124]]
 * 1.28 (January 01 2015)
  * Added support for the [Credentials Binding Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Binding+Plugin)

--- a/docs/Job-DSL-Commands.md
+++ b/docs/Job-DSL-Commands.md
@@ -309,7 +309,7 @@ job(Map<String, ?> arguments = [:]) {
     mavenOpts(String mavenOpts)
     mavenInstallation(String name) // since 1.20
     localRepository(LocalRepositoryLocation location)
-    perModuleEmail(boolean shouldSendEmailPerModule)
+    perModuleEmail(boolean shouldSendEmailPerModule) // deprecated since 1.29
     archivingDisabled(boolean shouldDisableArchiving)
     runHeadless(boolean shouldRunHeadless)
     preBuildSteps(Closure stepsClosure)

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -418,7 +418,7 @@ localRepository(LocalToWorkspace)
 
 ## Email Per Module
 ```groovy
-perModuleEmail(boolean shouldSendEmailPerModule)
+perModuleEmail(boolean shouldSendEmailPerModule) // deprecated since 1.29
 ```
 
 Enable or disable email notifications for each Maven module.

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -25,6 +25,33 @@ But to be able to use a library, it has to be added to the _Additional classpath
 step (e.g. `lib/commons-lang-2.4.jar` or `lib/*.jar`) and the JAR files have to be in workspace of the seed job (e.g. in
 a `lib` directory). See [[Using Libraries|User-Power-Moves#using-libraries]] for details.
 
+### Per Module Email
+
+The `perModuleEmail` option has been deprecated because the e-mail notification settings have changed in newer versions
+of the [Maven Project Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Maven+Project+Plugin), see
+[JENKINS-26284](https://issues.jenkins-ci.org/browse/JENKINS-26284).
+
+DSL prior to 1.29
+```groovy
+job(type: Maven) {
+    perModuleEmail(true)
+}
+```
+
+DSL since 1.29
+```groovy
+job(type: Maven) {
+    configure {
+        it / reporters << 'hudson.maven.reporters.MavenMailer' {
+            recipients()
+            dontNotifyEveryUnstableBuild(false)
+            sendToIndividuals(false)
+            perModuleEmail(true)
+        }
+    }
+}
+```
+
 ## Migrating to 1.28
 
 ### HTML Publisher

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
@@ -702,7 +702,9 @@ class Job extends Item {
      * If set, Jenkins will send an e-mail notifications for each module, defaults to <code>false</code>.
      * @param perModuleEmail set to <code>true</code> to enable per module e-mail notifications
      */
+    @Deprecated
     void perModuleEmail(boolean perModuleEmail) {
+        jobManagement.logDeprecationWarning()
         Preconditions.checkState(type == JobType.Maven, 'perModuleEmail can only be applied for Maven jobs')
 
         withXmlActions << WithXmlAction.create { Node project ->
@@ -928,7 +930,6 @@ class Job extends Item {
   <concurrentBuild>false</concurrentBuild>
   <aggregatorStyleBuild>true</aggregatorStyleBuild>
   <incrementalBuild>false</incrementalBuild>
-  <perModuleEmail>false</perModuleEmail>
   <ignoreUpstremChanges>true</ignoreUpstremChanges>
   <archivingDisabled>false</archivingDisabled>
   <resolveDependencies>false</resolveDependencies>

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobSpec.groovy
@@ -1388,7 +1388,6 @@ class JobSpec extends Specification {
     <concurrentBuild>false</concurrentBuild>
     <aggregatorStyleBuild>true</aggregatorStyleBuild>
     <incrementalBuild>false</incrementalBuild>
-    <perModuleEmail>false</perModuleEmail>
     <ignoreUpstremChanges>true</ignoreUpstremChanges>
     <archivingDisabled>false</archivingDisabled>
     <resolveDependencies>false</resolveDependencies>


### PR DESCRIPTION
Deprecated perModuleEmail and removed element from config XML template, see [JENKINS-26284](https://issues.jenkins-ci.org/browse/JENKINS-26284)