### PR TITLE
JENKINS-28048 Injection of variables and classloader customisation

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -31,7 +31,14 @@ public class DslScriptLoader {
     private static final Comparator<? super Item> ITEM_COMPARATOR = new ItemProcessingOrderComparator();
 
     public static JobParent runDslEngineForParent(ScriptRequest scriptRequest, JobManagement jobManagement) throws IOException {
-        ClassLoader parentClassLoader = DslScriptLoader.class.getClassLoader();
+        return runDslEngineForParent(scriptRequest, jobManagement, getDefaultClassLoader());
+    }
+
+    public static ClassLoader getDefaultClassLoader() {
+        return DslScriptLoader.class.getClassLoader();
+    }
+
+    public static JobParent runDslEngineForParent(ScriptRequest scriptRequest, JobManagement jobManagement, ClassLoader parentClassLoader) throws IOException {
         CompilerConfiguration config = createCompilerConfiguration(jobManagement);
 
         // Otherwise baseScript won't take effect
@@ -97,7 +104,11 @@ public class DslScriptLoader {
     }
 
     public static GeneratedItems runDslEngine(ScriptRequest scriptRequest, JobManagement jobManagement) throws IOException {
-        JobParent jp = runDslEngineForParent(scriptRequest, jobManagement);
+        return runDslEngine(scriptRequest, jobManagement, getDefaultClassLoader());
+    }
+
+    public static GeneratedItems runDslEngine(ScriptRequest scriptRequest, JobManagement jobManagement, ClassLoader parentClassLoader) throws IOException {
+        JobParent jp = runDslEngineForParent(scriptRequest, jobManagement, parentClassLoader);
         LOGGER.log(Level.FINE, String.format("Ran script and got back %s", jp));
 
         GeneratedItems generatedItems = new GeneratedItems();

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -51,6 +51,14 @@ public class DslScriptLoader {
 
         Binding binding = createBinding(jobManagement);
 
+        // Additional variables
+        Map<String, Object> variables = scriptRequest.getVariables();
+        if (variables != null) {
+            for (Map.Entry<String, Object> v : variables.entrySet()) {
+                binding.setVariable(v.getKey(), v.getValue());
+            }
+        }
+
         JobParent jp;
         try {
             Script script;

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ScriptRequest.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ScriptRequest.groovy
@@ -13,22 +13,30 @@ class ScriptRequest {
     // Ignore existing jobs
     final boolean ignoreExisting
 
+    // List of variables to inject in the script
+    final Map<String, Object> variables
+
     ScriptRequest(String location, String body, URL urlRoot) {
         this(location, body, [urlRoot] as URL[])
     }
 
     ScriptRequest(String location, String body, URL[] urlRoots) {
-        this(location, body, urlRoots, false)
+        this(location, body, urlRoots, false, [:])
     }
 
     ScriptRequest(String location, String body, URL urlRoot, boolean ignoreExisting) {
-        this(location, body, [urlRoot] as URL[], ignoreExisting)
+        this(location, body, [urlRoot] as URL[], ignoreExisting, [:])
     }
 
     ScriptRequest(String location, String body, URL[] urlRoots, boolean ignoreExisting) {
+        this(location, body, urlRoots, ignoreExisting, [:])
+    }
+
+    ScriptRequest(String location, String body, URL[] urlRoots, boolean ignoreExisting, Map<String, Object> variables) {
         this.location = location
         this.body = body
         this.urlRoots = urlRoots
         this.ignoreExisting = ignoreExisting
+        this.variables = variables
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslScriptLoaderSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslScriptLoaderSpec.groovy
@@ -3,6 +3,7 @@ package javaposse.jobdsl.dsl
 import com.google.common.collect.Iterables
 import javaposse.jobdsl.dsl.jobs.FreeStyleJob
 import spock.lang.Ignore
+import spock.lang.Issue
 import spock.lang.Specification
 
 class DslScriptLoaderSpec extends Specification {
@@ -317,5 +318,29 @@ folder {
 
         then:
         thrown UnsupportedOperationException
+    }
+
+    @Issue('JENKINS-28048')
+    def 'using variables in the script'() {
+        setup:
+        String script = '''counter.inc()'''
+        Counter counter = new Counter()
+        ScriptRequest request = new ScriptRequest(null, script, [resourcesDir] as URL[], false, ['counter': counter])
+
+        when:
+        DslScriptLoader.runDslEngine request, jm
+
+        then:
+        counter.value == 1
+    }
+
+    static class Counter {
+        private int count = 0
+        int inc() {
+            count++
+        }
+        int getValue() {
+            count
+        }
     }
 }


### PR DESCRIPTION
This pull request allows:

* to inject arbitrary variables in a DSL script
* to customise the class loader

Both features are useful when calling the `DslScriptLoader.runDslEngine` from within another plug-in.

It happens though that when calling the DSL from another plug-in, I still face the following error:

```
java.lang.VerifyError: (class: script1429801171807415604089, method: super$3$evaluate signature: (Ljava/lang/String;)Ljava/lang/Object;) Illegal use of nonvirtual function call
    	at java.lang.Class.getDeclaredConstructors0(Native Method)
    	at java.lang.Class.privateGetDeclaredConstructors(Class.java:2671)
    	at java.lang.Class.getConstructor0(Class.java:3075)
    	at java.lang.Class.newInstance(Class.java:412)
    	at org.codehaus.groovy.runtime.InvokerHelper.createScript(InvokerHelper.java:408)
    	at javaposse.jobdsl.dsl.DslScriptLoader.runDslEngineForParent(DslScriptLoader.java:75)
    	at javaposse.jobdsl.dsl.DslScriptLoader.runDslEngine(DslScriptLoader.java:111)
```

And I'm still doing some investigation around this. I've already tested in both JDK7 and JDK8 without any improvement.