### PR TITLE
[Rundeck] Support for shouldIncludeRundeckLogs

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -36,6 +36,8 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
    ([JENKINS-32419](https://issues.jenkins-ci.org/browse/JENKINS-32419))
  * Enhanced support for the [JaCoCo Plugins](https://wiki.jenkins-ci.org/display/JENKINS/JaCoCo+Plugin)
    ([#729](https://github.com/jenkinsci/job-dsl-plugin/pull/729))
+ * Enchanced support for the [RunDeck Plugin](https://wiki.jenkins-ci.org/display/JENKINS/RunDeck+Plugin)
+   ([#493](https://github.com/jenkinsci/job-dsl-plugin/pull/493))
  * Fixed support for the
    [Static Code Analysis Plugins](https://wiki.jenkins-ci.org/display/JENKINS/Static+Code+Analysis+Plug-ins)
    ([#724](https://github.com/jenkinsci/job-dsl-plugin/pull/724))

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/rundeck.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/rundeck.groovy
@@ -14,6 +14,7 @@ job('example-2') {
             nodeFilter('tags', 'www+dev')
             shouldWaitForRundeckJob()
             shouldFailTheBuild()
+            shouldIncludeRundeckLogs()
         }
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1187,7 +1187,7 @@ class PublisherContext extends AbstractExtensibleContext {
     void rundeck(String jobIdentifier, @DslContext(RundeckContext) Closure rundeckClosure = null) {
         checkNotNullOrEmpty(jobIdentifier, 'jobIdentifier cannot be null or empty')
 
-        RundeckContext rundeckContext = new RundeckContext()
+        RundeckContext rundeckContext = new RundeckContext(jobManagement)
         ContextHelper.executeInContext(rundeckClosure, rundeckContext)
 
         publisherNodes << new NodeBuilder().'org.jenkinsci.plugins.rundeck.RundeckNotifier' {
@@ -1197,6 +1197,7 @@ class PublisherContext extends AbstractExtensibleContext {
             tag rundeckContext.tag
             shouldWaitForRundeckJob rundeckContext.shouldWaitForRundeckJob
             shouldFailTheBuild rundeckContext.shouldFailTheBuild
+            includeRundeckLogs rundeckContext.shouldIncludeRundeckLogs
         }
     }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/RundeckContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/RundeckContext.groovy
@@ -1,13 +1,20 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.AbstractContext
+import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.RequiresPlugin
 
-class RundeckContext implements Context {
+class RundeckContext extends AbstractContext {
     Map<String, String> options = [:]
     Map<String, String> nodeFilters = [:]
     String tag = ''
     boolean shouldWaitForRundeckJob
     boolean shouldFailTheBuild
+    boolean shouldIncludeRundeckLogs
+
+    RundeckContext(JobManagement jobManagement) {
+        super(jobManagement)
+    }
 
     /**
      * Adds options for the Rundeck job to execute. Can be called multiple times to add more options.
@@ -59,5 +66,20 @@ class RundeckContext implements Context {
      */
     void shouldFailTheBuild(boolean shouldFailTheBuild = true) {
         this.shouldFailTheBuild = shouldFailTheBuild
+    }
+
+    /**
+     * If set, job execution logs on Rundeck are included in a Jenkins console. Defaults to {@code false}.
+     *
+     * It also sets waiting for Rundeck job to finish as a required element.
+     *
+     * @since 1.43
+     */
+    @RequiresPlugin(id = 'rundeck', minimumVersion = '3.4')
+    void shouldIncludeRundeckLogs(boolean shouldIncludeRundeckLogs = true) {
+        this.shouldIncludeRundeckLogs = shouldIncludeRundeckLogs
+        if (shouldIncludeRundeckLogs) {
+            this.shouldWaitForRundeckJob = true
+        }
     }
 }


### PR DESCRIPTION
As shouldIncludeRundeckLogs requires shouldFailTheBuild to be set I also added a shortcut `shouldWaitForRundeckJobAndIncludeRundeckLogs`. It is convenient, but I don't know how it fits into job-dsl conventions.