### PR TITLE
Fix generated XML for sshAgent wrapper

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -176,7 +176,10 @@ class WrapperContext extends AbstractExtensibleContext {
         Preconditions.checkNotNull(id, 'credentials not found')
 
         wrapperNodes << new NodeBuilder().'com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper' {
-            user id
+            credentialsId {
+                'string' id
+            }
+            ignoreMissing false
         }
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -338,7 +338,8 @@ class WrapperContextSpec extends Specification {
 
         then:
         context.wrapperNodes[0].name() == 'com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper'
-        context.wrapperNodes[0].user[0].value() == '4711'
+        context.wrapperNodes[0].credentialsId[0].string[0].value() == '4711'
+        context.wrapperNodes[0].ignoreMissing[0].value() == false
         1 * mockJobManagement.requirePlugin('ssh-agent')
     }
 


### PR DESCRIPTION
This fixes the inconsistency in XML generated for `sshAgent` wrapper by replicating the configuration from using the UI to configure the job.

This is what gets generated using `job-dsl`:

```xml
<com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
    <user>6ba0ca8d-6cc6-4b42-be1b-6c2508f824f1</user>
</com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
```

This is what I get when I configure a job in the UI:

```xml
<com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@1.6">
    <credentialIds>
        <string>6ba0ca8d-6cc6-4b42-be1b-6c2508f824f1</string>
    </credentialIds>
    <ignoreMissing>false</ignoreMissing>
</com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
```