### PR TITLE
[JENKINS-26796] Add a configure block to multijob job

### DIFF
--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -2263,7 +2263,7 @@ job(type: Multijob) {
                 disableJob(boolean exposedScm = true) // since 1.25
                 killPhaseCondition(String killPhaseCondition) // since 1.25
                 nodeLabel(String paramName, String nodeLabel) // since 1.26
-                configure(Closure configClosure) // since 1.29
+                configure(Closure configClosure) // since 1.30
             }
         }
     }

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -2263,6 +2263,7 @@ job(type: Multijob) {
                 disableJob(boolean exposedScm = true) // since 1.25
                 killPhaseCondition(String killPhaseCondition) // since 1.25
                 nodeLabel(String paramName, String nodeLabel) // since 1.26
+                configure(Closure configClosure) // since 1.29
             }
         }
     }
@@ -2303,6 +2304,11 @@ job(type: Multijob) {
                 gitRevision()
                 prop('prop1', 'value1')
                 nodeLabel('lParam', 'my_nodes')
+                configure { phaseJobConfig ->
+                  phaseJobConfig / enableCondition << 'true'
+                  phaseJobConfig / condition << '${RUN_JOB} == "true"'
+                  phaseJobConfig / customConfig << 'yes'
+                }
             }
         }
    }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/PhaseJobContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/PhaseJobContext.groovy
@@ -25,6 +25,7 @@ class PhaseJobContext implements Context {
     List<String> props = []
     boolean disableJob = false
     String killPhaseCondition = 'FAILURE'
+    Closure configureClosure
 
     PhaseJobContext(JobManagement jobManagement, String jobName, boolean currentJobParameters, boolean exposedScm) {
         this.jobManagement = jobManagement
@@ -120,5 +121,9 @@ class PhaseJobContext implements Context {
         )
 
         this.killPhaseCondition = killPhaseCondition
+    }
+
+    void configure(Closure configureClosure) {
+        this.configureClosure = configureClosure
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -637,7 +637,7 @@ class StepContext implements Context {
             continuationCondition phaseContext.continuationCondition
             phaseJobs {
                 phaseContext.jobsInPhase.each { PhaseJobContext jobInPhase ->
-                    'com.tikal.jenkins.plugins.multijob.PhaseJobsConfig' {
+                    Node phaseJobNode = 'com.tikal.jenkins.plugins.multijob.PhaseJobsConfig' {
                         jobName jobInPhase.jobName
                         currParams jobInPhase.currentJobParameters
                         exposedSCM jobInPhase.exposedScm
@@ -651,6 +651,15 @@ class StepContext implements Context {
                             configs('class': 'java.util.Collections$EmptyList')
                         }
                     }
+
+                    // Apply overrides
+                    if (jobInPhase.configureClosure) {
+                        jobInPhase.configureClosure.resolveStrategy = Closure.DELEGATE_FIRST
+                        WithXmlAction action = new WithXmlAction(jobInPhase.configureClosure)
+                        action.execute(phaseJobNode)
+                    }
+
+                    phaseJobNode
                 }
             }
         }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -654,7 +654,6 @@ class StepContext implements Context {
 
                     // Apply overrides
                     if (jobInPhase.configureClosure) {
-                        jobInPhase.configureClosure.resolveStrategy = Closure.DELEGATE_FIRST
                         WithXmlAction action = new WithXmlAction(jobInPhase.configureClosure)
                         action.execute(phaseJobNode)
                     }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
@@ -945,6 +945,9 @@ class StepContextSpec extends Specification {
                         prop4: 'value4'
                 ])
                 nodeLabel('nodeParam', 'node_label')
+                configure { phaseJobConfig ->
+                    phaseJobConfig / customConfig << 'foobar'
+                }
             }
         }
 
@@ -953,6 +956,10 @@ class StepContextSpec extends Specification {
         def jobNode = phaseNode.phaseJobs[0].'com.tikal.jenkins.plugins.multijob.PhaseJobsConfig'[0]
         jobNode.currParams[0].value() == false
         jobNode.exposedSCM[0].value() == true
+
+        def customConfigNode = jobNode.customConfig[0]
+        customConfigNode.value() == 'foobar'
+
         def configsNode = jobNode.configs[0]
         def boolParams = configsNode.'hudson.plugins.parameterizedtrigger.BooleanParameters'[0].configs[0]
         boolParams.children().size() == 3


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-26796

This adds support for adding custom configuration to each job config in a MultiJob phase.  This is useful when trying to configure newly released features, or when supporting a patched version of the MultiJob plugin.