### PR TITLE
Re-add ability to access jobManagement inside a ConditionalStepsContext

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -16,7 +16,7 @@ class StepContext implements Context {
     private static final List<String> VALID_CONTINUATION_CONDITIONS = ['SUCCESSFUL', 'UNSTABLE', 'COMPLETED']
 
     final List<Node> stepNodes = []
-    private final JobManagement jobManagement
+    protected final JobManagement jobManagement
 
     StepContext(JobManagement jobManagement) {
         this.jobManagement = jobManagement

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/ArbitraryCategory.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/ArbitraryCategory.groovy
@@ -4,4 +4,10 @@ class ArbitraryCategory {
     def sayHello(String who) {
         "Hi $who !"
     }
+
+    static useJobManagement(StepContext self, others) {
+        self.stepNodes << new NodeBuilder().'credentials' {
+            id(self.jobManagement.getCredentialsId(others[0]))
+        }
+    }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
@@ -2033,6 +2033,20 @@ still-another-dsl.groovy'''
         'dsl'                 | 'job { name "test" }'
     }
 
+    def 'JobManagement should be accessible from ConditionalStep when using Categories'() {
+        when:
+        use(ArbitraryCategory) {
+            context.conditionalSteps {
+                condition {
+                    status('FAILURE', 'SUCCESS')
+                }
+                useJobManagement('credentials')
+            }
+        }
+        then:
+        notThrown(MissingPropertyException)
+    }
+
     def 'environmentVariables are added'() {
         when:
         context.environmentVariables {


### PR DESCRIPTION
Since 8bfeba6, the visibility of jobManagement is private. In practice this is a good idea to limit the visibility of private contexts.

This unintentionally breaks JobDsl extension inside a conditionalStep when using either Categories or metaClass patching.  This is due to the fact that a conditionalStep no longer has access to the jobManagement field.

The solution is to make jobManagement protected which preserves the previous behavior.