### PR TITLE
Set default-Value of closure to {} to avoid having "null" in the gene…

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/TimeoutContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/TimeoutContext.groovy
@@ -90,14 +90,14 @@ class TimeoutContext extends AbstractContext {
         }
     }
 
-    private void setStrategy(String type, Closure closure = null) {
+    private void setStrategy(String type, Closure closure = {}) {
         strategy = new NodeBuilder().strategy(
                 class: "hudson.plugins.build_timeout.impl.${type}TimeOutStrategy",
                 closure
         )
     }
 
-    private void addOperation(String type, Closure closure = null) {
+    private void addOperation(String type, Closure closure = {}) {
         operations << new NodeBuilder()."hudson.plugins.build__timeout.operations.${type}Operation"(closure)
     }
 }


### PR DESCRIPTION
…rated xml.