### PR TITLE
Support configFiles file type argument

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -28,6 +28,7 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
    ([JENKINS-27838](https://issues.jenkins-ci.org/browse/JENKINS-27838), [JENKINS-27894](https://issues.jenkins-ci.org/browse/JENKINS-27894))
  * Enhanced support for the [GitHub Pull Request Builder Plugin](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin)
    ([JENKINS-27932](https://issues.jenkins-ci.org/browse/JENKINS-27932))
+ * Enhanced support for the [Config File Provider Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin)
  * Support for the older versions of the [Copy Artifact Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Copy+Artifact+Plugin) is deprecated, see [[Migration]]
  * Variants of `copyArtifacts` with more than two parameters have been replaced and are deprecated, see [[Migration]]
  * Added support for "Don't trigger a build on commit notifications" for the [Git Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin)

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -1923,6 +1923,7 @@ job {
                 targetLocation(String targetLocation) // optional
                 variable(String variable)             // optional
             }
+            file(String fileName, ConfigFileType type, Closure closure) // since 1.33
         }
     }
 }
@@ -1931,12 +1932,19 @@ job {
 Makes an existing custom config file available to builds. Requires
 the [Config File Provider Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin).
 
+Possible values for `type` are `ConfigFileType.Custom` and `ConfigFileType.MavenSettings`. If not specified type is `ConfigFileType.Custom`.
+
 ```groovy
 job('example') {
     wrappers {
         configFiles {
+        	// defaults to ConfigFileType.Custom
             file('myCustomConfigFile') {
                 variable('CONFIG_FILE')
+            }
+            // since 1.33
+            file('myJenkinsSettingsFile', ConfigFileType.MAVEN_SETTINGS) {
+                variable('JENKINS_SETTINGS_FILE')
             }
         }
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/ConfigFilesContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/ConfigFilesContext.groovy
@@ -15,7 +15,7 @@ class ConfigFilesContext extends AbstractContext {
     }
 
     void file(String fileName, ConfigFileType type, @DslContext(ConfigFileContext) Closure configFileClosure = null) {
-        Preconditions.checkNotNull(type, "Config file type must be specified")
+        Preconditions.checkNotNull(type, 'Config file type must be specified')
         String configFileId = jobManagement.getConfigFileId(type, fileName)
         Preconditions.checkNotNull(configFileId, "${type} config file with name '${fileName}' not found")
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/ConfigFilesContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/ConfigFilesContext.groovy
@@ -14,13 +14,18 @@ class ConfigFilesContext extends AbstractContext {
         super(jobManagement)
     }
 
-    void file(String fileName, @DslContext(ConfigFileContext) Closure configFileClosure = null) {
-        String configFileId = jobManagement.getConfigFileId(ConfigFileType.Custom, fileName)
-        Preconditions.checkNotNull(configFileId, "Custom config file with name '${fileName}' not found")
+    void file(String fileName, ConfigFileType type, @DslContext(ConfigFileContext) Closure configFileClosure = null) {
+        Preconditions.checkNotNull(type, "Config file type must be specified")
+        String configFileId = jobManagement.getConfigFileId(type, fileName)
+        Preconditions.checkNotNull(configFileId, "${type} config file with name '${fileName}' not found")
 
         ConfigFileContext configFileContext = new ConfigFileContext(configFileId)
         ContextHelper.executeInContext(configFileClosure, configFileContext)
 
         configFiles << configFileContext
+    }
+
+    void file(String fileName, @DslContext(ConfigFileContext) Closure configFileClosure = null) {
+        file(fileName, ConfigFileType.Custom, configFileClosure)
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -926,15 +926,14 @@ class WrapperContextSpec extends Specification {
         when:
         context.configFiles {
             file(configName, null) {
-                variable "CONFIG_FILE_LOCATION"
+                variable 'CONFIG_FILE_LOCATION'
             }
         }
 
         then:
         Exception e = thrown(NullPointerException)
-        e.message.contains("Config file type must be specified")
+        e.message.contains('Config file type must be specified')
     }
-
 
     def 'call configFile with unknown fileName'() {
         setup:


### PR DESCRIPTION
Add overloaded configFiles file method that accepts ConfigFileType
argument. This allows jobs to reference maven settings files in
addition to custom config files.