### PR TITLE
Restore Multijob phase support in conditionalSteps

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -33,6 +33,9 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
    ([JENKINS-29100](https://issues.jenkins-ci.org/browse/JENKINS-29100))
  * Fixed problem that caused a changing order of elements not to trigger a job update
    ([JENKINS-29107](https://issues.jenkins-ci.org/browse/JENKINS-29107))
+ * Fixed support for multi-job phases in conditional build steps
+ * Introduced nested steps context for conditional build steps and deprecated direct use of build steps in conditional
+   build steps, see [[Migration]]
  * Enhanced support for the [HTML Publisher Plugin](https://wiki.jenkins-ci.org/display/JENKINS/HTML+Publisher+Plugin)
    ([JENKINS-28564](https://issues.jenkins-ci.org/browse/JENKINS-28564))
  * Enhanced support for the [Config File Provider Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin)

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -33,6 +33,42 @@ Support for versions older than 1.15-0 of the
 [GitHub Pull Request Builder Plugin](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin) is
 [[deprecated|Deprecation-Policy]] and will be removed.
 
+## Conditional Build Steps
+
+Usage build steps directly in the `conditionalSteps` context is [[deprecated|Deprecation-Policy]] and will be removed.
+
+DSL prior to 1.35
+```groovy
+job('example') {
+    steps {
+        conditionalSteps {
+            condition {
+                stringsMatch('${SOME_PARAMETER}', 'pants', false)
+            }
+            runner('Fail')
+            shell("echo 'just one step'")
+        }
+    }
+}
+```
+
+DSL since to 1.35
+```groovy
+job('example') {
+    steps {
+        conditionalSteps {
+            condition {
+                stringsMatch('${SOME_PARAMETER}', 'pants', false)
+            }
+            runner('Fail')
+            steps {
+                shell("echo 'just one step'")
+            }
+        }
+    }
+}
+```
+
 ## Migrating to 1.34
 
 ### Conditional Build Steps

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/ConditionalStepsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/ConditionalStepsContext.groovy
@@ -1,6 +1,7 @@
 package javaposse.jobdsl.dsl.helpers.step
 
 import javaposse.jobdsl.dsl.AbstractContext
+import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.helpers.step.condition.RunCondition
@@ -8,12 +9,12 @@ import javaposse.jobdsl.dsl.helpers.step.condition.RunConditionFactory
 
 import static com.google.common.base.Preconditions.checkArgument
 
-class ConditionalStepsContext extends AbstractContext {
+class ConditionalStepsContext<T extends StepContext> extends AbstractContext {
     RunCondition runCondition
     String runnerClass
-    StepContext stepContext
+    T stepContext
 
-    ConditionalStepsContext(JobManagement jobManagement, StepContext freshStepContext) {
+    ConditionalStepsContext(JobManagement jobManagement, T freshStepContext) {
         super(jobManagement)
         this.stepContext = freshStepContext
     }
@@ -66,5 +67,9 @@ class ConditionalStepsContext extends AbstractContext {
         static find(String enumName) {
             values().find { it.name().toLowerCase() == enumName.toLowerCase() }
         }
+    }
+
+    void steps(@DslContext(T) Closure stepContextClosure) {
+        ContextHelper.executeInContext(stepContextClosure, stepContext)
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContext.groovy
@@ -76,7 +76,7 @@ class MultiJobStepContext extends StepContext {
     }
 
     @Override
-    StepContext newInstance() {
+    protected StepContext newInstance() {
         new MultiJobStepContext(jobManagement, item)
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContext.groovy
@@ -74,4 +74,9 @@ class MultiJobStepContext extends StepContext {
             }
         }
     }
+
+    @Override
+    StepContext newInstance() {
+        new MultiJobStepContext(jobManagement, item)
+    }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -499,7 +499,7 @@ class StepContext extends AbstractExtensibleContext {
                 conditionalStepsContext.runCondition.addArgs(delegate)
             }
             runner(class: conditionalStepsContext.runnerClass)
-            conditionalbuilders(conditionalStepsContext.stepNodes)
+            conditionalbuilders(conditionalStepsContext.stepContext.stepNodes)
         }
     }
 
@@ -705,7 +705,10 @@ class StepContext extends AbstractExtensibleContext {
         }
     }
 
-    StepContext newInstance() {
+    /**
+     * @since 1.35
+     */
+    protected StepContext newInstance() {
         new StepContext(jobManagement, item)
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -491,7 +491,7 @@ class StepContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'conditional-buildstep')
     void conditionalSteps(@DslContext(ConditionalStepsContext) Closure conditionalStepsClosure) {
-        ConditionalStepsContext conditionalStepsContext = new ConditionalStepsContext(jobManagement, item)
+        ConditionalStepsContext conditionalStepsContext = new ConditionalStepsContext(jobManagement, newInstance())
         ContextHelper.executeInContext(conditionalStepsClosure, conditionalStepsContext)
 
         stepNodes << new NodeBuilder().'org.jenkinsci.plugins.conditionalbuildstep.ConditionalBuilder' {
@@ -703,5 +703,9 @@ class StepContext extends AbstractExtensibleContext {
             signPackage(context.signPackage)
             buildEvenWhenThereAreNoChanges(context.alwaysBuild)
         }
+    }
+
+    StepContext newInstance() {
+        new StepContext(jobManagement, item)
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContextSpec.groovy
@@ -272,20 +272,23 @@ class MultiJobStepContextSpec extends Specification {
         }
 
         then:
-        Node step = context.stepNodes[0]
-        step.name() == 'org.jenkinsci.plugins.conditionalbuildstep.ConditionalBuilder'
-        step.runCondition[0].children().size() == 0
-
-        step.runCondition[0] != null
-        step.runner[0].attribute('class') == 'org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail'
-
-        step.conditionalbuilders[0].children().size() == 1
-        Node childStep = step.conditionalbuilders[0].children()[0]
-        childStep.name() == 'com.tikal.jenkins.plugins.multijob.MultiJobBuilder'
-        def jobNode = childStep.phaseJobs[0].'com.tikal.jenkins.plugins.multijob.PhaseJobsConfig'[0]
-        jobNode.children().size() == 4
-        jobNode.jobName[0].value() == 'JobA'
-
+        with(context.stepNodes[0]) {
+            name() == 'org.jenkinsci.plugins.conditionalbuildstep.ConditionalBuilder'
+            children().size() == 3
+            runCondition[0].children().size() == 0
+            runCondition[0] != null
+            runner[0].attribute('class') == 'org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail'
+            with(conditionalbuilders[0]) {
+                children().size() == 1
+                with(children()[0]) {
+                    name() == 'com.tikal.jenkins.plugins.multijob.MultiJobBuilder'
+                    with(phaseJobs[0].'com.tikal.jenkins.plugins.multijob.PhaseJobsConfig'[0]) {
+                        children().size() == 4
+                        jobName[0].value() == 'JobA'
+                    }
+                }
+            }
+        }
         1 * jobManagement.requirePlugin('conditional-buildstep')
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContextSpec.groovy
@@ -263,9 +263,11 @@ class MultiJobStepContextSpec extends Specification {
                 alwaysRun()
             }
             runner('Fail')
-            phase {
-                phaseName 'Second'
-                job('JobA')
+            steps {
+                phase {
+                    phaseName 'Second'
+                    job('JobA')
+                }
             }
         }
 


### PR DESCRIPTION
Replaces #513 and #516.

I removed the generics since those do not fix IDE support in this case. So there will be no IDE support for multi-job phases in conditional build steps, but that's a minor issue compare to having no support for conditional multi-job phases at all. It's also an issue for the new API browser (#479) because it uses the same annotations as the IDE support.

I also added deprecation warnings, release notes and updated the documentation.

@wolfs please review and if it's OK, hit the merge button and close #513 and #516.