### PR TITLE
Write output files for FileJobManagment to the same directory as the …

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
@@ -2,7 +2,7 @@ package javaposse.jobdsl.dsl
 
 class FileJobManagement extends MockJobManagement {
     /**
-     * Root of where to look for job config files
+     * Root of where to look for and write out job and view config files
      */
     File root
 
@@ -40,7 +40,7 @@ class FileJobManagement extends MockJobManagement {
 
         validateUpdateArgs(jobName, config)
 
-        new File(jobName + ext).write(config)
+        new File(root, jobName + ext).write(config)
         true
     }
 
@@ -48,7 +48,7 @@ class FileJobManagement extends MockJobManagement {
     void createOrUpdateView(String viewName, String config, boolean ignoreExisting) {
         validateUpdateArgs(viewName, config)
 
-        new File(viewName + ext).write(config)
+        new File(root, viewName + ext).write(config)
     }
 
     InputStream streamFileInWorkspace(String filePath) {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/FileJobManagementSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/FileJobManagementSpec.groovy
@@ -9,7 +9,8 @@ class FileJobManagementSpec extends Specification {
     @Rule
     TemporaryFolder temporaryFolder = new TemporaryFolder()
 
-    private final FileJobManagement jobManagement = new FileJobManagement(temporaryFolder.newFolder())
+    private final File tempFolder = temporaryFolder.newFolder()
+    private final FileJobManagement jobManagement = new FileJobManagement(tempFolder)
 
     def setup() {
         XMLUnit.ignoreWhitespace = true
@@ -78,7 +79,7 @@ class FileJobManagementSpec extends Specification {
 
         then:
         result
-        new File('foo.xml').text == 'bar'
+        new File(tempFolder, 'foo.xml').text == 'bar'
     }
 
     def 'createOrUpdateView complains about missing name'(String name) {
@@ -108,7 +109,7 @@ class FileJobManagementSpec extends Specification {
         jobManagement.createOrUpdateView('foo', 'bar', false)
 
         then:
-        new File('foo.xml').text == 'bar'
+        new File(tempFolder, 'foo.xml').text == 'bar'
     }
 
     def 'createOrUpdateConfigFile is not supported'() {


### PR DESCRIPTION
…input files.
The option "root" should take effect in writing out the generated config, too.