### PR TITLE
Removing label option for non properties file types.

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PlotContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PlotContext.groovy
@@ -62,10 +62,10 @@ class PlotContext implements Context {
         this.logarithmic = logarithmic
     }
 
-    void propertiesFile(String fileName, @DslContext(PlotSeriesContext) Closure plotSeriesClosure = null) {
+    void propertiesFile(String fileName, @DslContext(PlotPropSeriesContext) Closure plotSeriesClosure = null) {
         checkArgument(!Strings.isNullOrEmpty(fileName), 'fileName must not be null or empty')
 
-        PlotSeriesContext plotSeriesContext = new PlotSeriesContext(fileName, 'properties', 'PropertiesSeries')
+        PlotSeriesContext plotSeriesContext = new PlotPropSeriesContext(fileName)
         ContextHelper.executeInContext(plotSeriesClosure, plotSeriesContext)
 
         dataSeriesList << plotSeriesContext

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PlotPropSeriesContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PlotPropSeriesContext.groovy
@@ -1,0 +1,13 @@
+package javaposse.jobdsl.dsl.helpers.publisher
+
+class PlotPropSeriesContext extends PlotSeriesContext {
+    String label
+
+    PlotPropSeriesContext(String fileName) {
+        super(fileName, 'properties', 'PropertiesSeries')
+    }
+
+    void label(String label) {
+        this.label = label
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PlotSeriesContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PlotSeriesContext.groovy
@@ -6,15 +6,10 @@ class PlotSeriesContext implements Context {
     final String fileName
     final String fileType
     final String seriesType
-    String label
 
     PlotSeriesContext(String fileName, String fileType, String seriesType) {
         this.fileName = fileName
         this.fileType = fileType
         this.seriesType = seriesType
-    }
-
-    void label(String label) {
-        this.label = label
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -386,8 +386,10 @@ class PublisherContext implements Context {
                             plot.dataSeriesList.each { PlotSeriesContext data ->
                                 "hudson.plugins.plot.${data.seriesType}" {
                                     file(data.fileName)
-                                    label(data.label ?: '')
                                     fileType(data.fileType)
+                                    if (data instanceof PlotPropSeriesContext) {
+                                        label(data.label ?: '')
+                                    }
                                     if (data instanceof PlotXMLSeriesContext) {
                                         xpathString(data.xpath ?: '')
                                         url(data.url ?: '')

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -3228,9 +3228,8 @@ class PublisherContextSpec extends Specification {
                 exclZero[0].value() == false
                 logarithmic[0].value() == false
                 with(series[0].'hudson.plugins.plot.XMLSeries'[0]) {
-                    children().size() == 6
+                    children().size() == 5
                     file[0].value() == 'data.prop'
-                    label[0].value() == ''
                     fileType[0].value() == 'xml'
                     nodeTypeString[0].value() == 'NODESET'
                     url[0].value() == ''
@@ -3246,7 +3245,6 @@ class PublisherContextSpec extends Specification {
         context.plotBuildData {
             plot('my group', 'some.csv') {
                 xmlFile('data.prop') {
-                    label('some label')
                     nodeType('NODE')
                     url('http://somewhere')
                     xpath('an xpath string')
@@ -3272,9 +3270,8 @@ class PublisherContextSpec extends Specification {
                 exclZero[0].value() == false
                 logarithmic[0].value() == false
                 with(series[0].'hudson.plugins.plot.XMLSeries'[0]) {
-                    children().size() == 6
+                    children().size() == 5
                     file[0].value() == 'data.prop'
-                    label[0].value() == 'some label'
                     fileType[0].value() == 'xml'
                     nodeTypeString[0].value() == 'NODE'
                     url[0].value() == 'http://somewhere'


### PR DESCRIPTION
Noticed this when you did the cleanup and removed the label option from XML series in the docs.

The label option is only for properties files so I've fixed the code to do so.