### PR TITLE
Build Timeout Refactoring

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -23,6 +23,8 @@ And finally, if you want to get more involved, [here's how...](https://github.co
  * Added strategy build chooser for the [Gerrit Trigger](https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Trigger)
  * Enhanced support for the [Subversion Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Subversion+Plugin)
  * Added `abortBuild` action for the [Build Timeout](https://wiki.jenkins-ci.org/display/JENKINS/Build-timeout+Plugin)
+ * Deprecated the `failBuild` action with a boolean parameter for the [Build Timeout](https://wiki.jenkins-ci.org/display/JENKINS/Build-timeout+Plugin), see [[Migration]]
+ * Deprecated the `javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext.Timeout` enum, see [[Migration]]
  * Added support for label parameters from the [NodeLabel Parameter Plugin](https://wiki.jenkins-ci.org/display/JENKINS/NodeLabel+Parameter+Plugin)
  * Added populateToolInstallations and overrideBuildVariables options for the [EnvInject Plugin](https://wiki.jenkins-ci.org/display/JENKINS/EnvInject+Plugin)
  * Added groovy option in the wrappers context for the [EnvInject Plugin](https://wiki.jenkins-ci.org/display/JENKINS/EnvInject+Plugin)

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -1114,8 +1114,9 @@ job {
             noActivity(int seconds = 180)
             absolute(int minutes = 3)                  // default
             likelyStuck()
-            failBuild(boolean fail = true)
-            abortBuild(boolean abort = true)           // since 1.30
+            failBuild()
+            failBuild(boolean fail)                    // deprecated since 1.30
+            abortBuild()                               // since 1.30
             writeDescription(String description)
         }
     }

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -1,5 +1,36 @@
 ## Migrating to 1.29
 
+### Build Timeout
+
+The `javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext.Timeout` enum has been [[deprecated|Deprecation-Policy]]
+because it's not used by the DSL anymore.
+
+The `failBuild` option with a boolean argument has been [[deprecated|Deprecation-Policy]].
+
+DSL prior to 1.30
+```groovy
+job {
+    wrappers {
+        buildTimeout() {
+            failBuild(true)
+        }
+    }
+}
+```
+
+DSL since 1.30
+```groovy
+job {
+    wrappers {
+        buildTimeout() {
+            failBuild()
+        }
+    }
+}
+```
+
+## Migrating to 1.29
+
 ### Grab Support
 
 Support for the `@Grab` and `@Grapes` annotation has been [[deprecated|Deprecation-Policy]] and replaced by the

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -221,6 +221,22 @@ class WrapperContextSpec extends Specification {
         }
     }
 
+    def 'default timeout will not fail the build'() {
+        when:
+        context.timeout {
+            failBuild()
+            failBuild(false)
+        }
+
+        then:
+        with(context.wrapperNodes[0]) {
+            children().size() == 2
+            strategy[0].children().size() == 1
+            strategy[0].timeoutMinutes[0].value() == 3
+            operationList[0].children().size() == 0
+        }
+    }
+
     def 'default timeout will abort the build'() {
         when:
         context.timeout {


### PR DESCRIPTION
Timeout enum is used internally only and now deprecated. Removed the switch statement and the list of if statements by moving some logic to TimeoutContext. Deprecated the failBuild action with a boolean parameter, removed the abortBuild action with a boolean parameter.