### PR TITLE
use trusty64 box and add vagrant-cachier configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,28 +1,37 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+$base_script = <<SCRIPT
+sudo apt-get update
+sudo apt-get install -y openjdk-7-jdk git
+SCRIPT
+
 $script = <<SCRIPT
-wget --quiet --output-document=/etc/yum.repos.d/jenkins.repo http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo
-rpm --import http://pkg.jenkins-ci.org/redhat-stable/jenkins-ci.org.key
-yum --assumeyes --quiet install java-1.7.0-openjdk jenkins-1.554.2-1.1 git
-service jenkins start
+VERSION=1.554.2
+sudo apt-get install -y daemon
+wget -N -P /var/cache/wget --progress=dot:giga http://pkg.jenkins-ci.org/debian-stable/binary/jenkins_${VERSION}_all.deb
+sudo dpkg -i /var/cache/wget/jenkins_${VERSION}_all.deb
 SCRIPT
 
-$node_script = <<SCRIPT
-yum --assumeyes --quiet install java-1.7.0-openjdk git
-SCRIPT
-
-Vagrant.configure("2") do |config|
-    config.vm.box = "chef/centos-7.0"
+Vagrant.configure(2) do |config|
+    config.vm.box = "ubuntu/trusty64"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
 
     config.vm.define "master", primary: true do |master|
-      master.vm.network "forwarded_port", guest: 8080, host: 8081
-      master.vm.provision "shell", inline: $script
+        master.vm.network "forwarded_port", guest: 8080, host: 8081
+        master.vm.provision "shell", inline: $base_script
+        master.vm.provision "shell", inline: $script
     end
 
     config.vm.define "node", autostart: false do |node|
-      node.vm.provision "shell", inline: $node_script
+        node.vm.provision "shell", inline: $base_script
+    end
+
+    if Vagrant.has_plugin?("vagrant-cachier")
+        config.cache.scope = :box
+        config.cache.enable :generic, {
+            "wget" => { cache_dir: "/var/cache/wget" },
+        }
     end
 end


### PR DESCRIPTION
I switched to Ubuntu because vagrant-vbguest has problems with CentOS (https://github.com/dotless-de/vagrant-vbguest/issues/141). I also added configuration for the vagrant-cachier plugin to speed up provisioning.