### PR TITLE
Finding credentials by description is deprecated

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -34,6 +34,7 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
  * Fixed the `notifySuspects` option for the [Jabber Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Jabber+Plugin)
  * Fixed `extendedEmail` configure block resolve strategy ([JENKINS-27063](https://issues.jenkins-ci.org/browse/JENKINS-27063))
  * Deprecated some overloaded DSL methods for the [Jabber Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Jabber+Plugin), see [[Migration]]
+ * Finding credentials by description is deprecated, see [[Migration]]
 * 1.29 (February 05 2015)
  * Show seed job and template job info in the generated jobs
  * Added [CoreMirror](https://codemirror.net/) support for the DSL script input field

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -560,7 +560,7 @@ git {
         github(String ownerAndProject, String protocol = "https", String host = "github.com") // will also set the browser
                                                                                               // and GitHub property
         refspec(String refspec) // optional
-        credentials(String credentials) // optional
+        credentials(String credentialsId) // optional
     }
     branch(String name) // the branches to build, multiple calls are accumulated, defaults to **
     branches(String... names)
@@ -598,7 +598,9 @@ The GitHub variants will derive the Git URL from the ownerAndProject, protocol a
 
 The Git plugin has a lot of configurable options, which are currently not all supported by the DSL. A  configure block can be used to add more options.
 
-Version 2.0 or later of the Git Plugin is required to use `cloneTimeout` or Jenkins managed credentials for Git authentication. The arguments for the credentials method is the description field or the UUID generated from Jenkins | Manage Jenkins | Manage Credentials. The easiest way to find this value, is to navigate Jenkins | Credentials | Global credentials | (Key Name). Then look at the description in parenthesis or using the UUID in the URL.
+Version 2.0 or later of the Git Plugin is required to use `cloneTimeout` or Jenkins managed credentials for Git
+authentication. The argument for the `credentials` method can either be the ID of the credentials or its description.
+Note that finding credentials by description has been [[deprecated|Deprecation-Policy]], see [[Migration]].
 
 When Git Plugin version 2.0 or later is used, `mergeOptions` can be called multiple times to merge more than one branch.
 
@@ -650,7 +652,7 @@ github('jenkinsci/job-dsl-plugin')
 git {
     remote {
         github('account/repo', 'ssh')
-        credentials('GitHub CI Key')
+        credentials('github-ci-key')
     }
 }
 ```
@@ -665,7 +667,7 @@ job {
         svn { // since 1.30
             location(String svnUrl) {           // at least on required
                 directory(String directory)     // defaults to '.'
-                credentials(String credentials)
+                credentials(String credentialsId)
                 depth(SvnDepth depth)           // defaults to INFINITY
             }
             checkoutStrategy(SvnCheckoutStrategy strategy)
@@ -701,8 +703,9 @@ Valid values for `depth` are `SvnDepth.INFINITY` (the default), `SvnDepth.EMPTY`
 `excludedRegions`, `includedRegions`, `excludedUsers` and `excludedCommitMessages` can be called multiple times to
 exclude or include more patterns or users.
 
-Version 2.0 or later of the Subversion Plugin is required to use the `credentials` method. The parameter can either be
-the credentials` description or its UUID.
+Version 2.0 or later of the Subversion Plugin is required to use the `credentials` method. The argument for the
+`credentialsId` method can either be the ID of the credentials or its description. Note that finding credentials by
+description has been [[deprecated|Deprecation-Policy]], see [[Migration]].
 
 ```groovy
 // checkout a project into the workspace directory
@@ -873,7 +876,7 @@ job {
         rtc {
             buildDefinition(String buildDefinition)
             buildWorkspace(String buildWorkspace)
-            connection(String buildTool, String credentials,
+            connection(String buildTool, String credentialsId,
                        String serverURI, int timeout)
         }
     }
@@ -881,6 +884,9 @@ job {
 ```
 
 Support for the [Team Concert Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Team+Concert+Plugin).
+
+The `credentialsId` argument can either be the ID of the credentials or its description. Note that finding credentials
+by description has been [[deprecated|Deprecation-Policy]], see [[Migration]].
 
 Examples:
 
@@ -1264,12 +1270,13 @@ Makes shared SSH credential available to builds.
 ```groovy
 job {
     wrappers {
-        sshAgent(String credentials)
+        sshAgent(String credentialsId)
     }
 }
 ```
 
-The credentials argument is the description field or the UUID generated from Jenkins | Manage Jenkins | Manage Credentials. The easiest way to find this value, is to navigate Jenkins | Credentials | Global credentials | (Key Name). The look at the description in parenthesis or using the UUID in the URL.
+The `credentialsId` argument can either be the ID of the credentials or its description. Note that finding credentials
+by description has been [[deprecated|Deprecation-Policy]], see [[Migration]].
 
 (Since 1.17)
 
@@ -1817,10 +1824,10 @@ job {
 job {
     wrappers {
         credentialsBinding {
-            file(String variable, String credentials)
-            string(String variable, String credentials)
-            usernamePassword(String variable, String credentials)
-            zipFile(String variable, String credentials)
+            file(String variable, String credentialsId)
+            string(String variable, String credentialsId)
+            usernamePassword(String variable, String credentialsId)
+            zipFile(String variable, String credentialsId)
         }
     }
 }
@@ -1828,6 +1835,9 @@ job {
 
 Bindings environment variables to credentials. Requires the
 [Credentials Binding Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Binding+Plugin).
+
+The `credentialsId` argument can either be the ID of the credentials or its description. Note that finding credentials
+by description has been [[deprecated|Deprecation-Policy]], see [[Migration]].
 
 ```groovy
 job {

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -30,6 +30,44 @@ job {
 }
 ```
 
+## Finding Credentials by Description
+
+Finding credentials by description has been [[deprecated|Deprecation-Policy]]. The argument passed to the `credentials`
+methods (e.g. for Git or Subversion SCM) has been used to find credentials by comparing the value to the credential's
+description and ID. Using the description can cause problems because it's not enforced that descriptions are unique. But
+it was useful because the ID was a generated UUID that could not be changed and thus was neither portable between
+Jenkins instances nor readable in scripts as a symbolic name would be. Since version 1.21, the credentials plugin
+supports to set the ID to any unique value when creating new credentials. So it's no longer necessary to use the
+description for matching.
+
+DSL prior to 1.30
+```groovy
+job {
+    scm {
+        git {
+            remote {
+                github('account/repo')
+                credentials('GitHub CI Key')
+            }
+        }
+    }
+}
+```
+
+DSL since 1.30
+```groovy
+job {
+    scm {
+        git {
+            remote {
+                github('account/repo')
+                credentials('github-ci-key')
+            }
+        }
+    }
+}
+```
+
 ## Migrating to 1.29
 
 ### Build Timeout

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
@@ -45,6 +45,11 @@ abstract class AbstractJobManagement implements JobManagement {
     }
 
     @Override
+    void logDeprecationWarning(String subject) {
+        logDeprecationWarning(subject, getSourceDetails(stackTrace))
+    }
+
+    @Override
     void logDeprecationWarning(String subject, String scriptName, int lineNumber) {
         logDeprecationWarning(subject, getSourceDetails(scriptName, lineNumber))
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
@@ -93,6 +93,11 @@ interface JobManagement {
     void logDeprecationWarning()
 
     /**
+     * Logs a deprecation warning for the calling method with the given subject.
+     */
+    void logDeprecationWarning(String subject)
+
+    /**
      * Logs a deprecation warning for the given subject and source position.
      */
     void logDeprecationWarning(String subject, String scriptName, int lineNumber)

--- a/job-dsl-core/src/test/resources/deprecation-subject.groovy
+++ b/job-dsl-core/src/test/resources/deprecation-subject.groovy
@@ -1,0 +1,3 @@
+// test script
+
+jm.testMethodWithCustomSubject()

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -207,7 +207,10 @@ public final class JenkinsJobManagement extends AbstractJobManagement {
         if (credentialsPlugin != null && !credentialsPlugin.getWrapper().getVersionNumber().isOlderThan(new VersionNumber("1.6"))) {
             for (CredentialsProvider credentialsProvider : jenkins.getExtensionList(CredentialsProvider.class)) {
                 for (StandardCredentials credentials : credentialsProvider.getCredentials(StandardCredentials.class, jenkins, SYSTEM)) {
-                    if (credentials.getDescription().equals(credentialsDescription) || credentials.getId().equals(credentialsDescription)) {
+                    if (credentials.getDescription().equals(credentialsDescription)) {
+                        logDeprecationWarning("finding credentials by description");
+                        return credentials.getId();
+                    } else if (credentials.getId().equals(credentialsDescription)) {
                         return credentials.getId();
                     }
                 }


### PR DESCRIPTION
Finding credentials by description has been deprecated. The argument passed to the `credentials` methods (e.g. for Git or Subversion SCM) has been used to find credentials by comparing the value to the credential's
description and ID. Using the description can cause problems because it's not enforced that descriptions are unique. But it was useful because the ID was a generated UUID that could not be changed and thus was neither portable between Jenkins instances nor readable in scripts as a symbolic name would be. Since version 1.21, the credentials plugin supports to set the ID to any unique value when creating new credentials. So it's no longer necessary to use the description for matching.
