### PR TITLE
[JENKINS-28167] updated minimum Jenkins core version to 1.565

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,9 +7,9 @@ sudo apt-get install -y openjdk-7-jdk git
 SCRIPT
 
 $script = <<SCRIPT
-VERSION=1.554.2
+VERSION=1.565
 sudo apt-get install -y daemon
-wget -N -P /var/cache/wget --progress=dot:giga http://pkg.jenkins-ci.org/debian-stable/binary/jenkins_${VERSION}_all.deb
+wget -N -P /var/cache/wget --progress=dot:giga http://pkg.jenkins-ci.org/debian/binary/jenkins_${VERSION}_all.deb
 sudo dpkg -i /var/cache/wget/jenkins_${VERSION}_all.deb
 SCRIPT
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -36,6 +36,8 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
    ([JENKINS-27891](https://issues.jenkins-ci.org/browse/JENKINS-27891))
  * Added a Jenkins extension point for adding DSL methods
  * Added support for [HipChat Plugin](https://wiki.jenkins-ci.org/display/JENKINS/HipChat+Plugin]
+ * Increased the minimum supported Jenkins version to 1.565
+   ([JENKINS-28167](https://issues.jenkins-ci.org/browse/JENKINS-28167))
 * 1.32 (April 07 2015)
  * Added support for [PowerShell Plugin](https://wiki.jenkins-ci.org/display/JENKINS/PowerShell+Plugin)
    ([JENKINS-27820](https://issues.jenkins-ci.org/browse/JENKINS-27820))

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/MockJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/MockJobManagement.groovy
@@ -76,7 +76,7 @@ abstract class MockJobManagement extends AbstractJobManagement {
 
     @Override
     VersionNumber getJenkinsVersion() {
-        new VersionNumber('1.554.2')
+        new VersionNumber('1.565')
     }
 
     @Override

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
@@ -6,7 +6,6 @@ import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.JobManagement
-import javaposse.jobdsl.dsl.RequiresCore
 import javaposse.jobdsl.dsl.RequiresPlugin
 import javaposse.jobdsl.dsl.WithXmlAction
 import javaposse.jobdsl.dsl.helpers.common.DownstreamContext
@@ -236,7 +235,6 @@ class TriggerContext extends AbstractContext {
     /**
      * @since 1.33
      */
-    @RequiresCore(minimumVersion = '1.560')
     void upstream(String projects, String threshold = 'SUCCESS') {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(projects), 'projects must be specified')
         Preconditions.checkArgument(

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/CoreVersionASTTransformationSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/CoreVersionASTTransformationSpec.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.dsl
 
+import hudson.util.VersionNumber
 import javaposse.jobdsl.dsl.jobs.FreeStyleJob
 import spock.lang.Specification
 
@@ -8,12 +9,17 @@ class CoreVersionASTTransformationSpec extends Specification {
     FreeStyleJob job = new FreeStyleJob(jobManagement)
 
     def 'require plugin'() {
+        setup:
+        jobManagement.jenkinsVersion >> new VersionNumber('1.565')
+
         when:
-        job.triggers {
-            upstream('foo')
+        job.publishers {
+            archiveArtifacts {
+                fingerprint()
+            }
         }
 
         then:
-        1 * jobManagement.requireMinimumCoreVersion('1.560')
+        1 * jobManagement.requireMinimumCoreVersion('1.571')
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -125,7 +125,7 @@ class PublisherContextSpec extends Specification {
 
     def 'call archive artifacts with all args'() {
         setup:
-        jobManagement.jenkinsVersion >> new VersionNumber('1.554.2')
+        jobManagement.jenkinsVersion >> new VersionNumber('1.565')
 
         when:
         context.archiveArtifacts('include/*', 'exclude/*', true)
@@ -144,7 +144,7 @@ class PublisherContextSpec extends Specification {
 
     def 'call archive artifacts least args'() {
         setup:
-        jobManagement.jenkinsVersion >> new VersionNumber('1.554.2')
+        jobManagement.jenkinsVersion >> new VersionNumber('1.565')
 
         when:
         context.archiveArtifacts('include/*')
@@ -161,7 +161,7 @@ class PublisherContextSpec extends Specification {
 
     def 'call archive artifacts with closure'() {
         setup:
-        jobManagement.jenkinsVersion >> new VersionNumber('1.554.2')
+        jobManagement.jenkinsVersion >> new VersionNumber('1.565')
 
         when:
         context.archiveArtifacts {
@@ -218,7 +218,7 @@ class PublisherContextSpec extends Specification {
 
     def 'call archive artifacts with multiple patterns'() {
         setup:
-        jobManagement.jenkinsVersion >> new VersionNumber('1.554.2')
+        jobManagement.jenkinsVersion >> new VersionNumber('1.565')
 
         when:
         context.archiveArtifacts {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
@@ -536,7 +536,6 @@ class TriggerContextSpec extends Specification {
                 completeBuild[0].value() == true
             }
         }
-        1 * mockJobManagement.requireMinimumCoreVersion('1.560')
     }
 
     def 'call upstream trigger methods with threshold'() {
@@ -557,7 +556,6 @@ class TriggerContextSpec extends Specification {
                 completeBuild[0].value() == true
             }
         }
-        1 * mockJobManagement.requireMinimumCoreVersion('1.560')
 
         where:
         thresholdValue | ordinalValue | colorValue

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -18,7 +18,7 @@ description = 'Jenkins plugin to leverage job-dsl-core to programmatic create jo
 def generatedSourcesDir = 'generated'
 
 jenkinsPlugin {
-    coreVersion = '1.554.2'
+    coreVersion = '1.565'
     displayName = 'Job DSL'
     url = 'https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin'
     gitHubUrl = 'https://github.com/jenkinsci/job-dsl-plugin'


### PR DESCRIPTION
See [JENKINS-28167](https://issues.jenkins-ci.org/browse/JENKINS-28167) for details.