### PR TITLE
Add support for Phabricator Plugin

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -54,6 +54,7 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
  * Added support for the [Progress Bar Column Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Progress+Bar+Column+Plugin)
  * Added support for the [Rebuild Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Rebuild+Plugin)
  * Added support for the [Global Variable String Parameter Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Global+Variable+String+Parameter+Plugin)
+ * Added support for the [Phabricator Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Phabricator+Plugin)
 * 1.38 (September 09 2015)
  * Replaced the [[Job Reference]], [[View Reference]] and [[Folder Reference]] pages by the
    [API Viewer](https://jenkinsci.github.io/job-dsl-plugin/)

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/phabricatorNotifier.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/phabricatorNotifier.groovy
@@ -1,0 +1,12 @@
+job('example') {
+    publishers {
+        phabricatorNotifier {
+            commentOnSuccess()
+            enableUberalls()
+            commentFile('.contributor-guide')
+            preserveFormatting()
+            commentSize(2000)
+            commentWithConsoleLinkOnFailure()
+        }
+    }
+}

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext/phabricator.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext/phabricator.groovy
@@ -1,0 +1,9 @@
+job('example') {
+    wrappers {
+        phabricator {
+            createCommit()
+            applyToMaster()
+            showBuildStartedMessage()
+        }
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PhabricatorNotifierContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PhabricatorNotifierContext.groovy
@@ -1,0 +1,58 @@
+package javaposse.jobdsl.dsl.helpers.publisher
+
+import javaposse.jobdsl.dsl.Context
+
+class PhabricatorNotifierContext implements Context {
+    boolean commentOnSuccess
+    boolean enableUberalls
+    String commentFile = '.phabricator-comment'
+    boolean preserveFormatting
+    int commentSize = 1000
+    boolean commentWithConsoleLinkOnFailure
+
+    /**
+     * Post a differential comment on successful builds. Defaults to {@code false}.
+     */
+    void commentOnSuccess(boolean commentOnSuccess = true) {
+        this.commentOnSuccess = commentOnSuccess
+    }
+
+    /**
+     * Enable code coverage reporting. Defaults to {@code false}.
+     */
+    void enableUberalls(boolean enableUberalls = true) {
+        this.enableUberalls = enableUberalls
+    }
+
+    /**
+     * Add additional context to Phabricator comment by outputting to this file.
+     * Defaults to {@code '.phabricator-comment'}.
+     */
+    void commentFile(String commentFile) {
+        this.commentFile = commentFile
+    }
+
+    /**
+     * Preserve comment formatting. Defaults to {@code false}.
+     */
+    void preserveFormatting(boolean preserveFormatting = true) {
+        this.preserveFormatting = preserveFormatting
+    }
+
+    /**
+     * Maximum comment character length. Defaults to {@code 1000}.
+     */
+    void commentSize(int commentSize) {
+        this.commentSize = commentSize
+    }
+
+    /**
+     * Post a differential comment on failed builds with a link to the raw Console Output.
+     * Defaults to {@code false}.
+     */
+    void commentWithConsoleLinkOnFailure(boolean commentWithConsoleLinkOnFailure = true) {
+        this.commentWithConsoleLinkOnFailure = commentWithConsoleLinkOnFailure
+    }
+
+}
+

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1579,6 +1579,26 @@ class PublisherContext extends AbstractExtensibleContext {
     }
 
     /**
+     * Sends build status and coverage information to Pharbicator
+     *
+     * @since 1.39
+     */
+    @RequiresPlugin(id = 'phabricator-plugin', minimumVersion = '1.8.1')
+    void phabricatorNotifier(@DslContext(PhabricatorNotifierContext) Closure phabricatorNotifierClosure = null) {
+        PhabricatorNotifierContext phabricatorNotifierContext = new PhabricatorNotifierContext()
+        ContextHelper.executeInContext(phabricatorNotifierClosure, phabricatorNotifierContext)
+
+        publisherNodes << new NodeBuilder().'com.uber.jenkins.phabricator.PhabricatorNotifier' {
+            commentOnSuccess(phabricatorNotifierContext.commentOnSuccess)
+            commentWithConsoleLinkOnFailure(phabricatorNotifierContext.commentWithConsoleLinkOnFailure)
+            commentFile(phabricatorNotifierContext.commentFile)
+            commentSize(phabricatorNotifierContext.commentSize)
+            preserveFormatting(phabricatorNotifierContext.preserveFormatting)
+            uberallsEnabled(phabricatorNotifierContext.enableUberalls)
+        }
+    }
+
+    /**
      * Sends notifications to Slack.
      *
      * @since 1.36

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/PhabricatorContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/PhabricatorContext.groovy
@@ -1,0 +1,31 @@
+package javaposse.jobdsl.dsl.helpers.wrapper
+
+import javaposse.jobdsl.dsl.Context
+
+class PhabricatorContext implements Context {
+    boolean createCommit
+    boolean applyToMaster
+    boolean showBuildStartedMessage = true
+
+    /**
+     * Create a git commit with the patch. Defaults to {@code false}.
+     */
+    void createCommit(boolean createCommit = true) {
+        this.createCommit = createCommit
+    }
+
+    /**
+     * If true, always arc patch apply to master. Defaults to {@code false}.
+     */
+    void applyToMaster(boolean applyToMaster = true) {
+        this.applyToMaster = applyToMaster
+    }
+
+    /**
+     * Shows the 'Build Started:' information message in Phabricator. Defaults to {@code true}.
+     */
+    void showBuildStartedMessage(boolean showBuildStartedMessage = true) {
+        this.showBuildStartedMessage = showBuildStartedMessage
+    }
+}
+

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -306,6 +306,23 @@ class WrapperContext extends AbstractExtensibleContext {
     }
 
     /**
+     * Apply a Phabricator differential to the workspace before the build starts.
+     *
+     * @since 1.39
+     */
+    @RequiresPlugin(id = 'phabricator-plugin', minimumVersion = '1.8.1')
+    void phabricator(@DslContext(PhabricatorContext) Closure closure = null) {
+        PhabricatorContext context = new PhabricatorContext()
+        ContextHelper.executeInContext(closure, context)
+
+        wrapperNodes << new NodeBuilder().'com.uber.jenkins.phabricator.PhabricatorBuildWrapper' {
+            createCommit(context.createCommit)
+            applyToMaster(context.applyToMaster)
+            showBuildStartedMessage(context.showBuildStartedMessage)
+        }
+    }
+
+    /**
      * Deletes files from the workspace before the build starts.
      *
      * @since 1.22

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -4413,6 +4413,49 @@ class PublisherContextSpec extends Specification {
         1 * jobManagement.requireMinimumPluginVersion('build-publisher', '1.20')
     }
 
+    def 'phabricatorNotifier with no options'() {
+        when:
+        context.phabricatorNotifier()
+
+        then:
+        with(context.publisherNodes[0]) {
+            name() == 'com.uber.jenkins.phabricator.PhabricatorNotifier'
+            children().size() == 6
+            commentOnSuccess[0].value() == false
+            commentWithConsoleLinkOnFailure[0].value() == false
+            commentFile[0].value() == '.phabricator-comment'
+            commentSize[0].value() == 1000
+            preserveFormatting[0].value() == false
+            uberallsEnabled[0].value() == false
+        }
+        1 * jobManagement.requireMinimumPluginVersion('phabricator-plugin', '1.8.1')
+    }
+
+    def 'phabricatorNotifier with all options'() {
+        when:
+        context.phabricatorNotifier {
+            commentOnSuccess()
+            commentWithConsoleLinkOnFailure()
+            commentFile('.my-comment-file')
+            commentSize(2000)
+            preserveFormatting()
+            enableUberalls()
+        }
+
+        then:
+        with(context.publisherNodes[0]) {
+            name() == 'com.uber.jenkins.phabricator.PhabricatorNotifier'
+            children().size() == 6
+            commentOnSuccess[0].value() == true
+            commentWithConsoleLinkOnFailure[0].value() == true
+            commentFile[0].value() == '.my-comment-file'
+            commentSize[0].value() == 2000
+            preserveFormatting[0].value() == true
+            uberallsEnabled[0].value() == true
+        }
+        1 * jobManagement.requireMinimumPluginVersion('phabricator-plugin', '1.8.1')
+    }
+
     def 'publishBuild with all options'() {
         when:
         context.publishBuild {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -570,6 +570,40 @@ class WrapperContextSpec extends Specification {
         1 * mockJobManagement.requirePlugin('release')
     }
 
+    def 'phabricator with minimal options'() {
+        when:
+        context.phabricator()
+
+        then:
+        with(context.wrapperNodes[0]) {
+            name() == 'com.uber.jenkins.phabricator.PhabricatorBuildWrapper'
+            children().size() == 3
+            createCommit[0].value() == false
+            applyToMaster[0].value() == false
+            showBuildStartedMessage[0].value() == true
+        }
+        1 * mockJobManagement.requireMinimumPluginVersion('phabricator-plugin', '1.8.1')
+    }
+
+    def 'phabricator with all options'() {
+        when:
+        context.phabricator {
+            createCommit()
+            applyToMaster()
+            showBuildStartedMessage()
+        }
+
+        then:
+        with(context.wrapperNodes[0]) {
+            name() == 'com.uber.jenkins.phabricator.PhabricatorBuildWrapper'
+            children().size() == 3
+            createCommit[0].value() == true
+            applyToMaster[0].value() == true
+            showBuildStartedMessage[0].value() == true
+        }
+        1 * mockJobManagement.requireMinimumPluginVersion('phabricator-plugin', '1.8.1')
+    }
+
     def 'call preBuildCleanup with minimal options'() {
         when:
         context.preBuildCleanup()


### PR DESCRIPTION
I'm trying to add the support for the Phabricator-Jenkins plugin, however I'm not really sure why the build fails:

```
javaposse.jobdsl.dsl.DslScriptLoaderSpec > use @Grab FAILED
    org.codehaus.groovy.control.MultipleCompilationErrorsException at DslScriptLoaderSpec.groovy:183
```

My first guess is that it's due to the plugin not being officially hosted yet, as the registration is in progress (see https://github.com/uber/phabricator-jenkins-plugin/issues/8).

Thoughts?