### PR TITLE
NPE guard for views in folders that have already been deleted.

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
@@ -401,11 +401,13 @@ public class ExecuteDslScripts extends Builder {
                 View view = null;
                 if (parent instanceof ViewGroup) {
                     view = ((ViewGroup) parent).getView(FilenameUtils.getName(viewName));
+                    if (view != null) {
+                        ((ViewGroup) parent).deleteView(view);
+                    }
+                } else if (parent == null) {
+                    LOGGER.log(Level.FINE, "Parent ViewGroup seems to have been already deleted");
                 } else {
                     LOGGER.log(Level.WARNING, format("Could not delete view within %s", parent.getClass()));
-                }
-                if (view != null) {
-                    ((ViewGroup) parent).deleteView(view);
                 }
             }
         }


### PR DESCRIPTION
This NPE would happen if the dsl created a folder as well as a corresponding view in that folder. When later both are deleted, updateGeneratedViews cannot find the parent, which result in an NPE in logging.