### PR TITLE
Restore Multijob phase support in conditionalSteps

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContext.groovy
@@ -74,4 +74,9 @@ class MultiJobStepContext extends StepContext {
             }
         }
     }
+
+    @Override
+    StepContext newInstance() {
+        new MultiJobStepContext(jobManagement, item)
+    }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -491,7 +491,7 @@ class StepContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'conditional-buildstep')
     void conditionalSteps(@DslContext(ConditionalStepsContext) Closure conditionalStepsClosure) {
-        ConditionalStepsContext conditionalStepsContext = new ConditionalStepsContext(jobManagement, item)
+        ConditionalStepsContext conditionalStepsContext = new ConditionalStepsContext(jobManagement, newInstance())
         ContextHelper.executeInContext(conditionalStepsClosure, conditionalStepsContext)
 
         stepNodes << new NodeBuilder().'org.jenkinsci.plugins.conditionalbuildstep.ConditionalBuilder' {
@@ -703,5 +703,9 @@ class StepContext extends AbstractExtensibleContext {
             signPackage(context.signPackage)
             buildEvenWhenThereAreNoChanges(context.alwaysBuild)
         }
+    }
+
+    StepContext newInstance() {
+        new StepContext(jobManagement, item)
     }
 }


### PR DESCRIPTION
Make it possible to execute a Multijob phase conditionally.

It would probably be better to wrap the steps in the conditionalSteps within a Closure and adjust the dsl like this:
```groovy
conditionalSteps {
   steps {
      shell('echo Hello World')
   }
}
```