### PR TITLE
dsl api documentation

### DIFF
--- a/job-dsl-api-viewer/src/css/main.less
+++ b/job-dsl-api-viewer/src/css/main.less
@@ -1,5 +1,8 @@
 @color1: #13262F;
-//http://app.coolors.co/2e4057-583e23-13262f-66a182-caffb9
+@color2: #27A668;
+@color3: #FC715B;
+@color4: #E4344A;
+@color5: #FE9D0B;
 
 .text-ellipsis {
   white-space: nowrap;
@@ -203,6 +206,17 @@ body {
   .label {
     margin-bottom: 3px;
     display: inline-block;
+    font-size: 12px;
+    padding: 4px 5px 5px;
+    &.label-min-version {
+      background-color: @color2;
+    }
+    &.label-since {
+      background-color: @color4;
+    }
+    &.label-deprecated {
+      background-color: @color5;
+    }
   }
   .signature {
     .code-block;

--- a/job-dsl-api-viewer/src/css/main.less
+++ b/job-dsl-api-viewer/src/css/main.less
@@ -193,7 +193,7 @@ body {
 }
 
 .method-doc {
-  margin: 25px 0;
+  margin: 15px 0 15px 5px;
   text-align: left;
   pre {
     padding: 0;
@@ -212,10 +212,10 @@ body {
       background-color: @color2;
     }
     &.label-since {
-      background-color: @color4;
+      background-color: @color5;
     }
     &.label-deprecated {
-      background-color: @color5;
+      background-color: @color4;
     }
   }
   .signature {
@@ -224,6 +224,21 @@ body {
     margin-bottom: 10px;
     text-align: left;
     display: block;
+  }
+  .enums {
+    text-align: left;
+    margin-left: 5px;
+    margin-bottom: 10px;
+    ul {
+      padding: 0 0 0 20px;
+      margin: 0;
+      li {
+        font-family: monospace;;
+      }
+    }
+    .enum-title {
+      margin-bottom: 3px;
+    }
   }
 }
 

--- a/job-dsl-api-viewer/src/js/app.js
+++ b/job-dsl-api-viewer/src/js/app.js
@@ -186,7 +186,7 @@
                     text = '(' + text + ')';
                 }
 
-                return {
+                var data = {
                     name: method.name,
                     href: href,
                     path: path,
@@ -198,6 +198,13 @@
                     context: signature.context,
                     comment: signature.firstSentenceCommentText
                 };
+
+                if (signature.plugin) {
+                    data.plugin = signature.plugin;
+                    data.plugin.title = window.updateCenter.data.plugins[signature.plugin.id].title;
+                }
+
+                return data;
             }, this)
         },
 

--- a/job-dsl-api-viewer/src/js/app.js
+++ b/job-dsl-api-viewer/src/js/app.js
@@ -199,9 +199,30 @@
                     comment: signature.firstSentenceCommentText
                 };
 
+                var enums = _.chain(signature.parameters)
+                    .filter(function(parameter) { return parameter.enumConstants; })
+                    .map(function(parameter) {
+                        var typeTokens = parameter.type.split('.');
+                        var simpleName = typeTokens[typeTokens.length - 1];
+                        return {
+                            paramName: parameter.name,
+                            values: parameter.enumConstants.map(function(v) { return simpleName + '.' + v; })
+                        };
+                    })
+                    .value();
+
+                if (enums.length) {
+                    data.enums = enums;
+                }
+
                 if (signature.plugin) {
                     data.plugin = signature.plugin;
-                    data.plugin.title = window.updateCenter.data.plugins[signature.plugin.id].title;
+                    var pluginData = window.updateCenter.data.plugins[signature.plugin.id];
+                    if (pluginData) {
+                        data.plugin.title = pluginData.title;
+                    } else {
+                        console.log('plugin not found', signature.plugin.id);
+                    }
                 }
 
                 return data;

--- a/job-dsl-api-viewer/src/templates/detail.hbs
+++ b/job-dsl-api-viewer/src/templates/detail.hbs
@@ -14,11 +14,12 @@
         </h2>
         <div class="signatures">
             {{#each signatures}}
+                {{#if plugin.minimumVersion}}<span class="label label-min-version">Requires {{plugin.title}} v{{plugin.minimumVersion}}+</span>{{/if}}
                 {{#if availableSince}}
-                    <span class="label label-info">Since {{availableSince}}</span>
+                    <span class="label label-since">Since {{availableSince}}</span>
                 {{/if}}
                 {{#if deprecated}}
-                    <span class="label label-warning">Deprecated</span>
+                    <span class="label label-deprecated">Deprecated</span>
                 {{/if}}
                 <div class="signature">
                     {{name}}<span class="highlight groovy inline">{{text}}</span>

--- a/job-dsl-api-viewer/src/templates/detail.hbs
+++ b/job-dsl-api-viewer/src/templates/detail.hbs
@@ -28,6 +28,20 @@
                 {{#if html}}
                     <div class="method-doc">{{{html}}}</div>
                 {{/if}}
+                {{#if enums}}
+                    <div class="enums">
+                    {{#each enums}}
+                        <div class="enum">
+                            <div class="enum-title">Possible values for <code>{{paramName}}</code>:</div>
+                            <ul>
+                                {{#each values}}
+                                    <li>{{this}}</li>
+                                {{/each}}
+                            </ul>
+                        </div>
+                    {{/each}}
+                    </div>
+                {{/if}}
             {{/each}}
         </div>
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/doc/ApiDocGenerator.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/doc/ApiDocGenerator.groovy
@@ -245,6 +245,10 @@ class ApiDocGenerator {
             map.type = map.type.replaceAll('\\$', '.') // fix inner class names
         }
 
+        if (clazz.isEnum()) {
+            map.enumConstants = clazz.enumConstants*.toString()
+        }
+
         if (parameter.defaultValue()) {
             map.defaultValue = parameter.defaultValue()
         }


### PR DESCRIPTION
This PR adds the initial implementation of the auto-generating documentation. 
demo: http://sheehan.github.io/job-dsl-plugin/

Steps for publishing the docs:

1. Run ```./gradlew generateApiDoc``` 
   * This will create a JSON file in `/job-dsl-plugin-viewer/data/dsl-<version>.json`
2. Add the version to the select at `/job-dsl-api-viewer/index.html` if not already there
3. Run `./gradlew :job-dsl-api-viewer:publishGhPages`

The generator will use JavaDoc for the method documentation. For longer docs, you can create a markdown file in `job-dsl-core/api-docs/` instead. I've moved a few docs there from the wiki so far.