### PR TITLE
removed unnecessary update of Jenkins project dependency graph

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -37,6 +37,7 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
    ([JENKINS-28564](https://issues.jenkins-ci.org/browse/JENKINS-28564))
  * Enhanced support for the [Config File Provider Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin)
  * Enhanced support for the [GitHub Pull Request Builder Plugin](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin)
+ * Removed unnecessary update of Jenkins project dependency graph
  * Added support for the latest version of the [S3 Plugin](https://wiki.jenkins-ci.org/display/JENKINS/S3+Plugin)
    ([JENKINS-26561](https://issues.jenkins-ci.org/browse/JENKINS-26561))
  * Support for the older versions of the [S3 Plugin](https://wiki.jenkins-ci.org/display/JENKINS/S3+Plugin) is deprecated, see [[Migration]]

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
@@ -231,9 +231,6 @@ public class ExecuteDslScripts extends Builder {
                 build.addAction(new GeneratedConfigFilesBuildAction(freshConfigFiles));
                 build.addAction(new GeneratedUserContentsBuildAction(freshUserContents));
 
-                // Hint that our new jobs might have really shaken things up
-                Jenkins.getInstance().rebuildDependencyGraph();
-
                 return true;
             } finally {
                 generator.close();


### PR DESCRIPTION
The update is handled by Jenkins when creating, updating or deleting projects:

https://github.com/jenkinsci/jenkins/blob/jenkins-1.565/core/src/main/java/hudson/model/ItemGroupMixIn.java#L264
https://github.com/jenkinsci/jenkins/blob/jenkins-1.565/core/src/main/java/hudson/model/AbstractItem.java#L614
https://github.com/jenkinsci/jenkins/blob/jenkins-1.565/core/src/main/java/hudson/model/AbstractItem.java#L534