### PR TITLE
[JENKINS-26423] Support Categorized Job View plugin

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -17,6 +17,7 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
 
 ## Release Notes
 * 1.31 (unreleased)
+ * Added support for [Categorized Jobs View](https://wiki.jenkins-ci.org/display/JENKINS/Categorized+Jobs+View)
  * Added support for [Build Node Column Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin)
  * Added support for [Pre-SCM Build Step Plugin](https://wiki.jenkins-ci.org/display/JENKINS/pre-scm-buildstep)
  * Added support for [Sonar Plugin](http://docs.sonarqube.org/display/SONAR/Jenkins+Plugin)

--- a/docs/Job-DSL-Commands.md
+++ b/docs/Job-DSL-Commands.md
@@ -87,6 +87,8 @@ deliveryPipelineView(String name, Closure closure = null) // since 1.30
 buildPipelineView(String name, Closure closure = null)    // since 1.30
 
 buildMonitorView(String name, Closure closure = null)     // since 1.30
+
+categorizedJobsView(String name, Closure closure = null)     // since 1.31
 ```
 
 The view methods behaves like the [job](#job) methods and will return a view object.

--- a/docs/View-Reference.md
+++ b/docs/View-Reference.md
@@ -201,6 +201,7 @@ nestedView(String name) { // since 1.30
         deliveryPipelineView(String name, Closure closure = null) // since 1.30
         buildPipelineView(String name, Closure closure = null)    // since 1.30
         buildMonitorView(String name, Closure closure = null)     // since 1.30
+        categorizedJobsView(String name, Closure closure = null)  // since 1.31
         view(Map<String, Object> arguments = [:], String name, Closure viewClosure) // since 1.30, deprecated since 1.31
         view(Map<String, Object> arguments = [:], Closure viewClosure) // deprecated since 1.30
     }
@@ -318,6 +319,53 @@ buildMonitorView('project-A') {
     jobs {
         name('release-projectA')
         regex('project-A-.+')
+    }
+}
+```
+
+## Categorized Jobs View
+
+```groovy
+categorizedJobsView(String name) {  // since 1.31
+    // common options
+    description(String description)
+    filterBuildQueue(boolean filterBuildQueue = true)
+    filterExecutors(boolean filterExecutors = true)
+    configure(Closure configureBlock)
+
+    // list view options
+    // ... (all of them)
+    
+    // categorized jobs view options
+    categorizationCriteria {
+        groupingRule {
+            groupRegex(String groupRegex)
+            namingRule(String namingRule)
+        }
+        // short alias for groupingRule
+        byRegexWithNaming(String groupRegex, String namingRule)
+    }
+}
+```
+
+Creates a new view that is very similar to the standard Jenkins List Views, but where you can group jobs and 
+categorize them according to regular expressions.
+Requires the [Categorized Jobs View](https://wiki.jenkins-ci.org/display/JENKINS/Categorized+Jobs+View).
+
+```groovy
+categorizedJobsView("Configuration") {
+    jobs {
+        regex("configuration_.*")
+    }
+
+    categorizationCriteria {
+        byRegexWithNaming('^configuration_([^_]+).*$', '$1')
+    }
+
+    columns {
+        status()
+        name()
+        buildButton()
     }
 }
 ```
@@ -904,3 +952,26 @@ See [Status Filter](#status-filter) in the [List View Options](#list-view-option
 ### Jobs
 
 See [Jobs](#jobs) in the [List View Options](#list-view-options) above.
+
+
+## Categorized Jobs View Options
+
+### Categorization criteria
+
+Contains list of grouping rules in full or short form
+```groovy
+categorizationCriteria {
+      groupingRule {
+          groupRegex('^configuration_([^_]+).*$')
+          namingRule('$1')
+      }
+      // short alias for groupingRule (same effect)
+      byRegexWithNaming('^configuration_([^_]+).*$', '$1')
+    }
+```
+### Grouping rule (alias *byRegexWithNaming*)
+
+Adds a rule to categorize your jobs. Contains parameters: 
+- `groupRegex` - rule on how to group jobs (can use regex groups e.g. `some_(.*)_end`)
+- `namingRule` - how to name grouped jobs section (can use groups from `groupRegex` field, e.g. `$1`)
+

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
@@ -11,6 +11,7 @@ import javaposse.jobdsl.dsl.jobs.MultiJob
 import javaposse.jobdsl.dsl.jobs.WorkflowJob
 import javaposse.jobdsl.dsl.views.BuildMonitorView
 import javaposse.jobdsl.dsl.views.BuildPipelineView
+import javaposse.jobdsl.dsl.views.CategorizedJobsView
 import javaposse.jobdsl.dsl.views.DeliveryPipelineView
 import javaposse.jobdsl.dsl.views.ListView
 import javaposse.jobdsl.dsl.views.NestedView
@@ -122,6 +123,12 @@ abstract class JobParent extends Script implements DslFactory {
     @RequiresPlugin(id = 'build-monitor-plugin')
     BuildMonitorView buildMonitorView(String name, @DslContext(BuildMonitorView) Closure closure = null) {
         processView(name, BuildMonitorView, closure)
+    }
+
+    @Override
+    @RequiresPlugin(id = 'categorized-view')
+    CategorizedJobsView categorizedJobsView(String name, @DslContext(CategorizedJobsView) Closure closure = null) {
+        processView(name, CategorizedJobsView, closure)
     }
 
     // this method cannot be private due to http://jira.codehaus.org/browse/GROOVY-6263

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ViewFactory.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ViewFactory.groovy
@@ -2,6 +2,7 @@ package javaposse.jobdsl.dsl
 
 import javaposse.jobdsl.dsl.views.BuildMonitorView
 import javaposse.jobdsl.dsl.views.BuildPipelineView
+import javaposse.jobdsl.dsl.views.CategorizedJobsView
 import javaposse.jobdsl.dsl.views.DeliveryPipelineView
 import javaposse.jobdsl.dsl.views.ListView
 import javaposse.jobdsl.dsl.views.NestedView
@@ -37,4 +38,8 @@ interface ViewFactory {
     BuildMonitorView buildMonitorView(String name)
 
     BuildMonitorView buildMonitorView(String name, @DslContext(BuildMonitorView) Closure closure)
+
+    CategorizedJobsView categorizedJobsView(String name)
+
+    CategorizedJobsView categorizedJobsView(String name, @DslContext(CategorizedJobsView) Closure closure)
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/CategorizationCriteriaContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/CategorizationCriteriaContext.groovy
@@ -1,0 +1,37 @@
+package javaposse.jobdsl.dsl.views
+
+import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.DslContext
+import javaposse.jobdsl.dsl.JobManagement
+
+import static javaposse.jobdsl.dsl.ContextHelper.executeInContext
+
+/**
+ * For {@link javaposse.jobdsl.dsl.views.CategorizedJobsView}
+ * uses {@link javaposse.jobdsl.dsl.views.GroupingRuleContext}
+ */
+class CategorizationCriteriaContext implements Context {
+    private final JobManagement jobManagement
+    List<Node> groupingRules = []
+
+    CategorizationCriteriaContext(JobManagement jobManagement) {
+        this.jobManagement = jobManagement
+    }
+
+    void groupingRule(@DslContext(GroupingRuleContext) Closure groupingRuleClosure) {
+        GroupingRuleContext context = new GroupingRuleContext(jobManagement)
+        executeInContext(groupingRuleClosure, context)
+
+        groupingRules << new NodeBuilder().'org.jenkinsci.plugins.categorizedview.GroupingRule' {
+            groupRegex(context.groupRegex)
+            namingRule(context.namingRule)
+        }
+    }
+
+    void byRegexWithNaming(String groupRegex, String namingRule) {
+        groupingRule {
+            delegate.groupRegex(groupRegex)
+            delegate.namingRule(namingRule)
+        }
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/CategorizedJobsView.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/CategorizedJobsView.groovy
@@ -1,0 +1,56 @@
+package javaposse.jobdsl.dsl.views
+
+import javaposse.jobdsl.dsl.DslContext
+import javaposse.jobdsl.dsl.JobManagement
+
+import static javaposse.jobdsl.dsl.ContextHelper.executeInContext
+
+/**
+ * [Categorized Jobs View](https://wiki.jenkins-ci.org/display/JENKINS/Categorized+Jobs+View)
+ *
+ * Usage example:
+ *
+ * <pre>
+ *    categorizedJobsView("Configuration") {
+ *          // same as in listView
+ *          jobs {
+ *              regex("configuration_.*")
+ *          }
+ *
+ *          categorizationCriteria {
+ *              groupingRule {
+ *                  groupRegex("regex")
+ *                  namingRule("naming")
+ *              }
+ *              // short alias
+ *              byRegexWithNaming('^configuration_([^_]+).*$', '$1')
+ *          }
+ *
+ *          // same as in listView
+ *          columns {
+ *              status()
+ *              name()
+ *              buildButton()
+ *          }
+ *   }
+ *
+ * </pre>
+ *
+ * @since 1.31
+ */
+class CategorizedJobsView extends ListView {
+    CategorizedJobsView(JobManagement jobManagement) {
+        super(jobManagement)
+    }
+
+    void categorizationCriteria(@DslContext(CategorizationCriteriaContext) Closure categorizationCriteriaClosure) {
+        CategorizationCriteriaContext context = new CategorizationCriteriaContext(jobManagement)
+        executeInContext(categorizationCriteriaClosure, context)
+
+        execute {
+            context.groupingRules.each { groupingRule ->
+                it / 'categorizationCriteria' << groupingRule
+            }
+        }
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/GroupingRuleContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/GroupingRuleContext.groovy
@@ -1,0 +1,25 @@
+package javaposse.jobdsl.dsl.views
+
+import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.JobManagement
+
+/**
+ * For {@link javaposse.jobdsl.dsl.views.CategorizationCriteriaContext}
+ */
+class GroupingRuleContext implements Context {
+    private final JobManagement jobManagement
+    String groupRegex
+    String namingRule
+
+    GroupingRuleContext(JobManagement jobManagement) {
+        this.jobManagement = jobManagement
+    }
+
+    void groupRegex(String groupRegex) {
+        this.groupRegex = groupRegex
+    }
+
+    void namingRule(String namingRule) {
+        this.namingRule = namingRule
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/NestedViewsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/NestedViewsContext.groovy
@@ -72,6 +72,11 @@ class NestedViewsContext implements Context, ViewFactory {
         processView(name, BuildMonitorView, closure)
     }
 
+    @Override
+    CategorizedJobsView categorizedJobsView(String name, @DslContext(CategorizedJobsView) Closure closure = null) {
+        processView(name, CategorizedJobsView, closure)
+    }
+
     private <T extends View> T processView(String name, Class<T> viewClass, Closure closure) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(name), 'name must be specified')
 

--- a/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/views/CategorizedJobsView-template.xml
+++ b/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/views/CategorizedJobsView-template.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<org.jenkinsci.plugins.categorizedview.CategorizedJobsView plugin="categorized-view">
+    <filterExecutors>false</filterExecutors>
+    <filterQueue>false</filterQueue>
+    <properties class="hudson.model.View$PropertyList"/>
+    <jobNames>
+        <comparator class="hudson.util.CaseInsensitiveComparator"/>
+    </jobNames>
+    <jobFilters/>
+    <columns/>
+    <groupingRules/>
+    <categorizationCriteria/>
+</org.jenkinsci.plugins.categorizedview.CategorizedJobsView>

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobParentSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobParentSpec.groovy
@@ -8,6 +8,7 @@ import javaposse.jobdsl.dsl.jobs.MultiJob
 import javaposse.jobdsl.dsl.jobs.WorkflowJob
 import javaposse.jobdsl.dsl.views.BuildMonitorView
 import javaposse.jobdsl.dsl.views.BuildPipelineView
+import javaposse.jobdsl.dsl.views.CategorizedJobsView
 import javaposse.jobdsl.dsl.views.DeliveryPipelineView
 import javaposse.jobdsl.dsl.views.ListView
 import javaposse.jobdsl.dsl.views.NestedView
@@ -259,6 +260,31 @@ class JobParentSpec extends Specification {
         view instanceof DeliveryPipelineView
         parent.referencedViews.contains(view)
         _ * jobManagement.requirePlugin('delivery-pipeline-plugin')
+    }
+
+    def 'should add categorized jobs view'() {
+        when:
+        View view = parent.categorizedJobsView('test') {
+            description('foo')
+        }
+
+        then:
+        view.name == 'test'
+        view instanceof CategorizedJobsView
+        parent.referencedViews.contains(view)
+        view.node.description[0].text() == 'foo'
+        _ * jobManagement.requirePlugin('categorized-view')
+    }
+
+    def 'should add categorized jobs view without closure'() {
+        when:
+        View view = parent.categorizedJobsView('test')
+
+        then:
+        view.name == 'test'
+        view instanceof CategorizedJobsView
+        parent.referencedViews.contains(view)
+        _ * jobManagement.requirePlugin('categorized-view')
     }
 
     def 'folder deprecated variant'() {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/CategorizedJobsViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/CategorizedJobsViewSpec.groovy
@@ -1,0 +1,100 @@
+package javaposse.jobdsl.dsl.views
+
+class CategorizedJobsViewSpec extends ListViewSpec {
+
+    public static final String GROUPING_RULE_NODE_NAME = 'org.jenkinsci.plugins.categorizedview.GroupingRule'
+
+    def setup() {
+        view = new CategorizedJobsView(jobManagement)
+    }
+
+    protected String getDefaultXml() {
+        '''<?xml version='1.0' encoding='UTF-8'?>
+<org.jenkinsci.plugins.categorizedview.CategorizedJobsView plugin="categorized-view">
+    <filterExecutors>false</filterExecutors>
+    <filterQueue>false</filterQueue>
+    <properties class="hudson.model.View$PropertyList"/>
+    <jobNames>
+        <comparator class="hudson.util.CaseInsensitiveComparator"/>
+    </jobNames>
+    <jobFilters/>
+    <columns/>
+    <groupingRules/>
+    <categorizationCriteria/>
+</org.jenkinsci.plugins.categorizedview.CategorizedJobsView>'''
+    }
+
+    def 'should do nothing on empty categorization criteria'() {
+        when:
+        ((CategorizedJobsView) view).categorizationCriteria { }
+
+        then:
+        view.node.categorizationCriteria.size() == 1
+        view.node.categorizationCriteria.get(0).value().size() == 0
+    }
+
+    def 'should add group by full closure'() {
+        when:
+        ((CategorizedJobsView) view).categorizationCriteria {
+            groupingRule {
+                groupRegex('regex')
+                namingRule('naming')
+            }
+        }
+
+        and:
+        def node = view.node.categorizationCriteria.get(0)
+
+        then:
+        node.value().size() == 1
+        node.value().get(0).name() == GROUPING_RULE_NODE_NAME
+        node.value().get(0).value().size() == 2
+    }
+
+    def 'should add group by regex with naming'() {
+        when:
+        ((CategorizedJobsView) view).categorizationCriteria {
+            byRegexWithNaming('regex', 'naming')
+        }
+
+        and:
+        def node = view.node.categorizationCriteria.get(0)
+
+        then:
+        node.value().size() == 1
+        node.value().get(0).name() == GROUPING_RULE_NODE_NAME
+    }
+
+    def 'should use groupRegex and namingRule names for alias'() {
+        given:
+        def rule = new CategorizationCriteriaContext(jobManagement)
+
+        when:
+        rule.byRegexWithNaming('regex', 'naming')
+
+        and:
+        def content = rule.groupingRules.get(0).value()
+
+        then:
+        content.size() == 2
+        content.get(0).name() == 'groupRegex'
+        content.get(0).value() == 'regex'
+        content.get(1).name() == 'namingRule'
+        content.get(1).value() == 'naming'
+
+    }
+
+    def 'should add more than one group'() {
+        when:
+        ((CategorizedJobsView) view).categorizationCriteria {
+            byRegexWithNaming('regex', 'naming')
+            byRegexWithNaming('regex', 'naming')
+        }
+
+        and:
+        def node = view.node.categorizationCriteria.get(0)
+
+        then:
+        node.value().size() == 2
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/NestedViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/NestedViewSpec.groovy
@@ -221,6 +221,35 @@ class NestedViewSpec extends Specification {
         view.node.views[0].children()[0].name() == 'hudson.plugins.nested__view.NestedView'
     }
 
+    def 'should add categorized jobs view'() {
+        when:
+        View categorizedView
+        view.views {
+            categorizedView = delegate.categorizedJobsView('test') {
+                description('foo')
+            }
+        }
+
+        then:
+        categorizedView.name == 'test'
+        categorizedView instanceof CategorizedJobsView
+        view.node.views[0].children()[0].name() == 'org.jenkinsci.plugins.categorizedview.CategorizedJobsView'
+        view.node.views[0].children()[0].description[0].text() == 'foo'
+    }
+
+    def 'should add categorized jobs view without closure'() {
+        when:
+        View categorizedView
+        view.views {
+            categorizedView = delegate.categorizedJobsView('test')
+        }
+
+        then:
+        categorizedView.name == 'test'
+        categorizedView instanceof CategorizedJobsView
+        view.node.views[0].children()[0].name() == 'org.jenkinsci.plugins.categorizedview.CategorizedJobsView'
+    }
+
     def 'nested delivery pipeline view'() {
         when:
         View nestedView


### PR DESCRIPTION
## Categorized Jobs View
Closes [JENKINS-26423](https://issues.jenkins-ci.org/browse/JENKINS-26423)
```groovy
categorizedJobsView(String name) {  
    // list view options
    // ... (all of them)
    
    // categorized jobs view options
    categorizationCriteria {
        groupingRule {
            groupRegex(String groupRegex)
            namingRule(String namingRule)
        }
        // short alias for groupingRule
        byRegexWithNaming(String groupRegex, String namingRule)
    }
}
```

Creates a new view that is very similar to the standard Jenkins List Views, but where you can group jobs and categorize them according to regular expressions. Requires the [Categorized Jobs View](https://wiki.jenkins-ci.org/display/JENKINS/Categorized+Jobs+View).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/job-dsl-plugin/435)
<!-- Reviewable:end -->
