### PR TITLE
[JENKINS-16365] Added pre-set permissions

### DIFF
--- a/config/codenarc/rules.groovy
+++ b/config/codenarc/rules.groovy
@@ -16,6 +16,8 @@ ruleset {
         // we don't care
         exclude 'BuilderMethodWithSideEffects'
         // we don't care
+        exclude 'EmptyMethodInAbstractClass'
+        // we don't care
         exclude 'Instanceof'
     }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
@@ -4,37 +4,13 @@ import static java.lang.Thread.currentThread
 import static org.codehaus.groovy.runtime.StackTraceUtils.isApplicationClass
 
 /**
- * Abstract version of JobManagement to minimize impact on future API changes.
+ * Abstract base class providing common functionality for all {@link JobManagement} implementations.
  */
 abstract class AbstractJobManagement implements JobManagement {
     final PrintStream outputStream
 
     protected AbstractJobManagement(PrintStream out) {
         this.outputStream = out
-    }
-
-    protected AbstractJobManagement() {
-        this(System.out)
-    }
-
-    @Override
-    void queueJob(String jobName) throws NameNotProvidedException {
-        validateNameArg(jobName)
-    }
-
-    @Override
-    InputStream streamFileInWorkspace(String filePath) throws IOException {
-        throw new UnsupportedOperationException()
-    }
-
-    @Override
-    String readFileInWorkspace(String filePath) throws IOException {
-        throw new UnsupportedOperationException()
-    }
-
-    @Override
-    String readFileInWorkspace(String jobName, String filePath) throws IOException {
-        throw new UnsupportedOperationException()
     }
 
     @Override

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
@@ -1,8 +1,6 @@
 package javaposse.jobdsl.dsl
 
-import hudson.util.VersionNumber
-
-class FileJobManagement extends AbstractJobManagement {
+class FileJobManagement extends MockJobManagement {
     /**
      * Root of where to look for job config files
      */
@@ -12,12 +10,6 @@ class FileJobManagement extends AbstractJobManagement {
      * Extension to append to job name when looking at the filesystem
      */
     String ext = '.xml'
-
-    /**
-     * map to store job parameters from System properties and
-     * Environment variables.
-     */
-    final Map<String, String> parameters = [:]
 
     FileJobManagement(File root) {
         this.root = root
@@ -56,15 +48,6 @@ class FileJobManagement extends AbstractJobManagement {
         new File(viewName + ext).write(config)
     }
 
-    @Override
-    String createOrUpdateConfigFile(ConfigFile configFile, boolean ignoreExisting) {
-        throw new UnsupportedOperationException()
-    }
-
-    @Override
-    void renameJobMatching(String previousNames, String destination) throws IOException {
-    }
-
     InputStream streamFileInWorkspace(String filePath) {
         new FileInputStream(new File(root, filePath))
     }
@@ -72,38 +55,5 @@ class FileJobManagement extends AbstractJobManagement {
     @Override
     String readFileInWorkspace(String filePath) {
         new File(root, filePath).text
-    }
-
-    @Override
-    void requirePlugin(String pluginShortName) {
-    }
-
-    @Override
-    void requireMinimumPluginVersion(String pluginShortName, String version) {
-    }
-
-    @Override
-    String getCredentialsId(String credentialsDescription) {
-        null
-    }
-
-    @Override
-    VersionNumber getPluginVersion(String pluginShortName) {
-        null
-    }
-
-    @Override
-    Integer getVSphereCloudHash(String name) {
-        null
-    }
-
-    @Override
-    String getConfigFileId(ConfigFileType type, String name) {
-        null
-    }
-
-    @Override
-    Set<String> getPermissions(String authorizationMatrixPropertyClassName) {
-        []
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
@@ -79,7 +79,7 @@ interface JobManagement {
     PrintStream getOutputStream()
 
     /**
-     * Map if variables that should be available to the script.
+     * Map of variables that should be available to the script.
      */
     Map<String, String> getParameters()
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/MemoryJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/MemoryJobManagement.groovy
@@ -1,19 +1,17 @@
 package javaposse.jobdsl.dsl
 
-import hudson.util.VersionNumber
 import org.apache.commons.codec.digest.DigestUtils
 
 /**
  * In-memory JobManagement for testing.
  */
-class MemoryJobManagement extends AbstractJobManagement {
+class MemoryJobManagement extends MockJobManagement {
     final Map<String, String> availableConfigs = [:]
     final Map<String, String> savedConfigs = [:]
     final Map<String, String> savedViews = [:]
     final Set<ConfigFile> savedConfigFiles = []
     final Map<String, String> availableFiles = [:]
 
-    final Map<String, String> parameters = [:]
     final List<String> scheduledJobs = []
 
     MemoryJobManagement() {
@@ -55,10 +53,6 @@ class MemoryJobManagement extends AbstractJobManagement {
     }
 
     @Override
-    void renameJobMatching(String previousNames, String destination) throws IOException {
-    }
-
-    @Override
     void queueJob(String jobName) throws NameNotProvidedException {
         scheduledJobs << jobName
     }
@@ -78,37 +72,9 @@ class MemoryJobManagement extends AbstractJobManagement {
     }
 
     @Override
-    void requirePlugin(String pluginShortName) {
-    }
-
-    @Override
-    void requireMinimumPluginVersion(String pluginShortName, String version) {
-    }
-
-    @Override
-    String getCredentialsId(String credentialsDescription) {
-        null
-    }
-
-    @Override
-    VersionNumber getPluginVersion(String pluginShortName) {
-        null
-    }
-
-    @Override
-    Integer getVSphereCloudHash(String name) {
-        null
-    }
-
-    @Override
     String getConfigFileId(ConfigFileType type, String name) {
         ConfigFile configFile = savedConfigFiles.find { it.type == type && it.name == name }
         configFile == null ? null : createConfigFileId(configFile)
-    }
-
-    @Override
-    Set<String> getPermissions(String authorizationMatrixPropertyClassName) {
-        []
     }
 
     private static String createConfigFileId(ConfigFile configFile) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/MockJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/MockJobManagement.groovy
@@ -7,6 +7,22 @@ import hudson.util.VersionNumber
  */
 abstract class MockJobManagement extends AbstractJobManagement {
     final Map<String, String> parameters = [:]
+    final Map<String, List<String>> permissions = [
+            'hudson.security.AuthorizationMatrixProperty': [
+                    'hudson.model.Item.Delete',
+                    'hudson.model.Item.Configure',
+                    'hudson.model.Item.Read',
+                    'hudson.model.Item.Discover',
+                    'hudson.model.Item.Build',
+                    'hudson.model.Item.Workspace',
+                    'hudson.model.Item.Cancel',
+                    'hudson.model.Item.Release',
+                    'hudson.model.Item.ExtendedRead',
+                    'hudson.model.Run.Delete',
+                    'hudson.model.Run.Update',
+                    'hudson.scm.SCM.Tag'
+            ]
+    ]
 
     protected MockJobManagement() {
         super(System.out)
@@ -65,6 +81,6 @@ abstract class MockJobManagement extends AbstractJobManagement {
 
     @Override
     Set<String> getPermissions(String authorizationMatrixPropertyClassName) {
-        []
+        permissions[authorizationMatrixPropertyClassName]
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/MockJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/MockJobManagement.groovy
@@ -1,0 +1,70 @@
+package javaposse.jobdsl.dsl
+
+import hudson.util.VersionNumber
+
+/**
+ * Abstract base class for all non-Jenkins implementations of {@link JobManagement}.
+ */
+abstract class MockJobManagement extends AbstractJobManagement {
+    final Map<String, String> parameters = [:]
+
+    protected MockJobManagement() {
+        super(System.out)
+    }
+
+    protected MockJobManagement(PrintStream out) {
+        super(out)
+    }
+
+    @Override
+    String createOrUpdateConfigFile(ConfigFile configFile, boolean ignoreExisting) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    void renameJobMatching(String previousNames, String destination) throws IOException {
+    }
+
+    @Override
+    void queueJob(String jobName) throws NameNotProvidedException {
+        validateNameArg(jobName)
+    }
+
+    @Override
+    String readFileInWorkspace(String jobName, String filePath) throws IOException {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    void requirePlugin(String pluginShortName) {
+    }
+
+    @Override
+    void requireMinimumPluginVersion(String pluginShortName, String version) {
+    }
+
+    @Override
+    String getCredentialsId(String credentialsDescription) {
+        null
+    }
+
+    @Override
+    VersionNumber getPluginVersion(String pluginShortName) {
+        null
+    }
+
+    @Override
+    Integer getVSphereCloudHash(String name) {
+        null
+    }
+
+    @Override
+    String getConfigFileId(ConfigFileType type, String name) {
+        null
+    }
+
+    @Override
+    Set<String> getPermissions(String authorizationMatrixPropertyClassName) {
+        []
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
@@ -1,6 +1,5 @@
 package javaposse.jobdsl.dsl
 
-import hudson.util.VersionNumber
 import spock.lang.Specification
 
 import static org.codehaus.groovy.runtime.InvokerHelper.createScript
@@ -92,41 +91,13 @@ class AbstractJobManagementSpec extends Specification {
         buffer.toString().trim() == 'Warning: foo is deprecated (test.groovy, line 12)'
     }
 
-    def 'reading files from workspace is not supported'() {
-        setup:
-        AbstractJobManagement jobManagement = new TestJobManagement()
-
-        when:
-        jobManagement.readFileInWorkspace('test.txt')
-
-        then:
-        thrown(UnsupportedOperationException)
-
-        when:
-        jobManagement.streamFileInWorkspace('test.txt')
-
-        then:
-        thrown(UnsupportedOperationException)
-
-        when:
-        jobManagement.readFileInWorkspace('my-job', 'test.txt')
-
-        then:
-        thrown(UnsupportedOperationException)
-    }
-
-    static class TestJobManagement extends AbstractJobManagement {
+    static class TestJobManagement extends MockJobManagement {
         TestJobManagement() {
             super()
         }
 
         TestJobManagement(PrintStream out) {
             super(out)
-        }
-
-        @Override
-        Map<String, String> getParameters() {
-            throw new UnsupportedOperationException()
         }
 
         @Override
@@ -145,48 +116,13 @@ class AbstractJobManagementSpec extends Specification {
         }
 
         @Override
-        String createOrUpdateConfigFile(ConfigFile configFile, boolean ignoreExisting) {
+        InputStream streamFileInWorkspace(String filePath) throws IOException {
             throw new UnsupportedOperationException()
         }
 
         @Override
-        void renameJobMatching(String previousNames, String destination) throws IOException {
+        String readFileInWorkspace(String filePath) throws IOException {
             throw new UnsupportedOperationException()
-        }
-
-        @Override
-        void requirePlugin(String pluginShortName) {
-            throw new UnsupportedOperationException()
-        }
-
-        @Override
-        void requireMinimumPluginVersion(String pluginShortName, String version) {
-            throw new UnsupportedOperationException()
-        }
-
-        @Override
-        String getCredentialsId(String credentialsDescription) {
-            null
-        }
-
-        @Override
-        VersionNumber getPluginVersion(String pluginShortName) {
-            null
-        }
-
-        @Override
-        Integer getVSphereCloudHash(String name) {
-            null
-        }
-
-        @Override
-        String getConfigFileId(ConfigFileType type, String name) {
-            null
-        }
-
-        @Override
-        Set<String> getPermissions(String authorizationMatrixPropertyClassName) {
-            []
         }
 
         void testMethod() {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/MockJobManagementSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/MockJobManagementSpec.groovy
@@ -1,0 +1,40 @@
+package javaposse.jobdsl.dsl
+
+import spock.lang.Specification
+
+import static org.codehaus.groovy.runtime.InvokerHelper.createScript
+
+class MockJobManagementSpec extends Specification {
+    MockJobManagement mockJobManagement = Spy(MockJobManagement)
+
+    def 'job permissions are pre-set'() {
+        when:
+        Set<String> permissions = mockJobManagement.getPermissions('hudson.security.AuthorizationMatrixProperty')
+
+        then:
+        permissions.size() == 12
+        'hudson.model.Item.Delete' in permissions
+        'hudson.model.Item.Configure' in permissions
+        'hudson.model.Item.Read' in permissions
+        'hudson.model.Item.Discover' in permissions
+        'hudson.model.Item.Build' in permissions
+        'hudson.model.Item.Workspace' in permissions
+        'hudson.model.Item.Cancel' in permissions
+        'hudson.model.Item.Release' in permissions
+        'hudson.model.Item.ExtendedRead' in permissions
+        'hudson.model.Run.Delete' in permissions
+        'hudson.model.Run.Update' in permissions
+        'hudson.scm.SCM.Tag' in permissions
+    }
+
+    def 'queueJob validates name argument'() {
+        when:
+        mockJobManagement.queueJob(name)
+
+        then:
+        thrown(NameNotProvidedException)
+
+        where:
+        name << ['', null]
+    }
+}


### PR DESCRIPTION
Added pre-set permissions to FileJobManagement and MemoryJobManagement to be able to use the permissions DSL outside of Jenkins. That's a follow-up of JENKINS-16365. Also did some refactoring to introduce a base class for all non-Jenkins JobManagement implementations.