### PR TITLE
Jenkins 28564: Add new option "Always link to last build on job page" for html-publisher	

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -22,6 +22,7 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
    ([JENKINS-28458](https://issues.jenkins-ci.org/browse/JENKINS-28458))
  * Fixed [Parameterized Trigger Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Parameterized+Trigger+Plugin) build step
    ([JENKINS-28353](https://issues.jenkins-ci.org/browse/JENKINS-28353))
+ * Add support for new html-publisher option ([JENKINS-28564](https://issues.jenkins-ci.org/browse/JENKINS-28564))
 * 1.34 (May 08 2015)
  * Enhanced support for the [Publish Over SSH Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Publish+Over+SSH+Plugin)
    ([JENKINS-26636](https://issues.jenkins-ci.org/browse/JENKINS-26636))

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -3913,11 +3913,12 @@ job('example') {
 job {
     publishers {
         publishHtml {
-            report(String reportDir) {                    // since 1.28
+            report(String reportDir) {                                      // since 1.28
                 reportName(String reportName)
-                reportFiles(String reportFiles)           // defaults to 'index.html' if omitted
-                allowMissing(boolean allowMissing = true) // defaults to false if omitted
-                keepAll(boolean keepAll = true)           // defaults to false if omitted
+                reportFiles(String reportFiles)                             // defaults to 'index.html' if omitted
+                allowMissing(boolean allowMissing = true)                   // defaults to false if omitted
+                keepAll(boolean keepAll = true)                             // defaults to false if omitted
+                alwaysLinkToLastBuild(boolean alwaysLinkToLastBuild = true) // defaults to false if omitted
             }
             report(String reportDir, String reportName, String reportFiles = 'index.html',
                    Boolean keepAll = false) // deprecated since 1.28
@@ -3940,6 +3941,7 @@ job('example') {
                 reportName('Gradle Tests')
                 keepAll()
                 allowMissing()
+                alwaysLinkToLastBuild()
             }
         }
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/HtmlReportTargetContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/HtmlReportTargetContext.groovy
@@ -11,6 +11,7 @@ class HtmlReportTargetContext extends AbstractContext {
     String reportFiles = 'index.html'
     boolean keepAll
     boolean allowMissing
+    boolean alwaysLinkToLastBuild
 
     HtmlReportTargetContext(JobManagement jobManagement, String reportDir) {
         super(jobManagement)
@@ -32,5 +33,10 @@ class HtmlReportTargetContext extends AbstractContext {
     @RequiresPlugin(id = 'htmlpublisher', minimumVersion = '1.3')
     void allowMissing(boolean allowMissing = true) {
         this.allowMissing = allowMissing
+    }
+
+    @RequiresPlugin(id = 'htmlpublisher', minimumVersion = '1.4')
+    void alwaysLinkToLastBuild(boolean alwaysLinkToLastBuild = true) {
+        this.alwaysLinkToLastBuild = alwaysLinkToLastBuild
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -317,6 +317,9 @@ class PublisherContext extends AbstractExtensibleContext {
                         if (!jobManagement.getPluginVersion('htmlpublisher')?.isOlderThan(new VersionNumber('1.3'))) {
                             allowMissing(target.allowMissing)
                         }
+                        if (!jobManagement.getPluginVersion('htmlpublisher')?.isOlderThan(new VersionNumber('1.4'))) {
+                            alwaysLinkToLastBuild(target.alwaysLinkToLastBuild)
+                        }
                         wrapperName('htmlpublisher-wrapper.html')
                     }
                 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -670,12 +670,13 @@ class PublisherContextSpec extends Specification {
         publisherHtmlNode.name() == 'htmlpublisher.HtmlPublisher'
         !publisherHtmlNode.reportTargets.isEmpty()
         def target = publisherHtmlNode.reportTargets[0].'htmlpublisher.HtmlPublisherTarget'[0]
-        target.children().size() == 6
+        target.children().size() == 7
         target.reportName[0].value() == ''
         target.reportDir[0].value() == 'build/*'
         target.reportFiles[0].value() == 'index.html'
         target.keepAll[0].value() == false
         target.allowMissing[0].value() == false
+        target.alwaysLinkToLastBuild[0].value() == false
         target.wrapperName[0].value() == 'htmlpublisher-wrapper.html'
         1 * jobManagement.requirePlugin('htmlpublisher')
     }
@@ -704,6 +705,30 @@ class PublisherContextSpec extends Specification {
         1 * jobManagement.requirePlugin('htmlpublisher')
     }
 
+    def 'calling minimal html publisher closure, plugin version older than 1.4'() {
+        setup:
+        jobManagement.getPluginVersion('htmlpublisher') >> new VersionNumber('1.3')
+
+        when:
+        context.publishHtml {
+            report('build/*') {
+            }
+        }
+
+        then:
+        Node publisherHtmlNode = context.publisherNodes[0]
+        publisherHtmlNode.name() == 'htmlpublisher.HtmlPublisher'
+        !publisherHtmlNode.reportTargets.isEmpty()
+        def target = publisherHtmlNode.reportTargets[0].'htmlpublisher.HtmlPublisherTarget'[0]
+        target.children().size() == 6
+        target.reportName[0].value() == ''
+        target.reportDir[0].value() == 'build/*'
+        target.reportFiles[0].value() == 'index.html'
+        target.keepAll[0].value() == false
+        target.allowMissing[0].value() == false
+        target.wrapperName[0].value() == 'htmlpublisher-wrapper.html'
+        1 * jobManagement.requirePlugin('htmlpublisher')
+    }
     def 'calling html publisher closure with all options'() {
         when:
         context.publishHtml {
@@ -712,6 +737,7 @@ class PublisherContextSpec extends Specification {
                 reportFiles('test.html')
                 allowMissing()
                 keepAll()
+                alwaysLinkToLastBuild()
             }
         }
 
@@ -721,12 +747,13 @@ class PublisherContextSpec extends Specification {
         publisherHtmlNode.name() == 'htmlpublisher.HtmlPublisher'
         !publisherHtmlNode.reportTargets.isEmpty()
         def target = publisherHtmlNode.reportTargets[0].'htmlpublisher.HtmlPublisherTarget'[0]
-        target.children().size() == 6
+        target.children().size() == 7
         target.reportName[0].value() == 'foo'
         target.reportDir[0].value() == 'build/*'
         target.reportFiles[0].value() == 'test.html'
         target.keepAll[0].value() == true
         target.allowMissing[0].value() == true
+        target.alwaysLinkToLastBuild[0].value() == true
         target.wrapperName[0].value() == 'htmlpublisher-wrapper.html'
         1 * jobManagement.requirePlugin('htmlpublisher')
     }
@@ -742,12 +769,13 @@ class PublisherContextSpec extends Specification {
         publisherHtmlNode.name() == 'htmlpublisher.HtmlPublisher'
         !publisherHtmlNode.reportTargets.isEmpty()
         def target = publisherHtmlNode.reportTargets[0].'htmlpublisher.HtmlPublisherTarget'[0]
-        target.children().size() == 6
+        target.children().size() == 7
         target.reportName[0].value() == 'My Name'
         target.reportDir[0].value() == 'build/*'
         target.reportFiles[0].value() == 'index.html'
         target.keepAll[0].value() == false
         target.allowMissing[0].value() == false
+        target.alwaysLinkToLastBuild[0].value() == false
         target.wrapperName[0].value() == 'htmlpublisher-wrapper.html'
         1 * jobManagement.requirePlugin('htmlpublisher')
     }
@@ -763,12 +791,13 @@ class PublisherContextSpec extends Specification {
         publisherHtmlNode.name() == 'htmlpublisher.HtmlPublisher'
         !publisherHtmlNode.reportTargets.isEmpty()
         def target = publisherHtmlNode.reportTargets[0].'htmlpublisher.HtmlPublisherTarget'[0]
-        target.children().size() == 6
+        target.children().size() == 7
         target.reportName[0].value() == 'Report Name'
         target.reportDir[0].value() == 'build/*'
         target.reportFiles[0].value() == 'content.html'
         target.keepAll[0].value() == true
         target.allowMissing[0].value() == false
+        target.alwaysLinkToLastBuild[0].value() == false
         target.wrapperName[0].value() == 'htmlpublisher-wrapper.html'
         1 * jobManagement.requirePlugin('htmlpublisher')
     }
@@ -784,12 +813,13 @@ class PublisherContextSpec extends Specification {
         publisherHtmlNode.name() == 'htmlpublisher.HtmlPublisher'
         !publisherHtmlNode.reportTargets.isEmpty()
         def target = publisherHtmlNode.reportTargets[0].'htmlpublisher.HtmlPublisherTarget'[0]
-        target.children().size() == 6
+        target.children().size() == 7
         target.reportName[0].value() == 'Report Name'
         target.reportDir[0].value() == 'build/*'
         target.reportFiles[0].value() == 'index.html'
         target.keepAll[0].value() == false
         target.allowMissing[0].value() == false
+        target.alwaysLinkToLastBuild[0].value() == false
         target.wrapperName[0].value() == 'htmlpublisher-wrapper.html'
         1 * jobManagement.requirePlugin('htmlpublisher')
     }


### PR DESCRIPTION
I added the option to the DSL and added test cases for it.
Documentation is updated and Release Notes entry was added. 

What do you think?