### PR TITLE
provide better error messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ even delay the merge until someone finds time to review a huge change. Only impl
 leave room so that the remaining options can be added when needed.
 
 ## Our Basic Design Decisions / Conventions
-1. Use `com.google.common.base.Preconditions` for argument validation. E.g. `Preconditions.checkArgument(name, "Channel name for irc channel is required!")`
+1. Use `javaposse.jobdsl.dsl.Preconditions` for argument validation. E.g. `Preconditions.checkArgument(name, "Channel name for irc channel is required!")`
 1. We write tests using [Spock](http://code.google.com/p/spock/), so if (for example) you add a new Helper (e.g. `ScmHelper`), then add a corresponding ScmHelperSpec in the tests directory tree.
 
 ## DSL Design

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -17,6 +17,10 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
 
 ## Release Notes
 * 1.36 (unreleased)
+ * Improved error logging
+   ([JENKINS-16354](https://issues.jenkins-ci.org/browse/JENKINS-16354))
+ * Some methods in `AbstractJobManagement` have been deprecated and the exception handling has changed, see
+   [Migration](Migration#migrating-to-136)
 * 1.35 (July 01 2015)
  * Added support for the [Build Flow Test Aggregator Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build+Flow+Test+Aggregator+Plugin)
    ([JENKINS-28851](https://issues.jenkins-ci.org/browse/JENKINS-28851))

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -1,3 +1,27 @@
+## Migrating to 1.36
+
+### AbstractJobManagement
+
+The following methods in AbstractJobManagement have been [[deprecated|Deprecation-Policy]] and will be removed:
+
+```groovy
+protected static List<StackTraceElement> getStackTrace()
+
+protected static String getSourceDetails(List<StackTraceElement> stackTrace)
+
+protected static String getSourceDetails(String scriptName, int lineNumber)
+
+protected void logWarning(String message, Object... args)
+```
+
+### Exception Handling
+
+DSL methods will now throw a `javaposse.jobdsl.dsl.DslException` instead of `java.lang.IllegalArgumentException`,
+`java.lang.IllegalStateException` or `java.lang.NullPointerException` when validating arguments.
+
+The `javaposse.jobdsl.dsl.DslScriptLoader` will also throw a `javaposse.jobdsl.dsl.DslException` on script errors like
+compilation failures and missing methods or properties.
+
 ## Migrating to 1.35
 
 ### Maven

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
@@ -1,8 +1,5 @@
 package javaposse.jobdsl.dsl
 
-import static java.lang.Thread.currentThread
-import static org.codehaus.groovy.runtime.StackTraceUtils.isApplicationClass
-
 /**
  * Abstract base class providing common functionality for all {@link JobManagement} implementations.
  */
@@ -36,19 +33,19 @@ abstract class AbstractJobManagement implements JobManagement {
 
     @Override
     void logDeprecationWarning() {
-        List<StackTraceElement> currentStackTrack = stackTrace
-        String details = getSourceDetails(currentStackTrack)
+        List<StackTraceElement> currentStackTrack = DslScriptHelper.stackTrace
+        String details = DslScriptHelper.getSourceDetails(currentStackTrack)
         logDeprecationWarning(currentStackTrack[0].methodName, details)
     }
 
     @Override
     void logDeprecationWarning(String subject) {
-        logDeprecationWarning(subject, getSourceDetails(stackTrace))
+        logDeprecationWarning(subject, DslScriptHelper.sourceDetails)
     }
 
     @Override
     void logDeprecationWarning(String subject, String scriptName, int lineNumber) {
-        logDeprecationWarning(subject, getSourceDetails(scriptName, lineNumber))
+        logDeprecationWarning(subject, DslScriptHelper.getSourceDetails(scriptName, lineNumber))
     }
 
     protected void logDeprecationWarning(String subject, String details) {
@@ -72,25 +69,19 @@ abstract class AbstractJobManagement implements JobManagement {
         }
     }
 
+    @Deprecated
     protected static List<StackTraceElement> getStackTrace() {
-        List<StackTraceElement> result = currentThread().stackTrace.findAll { isApplicationClass(it.className) }
-        result[4..-1]
+        DslScriptHelper.stackTrace
     }
 
+    @Deprecated
     protected static String getSourceDetails(List<StackTraceElement> stackTrace) {
-        StackTraceElement source = stackTrace.find { !it.className.startsWith('javaposse.jobdsl.') }
-        getSourceDetails(source?.fileName, source == null ? -1 : source.lineNumber)
+        DslScriptHelper.getSourceDetails(stackTrace)
     }
 
+    @Deprecated
     protected static String getSourceDetails(String scriptName, int lineNumber) {
-        String details = 'unknown source'
-        if (scriptName != null) {
-            details = scriptName.matches(/script\d+\.groovy/) ? 'DSL script' : scriptName
-            if (lineNumber > 0) {
-                details += ", line ${lineNumber}"
-            }
-        }
-        details
+        DslScriptHelper.getSourceDetails(scriptName, lineNumber)
     }
 
     protected void logWarning(String message, Object... args) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
@@ -69,26 +69,41 @@ abstract class AbstractJobManagement implements JobManagement {
         }
     }
 
+    /**
+     * @deprecated use {@link DslScriptHelper#getStackTrace()} instead
+     */
     @Deprecated
     protected static List<StackTraceElement> getStackTrace() {
         DslScriptHelper.stackTrace
     }
 
+    /**
+     * @deprecated use {@link DslScriptHelper#getSourceDetails(java.util.List)} instead
+     */
     @Deprecated
     protected static String getSourceDetails(List<StackTraceElement> stackTrace) {
         DslScriptHelper.getSourceDetails(stackTrace)
     }
 
+    /**
+     * @deprecated use {@link DslScriptHelper#getSourceDetails(java.lang.String, int)} instead
+     */
     @Deprecated
     protected static String getSourceDetails(String scriptName, int lineNumber) {
         DslScriptHelper.getSourceDetails(scriptName, lineNumber)
     }
 
+    /**
+     * @deprecated use {@link #logWarning(java.lang.String)} instead
+     */
     @Deprecated
     protected void logWarning(String message, Object... args) {
         outputStream.printf("Warning: $message\n", args)
     }
 
+    /**
+     * @since 1.36
+     */
     protected void logWarning(String message, String details = DslScriptHelper.getSourceDetails()) {
         outputStream.println("Warning: ($details) $message")
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
@@ -49,7 +49,7 @@ abstract class AbstractJobManagement implements JobManagement {
     }
 
     protected void logDeprecationWarning(String subject, String details) {
-        logWarning('%s is deprecated (%s)', subject, details)
+        logWarningWithDetails("${subject} is deprecated", details)
     }
 
     protected static void validateUpdateArgs(String jobName, String config) {
@@ -82,6 +82,10 @@ abstract class AbstractJobManagement implements JobManagement {
     @Deprecated
     protected static String getSourceDetails(String scriptName, int lineNumber) {
         DslScriptHelper.getSourceDetails(scriptName, lineNumber)
+    }
+
+    protected void logWarningWithDetails(String message, String details = DslScriptHelper.getSourceDetails()) {
+        logWarning('(%s) %s', details, message)
     }
 
     protected void logWarning(String message, Object... args) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
@@ -49,7 +49,7 @@ abstract class AbstractJobManagement implements JobManagement {
     }
 
     protected void logDeprecationWarning(String subject, String details) {
-        logWarningWithDetails("${subject} is deprecated", details)
+        logWarning("${subject} is deprecated", details)
     }
 
     protected static void validateUpdateArgs(String jobName, String config) {
@@ -84,11 +84,12 @@ abstract class AbstractJobManagement implements JobManagement {
         DslScriptHelper.getSourceDetails(scriptName, lineNumber)
     }
 
-    protected void logWarningWithDetails(String message, String details = DslScriptHelper.getSourceDetails()) {
-        logWarning('(%s) %s', details, message)
-    }
-
+    @Deprecated
     protected void logWarning(String message, Object... args) {
         outputStream.printf("Warning: $message\n", args)
+    }
+
+    protected void logWarning(String message, String details = DslScriptHelper.getSourceDetails()) {
+        outputStream.println("Warning: ($details) $message")
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ConfigFile.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ConfigFile.groovy
@@ -1,7 +1,5 @@
 package javaposse.jobdsl.dsl
 
-import com.google.common.base.Preconditions
-
 class ConfigFile implements Context {
     final ConfigFileType type
     final JobManagement jobManagement
@@ -21,13 +19,13 @@ class ConfigFile implements Context {
     }
 
     void comment(String comment) {
-        Preconditions.checkArgument(comment != null, 'comment must not be null')
+        Preconditions.checkNotNull(comment, 'comment must not be null')
 
         this.comment = comment
     }
 
     void content(String content) {
-        Preconditions.checkArgument(content != null, 'content must not be null')
+        Preconditions.checkNotNull(content, 'content must not be null')
 
         this.content = content
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslException.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslException.groovy
@@ -5,6 +5,9 @@ class DslException extends RuntimeException {
         super(message)
     }
 
+    /**
+     * @since 1.36
+     */
     DslException(String message, Throwable cause) {
         super(message, cause)
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslException.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslException.groovy
@@ -4,4 +4,8 @@ class DslException extends RuntimeException {
     DslException(String message) {
         super(message)
     }
+
+    DslException(String message, Throwable cause) {
+        super(message, cause)
+    }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptException.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptException.groovy
@@ -13,8 +13,12 @@ class DslScriptException extends DslException {
         super(message)
     }
 
+    DslScriptException(String message, Throwable cause) {
+        super(message, cause)
+    }
+
     @Override
     String getMessage() {
-        "${super.message} (${getSourceDetails(stackTrace)})"
+        "(${getSourceDetails(cause ? cause.stackTrace : stackTrace)}) ${super.message}"
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptException.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptException.groovy
@@ -1,0 +1,20 @@
+package javaposse.jobdsl.dsl
+
+import static javaposse.jobdsl.dsl.DslScriptHelper.getSourceDetails
+
+/**
+ * Indicates a DSL script problem on user-level. The problem will be logged to the build log with a pointer to the
+ * source location in the DSL script, but without a stack trace.
+ *
+ * @since 1.36
+ */
+class DslScriptException extends DslException {
+    DslScriptException(String message) {
+        super(message)
+    }
+
+    @Override
+    String getMessage() {
+        "${super.message} (${getSourceDetails(stackTrace)})"
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptHelper.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptHelper.groovy
@@ -1,0 +1,55 @@
+package javaposse.jobdsl.dsl
+
+import static java.lang.Thread.currentThread
+import static org.codehaus.groovy.runtime.StackTraceUtils.isApplicationClass
+
+/**
+ * Helper class for dealing with stack traces originating from DSL scripts and finding the DSL script source line that
+ * led to a stack trace.
+ *
+ * @since 1.36
+ */
+class DslScriptHelper {
+    private static final Set<String> CLASS_FILTER = [
+            DslScriptHelper.name,
+            JobManagement.name,
+            AbstractJobManagement.name,
+    ]
+
+    private DslScriptHelper() {
+    }
+
+    static List<StackTraceElement> getStackTrace() {
+        currentThread().stackTrace.findAll { StackTraceElement element ->
+            isApplicationClass(element.className) &&
+                    !(element.className in CLASS_FILTER) &&
+                    !CLASS_FILTER.any { element.className.startsWith(it + '$') }
+        }
+    }
+
+    static String getSourceDetails() {
+        getSourceDetails(stackTrace)
+    }
+
+    static String getSourceDetails(StackTraceElement[] stackTrace) {
+        getSourceDetails(stackTrace as List<StackTraceElement>)
+    }
+
+    static String getSourceDetails(List<StackTraceElement> stackTrace) {
+        StackTraceElement source = stackTrace.find {
+            isApplicationClass(it.className) && !it.className.startsWith('javaposse.jobdsl.')
+        }
+        getSourceDetails(source?.fileName, source == null ? -1 : source.lineNumber)
+    }
+
+    static String getSourceDetails(String scriptName, int lineNumber) {
+        String details = 'unknown source'
+        if (scriptName != null) {
+            details = scriptName.matches(/script\d+\.groovy/) ? 'DSL script' : scriptName
+            if (lineNumber > 0) {
+                details += ", line ${lineNumber}"
+            }
+        }
+        details
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
@@ -1,11 +1,10 @@
 package javaposse.jobdsl.dsl
 
-import com.google.common.base.Preconditions
 import hudson.util.VersionNumber
 import javaposse.jobdsl.dsl.helpers.BuildParametersContext
 import javaposse.jobdsl.dsl.helpers.JobAuthorizationContext
-import javaposse.jobdsl.dsl.helpers.properties.PropertiesContext
 import javaposse.jobdsl.dsl.helpers.ScmContext
+import javaposse.jobdsl.dsl.helpers.properties.PropertiesContext
 import javaposse.jobdsl.dsl.helpers.publisher.PublisherContext
 import javaposse.jobdsl.dsl.helpers.step.StepContext
 import javaposse.jobdsl.dsl.helpers.toplevel.EnvironmentVariableContext
@@ -14,6 +13,10 @@ import javaposse.jobdsl.dsl.helpers.toplevel.NotificationContext
 import javaposse.jobdsl.dsl.helpers.toplevel.ThrottleConcurrentBuildsContext
 import javaposse.jobdsl.dsl.helpers.triggers.TriggerContext
 import javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext
+
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNull
+import static javaposse.jobdsl.dsl.Preconditions.checkState
 
 /**
  * DSL element representing a Jenkins job.
@@ -34,7 +37,7 @@ abstract class Job extends Item {
      * @throws JobTemplateMissingException
      */
     void using(String templateName) throws JobTemplateMissingException {
-        Preconditions.checkState(this.templateName == null, 'Can only use "using" once')
+        checkArgument(this.templateName == null, 'Can only use "using" once')
         this.templateName = templateName
     }
 
@@ -265,7 +268,7 @@ abstract class Job extends Item {
      * @since 1.16
      */
     void displayName(String displayName) {
-        Preconditions.checkNotNull(displayName, 'Display name must not be null.')
+        checkNotNull(displayName, 'Display name must not be null.')
         withXmlActions << WithXmlAction.create { Node project ->
             Node node = methodMissing('displayName', displayName)
             project / node
@@ -279,7 +282,7 @@ abstract class Job extends Item {
      * @since 1.16
      */
     void customWorkspace(String workspacePath) {
-        Preconditions.checkNotNull(workspacePath, 'Workspace path must not be null')
+        checkNotNull(workspacePath, 'Workspace path must not be null')
         withXmlActions << WithXmlAction.create { Node project ->
             Node node = methodMissing('customWorkspace', workspacePath)
             project / node
@@ -418,7 +421,7 @@ abstract class Job extends Item {
         ContextHelper.executeInContext(closure, context)
 
         if (!context.scmNodes.empty) {
-            Preconditions.checkState(context.scmNodes.size() == 1, 'Outside "multiscm", only one SCM can be specified')
+            checkState(context.scmNodes.size() == 1, 'Outside "multiscm", only one SCM can be specified')
 
             withXmlActions << WithXmlAction.create { Node project ->
                 Node scm = project / scm

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
@@ -1,7 +1,5 @@
 package javaposse.jobdsl.dsl
 
-import com.google.common.base.Preconditions
-import com.google.common.base.Strings
 import com.google.common.collect.Sets
 import javaposse.jobdsl.dsl.jobs.BuildFlowJob
 import javaposse.jobdsl.dsl.jobs.FreeStyleJob
@@ -16,6 +14,9 @@ import javaposse.jobdsl.dsl.views.DeliveryPipelineView
 import javaposse.jobdsl.dsl.views.ListView
 import javaposse.jobdsl.dsl.views.NestedView
 import javaposse.jobdsl.dsl.views.SectionedView
+
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNull
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 
 abstract class JobParent extends Script implements DslFactory {
     JobManagement jm
@@ -87,7 +88,7 @@ abstract class JobParent extends Script implements DslFactory {
 
     // this method cannot be private due to http://jira.codehaus.org/browse/GROOVY-6263
     protected <T extends Job> T processJob(String name, Class<T> jobClass, Closure closure) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(name), 'name must be specified')
+        checkNotNullOrEmpty(name, 'name must be specified')
 
         T job = jobClass.newInstance(jm)
         job.name = name
@@ -176,7 +177,7 @@ abstract class JobParent extends Script implements DslFactory {
 
     // this method cannot be private due to http://jira.codehaus.org/browse/GROOVY-6263
     protected <T extends View> T processView(String name, Class<T> viewClass, Closure closure) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(name), 'name must be specified')
+        checkNotNullOrEmpty(name, 'name must be specified')
 
         T view = viewClass.newInstance(jm)
         view.name = name
@@ -224,7 +225,7 @@ abstract class JobParent extends Script implements DslFactory {
     @Override
     @RequiresPlugin(id = 'cloudbees-folder')
     Folder folder(String name, @DslContext(Folder) Closure closure = null) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(name), 'name must be specified')
+        checkNotNullOrEmpty(name, 'name must be specified')
 
         Folder folder = new Folder(jm)
         folder.name = name
@@ -270,7 +271,7 @@ abstract class JobParent extends Script implements DslFactory {
 
     // this method cannot be private due to http://jira.codehaus.org/browse/GROOVY-6263
     protected ConfigFile processConfigFile(String name, ConfigFileType configFileType, Closure closure) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(name), 'name must be specified')
+        checkNotNullOrEmpty(name, 'name must be specified')
 
         ConfigFile configFile = new ConfigFile(configFileType, jm)
         configFile.name = name
@@ -299,7 +300,8 @@ abstract class JobParent extends Script implements DslFactory {
      */
     @Override
     void queue(Job job) {
-        Preconditions.checkArgument(job.name as Boolean)
+        checkNotNull(job, 'job must not be null')
+        checkNotNullOrEmpty(job.name, 'job name must not be null or empty')
         queueToBuild << job.name
     }
 
@@ -308,7 +310,7 @@ abstract class JobParent extends Script implements DslFactory {
      */
     @Override
     InputStream streamFileFromWorkspace(String filePath) {
-        Preconditions.checkArgument(filePath as Boolean)
+        checkNotNullOrEmpty(filePath, 'filePath must not be null or empty')
         jm.streamFileInWorkspace(filePath)
     }
 
@@ -317,7 +319,7 @@ abstract class JobParent extends Script implements DslFactory {
      */
     @Override
     String readFileFromWorkspace(String filePath) {
-        Preconditions.checkArgument(filePath as Boolean)
+        checkNotNullOrEmpty(filePath, 'filePath must not be null or empty')
         jm.readFileInWorkspace(filePath)
     }
 
@@ -326,8 +328,8 @@ abstract class JobParent extends Script implements DslFactory {
      */
     @Override
     String readFileFromWorkspace(String jobName, String filePath) {
-        Preconditions.checkArgument(jobName as Boolean)
-        Preconditions.checkArgument(filePath as Boolean)
+        checkNotNullOrEmpty(jobName, 'jobName must not be null or empty')
+        checkNotNullOrEmpty(filePath, 'filePath must not be null or empty')
         jm.readFileInWorkspace(jobName, filePath)
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Preconditions.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Preconditions.groovy
@@ -1,5 +1,10 @@
 package javaposse.jobdsl.dsl
 
+/**
+ * Provides methods for argument validation to be used in DSL methods.
+ *
+ * @since 1.36
+ */
 class Preconditions {
     private Preconditions() {
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Preconditions.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Preconditions.groovy
@@ -1,0 +1,66 @@
+package javaposse.jobdsl.dsl
+
+class Preconditions {
+    private Preconditions() {
+    }
+
+    /**
+     * Ensures the truth of an expression involving one or more parameters to the
+     * calling method.
+     *
+     * @param expression a boolean expression
+     * @param errorMessage the exception message to use if the check fails; will
+     *     be converted to a string using {@link String#valueOf(Object)}
+     * @throws DslScriptException if {@code expression} is false
+     */
+    static void checkArgument(boolean expression, Object errorMessage) {
+        if (!expression) {
+            throw new DslScriptException(String.valueOf(errorMessage))
+        }
+    }
+
+    /**
+     * Ensures the truth of an expression involving the state of the calling
+     * instance, but not involving any parameters to the calling method.
+     *
+     * @param expression a boolean expression
+     * @param errorMessage the exception message to use if the check fails; will
+     *     be converted to a string using {@link String#valueOf(Object)}
+     * @throws DslScriptException if {@code expression} is false
+     */
+    static void checkState(boolean expression, Object errorMessage) {
+        if (!expression) {
+            throw new DslScriptException(String.valueOf(errorMessage))
+        }
+    }
+
+    /**
+     * Ensures that an object reference passed as a parameter to the calling
+     * method is not null.
+     *
+     * @param reference an object reference
+     * @param errorMessage the exception message to use if the check fails; will
+     *     be converted to a string using {@link String#valueOf(Object)}
+     * @return the non-null reference that was validated
+     * @throws DslScriptException if {@code reference} is null
+     */
+    static void checkNotNull(Object reference, Object errorMessage) {
+        if (reference == null) {
+            throw new DslScriptException(String.valueOf(errorMessage))
+        }
+    }
+
+    /**
+     * Ensures that a string passed as a parameter is not {@code null} or an empty string.
+     *
+     * @param string a string
+     * @param errorMessage the exception message to use if the check fails; will
+     *     be converted to a string using {@link String#valueOf(Object)}
+     * @throws DslScriptException if {@code string} is {@code null} or an empty string
+     */
+    static void checkNotNullOrEmpty(String string, Object errorMessage) {
+        if (!string) {
+            throw new DslScriptException(String.valueOf(errorMessage))
+        }
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/WithXmlAction.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/WithXmlAction.groovy
@@ -1,17 +1,14 @@
 package javaposse.jobdsl.dsl
 
-import com.google.common.base.Preconditions
-
 class WithXmlAction {
     private final Closure closure
 
     WithXmlAction(Closure closure) {
-        this.closure = Preconditions.checkNotNull(closure, 'Closure has to be set during constructor')
+        Preconditions.checkNotNull(closure, 'Closure has to be set during constructor')
+        this.closure = closure
     }
 
     void execute(Node root) {
-        Preconditions.checkNotNull(root)
-
         closure.delegate = new MissingPropertyToStringDelegate(root)
 
         use(NodeEnhancement) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/AuthorizationContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/AuthorizationContext.groovy
@@ -1,10 +1,10 @@
 package javaposse.jobdsl.dsl.helpers
 
-import com.google.common.base.Strings
 import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.JobManagement
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 
 /**
  * Builds up perms in a closure. So that it be used to build a withXml block
@@ -25,7 +25,7 @@ class AuthorizationContext extends AbstractContext {
     }
 
     void permission(String permission) {
-        checkArgument(!Strings.isNullOrEmpty(permission), 'permission must not be null or empty')
+        checkNotNullOrEmpty(permission, 'permission must not be null or empty')
         checkArgument(permission.contains(':'), 'permission must be <permission>:<user>')
 
         String[] permissionAndUser = permission.split(':', 2)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -6,9 +6,10 @@ import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.RequiresPlugin
 
-import static com.google.common.base.Preconditions.checkArgument
-import static com.google.common.base.Preconditions.checkNotNull
 import static java.util.UUID.randomUUID
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNull
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 
 class BuildParametersContext extends AbstractContext {
     Map<String, Node> buildParameterNodes = [:]
@@ -26,10 +27,8 @@ class BuildParametersContext extends AbstractContext {
                       boolean sortZtoA = false, String maxTagsToDisplay = 'all', String defaultValue = null,
                       String description = null) {
         checkArgument(!buildParameterNodes.containsKey(parameterName), 'parameter $parameterName already defined')
-        checkNotNull(parameterName, 'parameterName cannot be null')
-        checkArgument(parameterName.length() > 0)
-        checkNotNull(scmUrl, 'scmUrl cannot be null')
-        checkArgument(scmUrl.length() > 0)
+        checkNotNullOrEmpty(parameterName, 'parameterName cannot be null or empty')
+        checkNotNullOrEmpty(scmUrl, 'scmUrl cannot be null or empty')
 
         Node definitionNode = new Node(null, 'hudson.scm.listtagsparameter.ListSubversionTagsParameterDefinition')
         definitionNode.appendNode('name', parameterName)
@@ -51,8 +50,7 @@ class BuildParametersContext extends AbstractContext {
 
     void choiceParam(String parameterName, List<String> options, String description = null) {
         checkArgument(!buildParameterNodes.containsKey(parameterName), 'parameter $parameterName already defined')
-        checkNotNull(parameterName, 'parameterName cannot be null')
-        checkArgument(parameterName.length() > 0)
+        checkNotNullOrEmpty(parameterName, 'parameterName cannot be null or empty')
         checkNotNull(options, 'options cannot be null')
         checkArgument(options.size() > 0, 'at least one option must be specified')
 
@@ -75,8 +73,7 @@ class BuildParametersContext extends AbstractContext {
 
     void fileParam(String fileLocation, String description = null) {
         checkArgument(!buildParameterNodes.containsKey(fileLocation), 'parameter $fileLocation already defined')
-        checkNotNull(fileLocation, 'fileLocation cannot be null')
-        checkArgument(fileLocation.length() > 0)
+        checkNotNullOrEmpty(fileLocation, 'fileLocation cannot be null or empty')
 
         Node definitionNode = new Node(null, 'hudson.model.FileParameterDefinition')
         definitionNode.appendNode('name', fileLocation)
@@ -89,10 +86,8 @@ class BuildParametersContext extends AbstractContext {
 
     void runParam(String parameterName, String jobToRun, String description = null, String filter = null) {
         checkArgument(!buildParameterNodes.containsKey(parameterName), 'parameter $parameterName already defined')
-        checkNotNull(parameterName, 'parameterName cannot be null')
-        checkArgument(parameterName.length() > 0)
-        checkNotNull(jobToRun, 'jobToRun cannot be null')
-        checkArgument(jobToRun.length() > 0)
+        checkNotNullOrEmpty(parameterName, 'parameterName cannot be null or empty')
+        checkNotNullOrEmpty(jobToRun, 'jobToRun cannot be null or empty')
 
         Node definitionNode = new Node(null, 'hudson.model.RunParameterDefinition')
         definitionNode.appendNode('name', parameterName)
@@ -113,8 +108,7 @@ class BuildParametersContext extends AbstractContext {
     @RequiresPlugin(id = 'nodelabelparameter')
     void labelParam(String parameterName, @DslContext(LabelParamContext) Closure labelParamClosure = null) {
         checkArgument(!buildParameterNodes.containsKey(parameterName), 'parameter $parameterName already defined')
-        checkNotNull(parameterName, 'parameterName cannot be null')
-        checkArgument(parameterName.length() > 0)
+        checkNotNullOrEmpty(parameterName, 'parameterName cannot be null or empty')
 
         LabelParamContext context = new LabelParamContext()
         ContextHelper.executeInContext(labelParamClosure, context)
@@ -136,8 +130,7 @@ class BuildParametersContext extends AbstractContext {
     @RequiresPlugin(id = 'nodelabelparameter')
     void nodeParam(String parameterName, @DslContext(NodeParamContext) Closure nodeParamClosure = null) {
         checkArgument(!buildParameterNodes.containsKey(parameterName), 'parameter $parameterName already defined')
-        checkNotNull(parameterName, 'parameterName cannot be null')
-        checkArgument(parameterName.length() > 0)
+        checkNotNullOrEmpty(parameterName, 'parameterName cannot be null or empty')
 
         NodeParamContext context = new NodeParamContext()
         ContextHelper.executeInContext(nodeParamClosure, context)
@@ -166,8 +159,7 @@ class BuildParametersContext extends AbstractContext {
     @RequiresPlugin(id = 'git-parameter', minimumVersion = '0.4.0')
     void gitParam(String parameterName, @DslContext(GitParamContext) Closure closure = null) {
         checkArgument(!buildParameterNodes.containsKey(parameterName), 'parameter $parameterName already defined')
-        checkNotNull(parameterName, 'parameterName cannot be null')
-        checkArgument(parameterName.length() > 0)
+        checkNotNullOrEmpty(parameterName, 'parameterName cannot be null or empty')
 
         GitParamContext context = new GitParamContext()
         ContextHelper.executeInContext(closure, context)
@@ -195,8 +187,7 @@ class BuildParametersContext extends AbstractContext {
 
     private simpleParam(String type, String parameterName, Object defaultValue = null, String description = null) {
         checkArgument(!buildParameterNodes.containsKey(parameterName), 'parameter $parameterName already defined')
-        checkNotNull(parameterName, 'parameterName cannot be null')
-        checkArgument(parameterName.length() > 0)
+        checkNotNullOrEmpty(parameterName, 'parameterName cannot be null or empty')
 
         Node definitionNode = new Node(null, type)
         definitionNode.appendNode('name', parameterName)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/GitParamContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/GitParamContext.groovy
@@ -2,7 +2,7 @@ package javaposse.jobdsl.dsl.helpers
 
 import javaposse.jobdsl.dsl.Context
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 final class GitParamContext implements Context {
     private static final Set<String> VALID_TYPES = [

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/LabelParamContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/LabelParamContext.groovy
@@ -2,7 +2,7 @@ package javaposse.jobdsl.dsl.helpers
 
 import javaposse.jobdsl.dsl.Context
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class LabelParamContext implements Context {
     private static final List<String> ELIGIBILITY = [

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/NodeParamContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/NodeParamContext.groovy
@@ -2,7 +2,7 @@ package javaposse.jobdsl.dsl.helpers
 
 import javaposse.jobdsl.dsl.Context
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class NodeParamContext implements Context {
     private static final List<String> ELIGIBILITY = [

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/ScmContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/ScmContext.groovy
@@ -1,6 +1,5 @@
 package javaposse.jobdsl.dsl.helpers
 
-import com.google.common.base.Strings
 import hudson.util.VersionNumber
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.Item
@@ -14,10 +13,11 @@ import javaposse.jobdsl.dsl.helpers.scm.PerforcePasswordEncryptor
 import javaposse.jobdsl.dsl.helpers.scm.RTCContext
 import javaposse.jobdsl.dsl.helpers.scm.SvnContext
 
-import static com.google.common.base.Preconditions.checkArgument
-import static com.google.common.base.Preconditions.checkNotNull
-import static com.google.common.base.Preconditions.checkState
 import static javaposse.jobdsl.dsl.ContextHelper.executeInContext
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNull
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
+import static javaposse.jobdsl.dsl.Preconditions.checkState
 import static javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.validCloneWorkspaceCriteria
 
 class ScmContext extends AbstractExtensibleContext {
@@ -44,7 +44,7 @@ class ScmContext extends AbstractExtensibleContext {
         jobManagement.logPluginDeprecationWarning('mercurial', '1.50.1')
 
         if (jobManagement.getPluginVersion('mercurial')?.isOlderThan(new VersionNumber('1.50.1'))) {
-            checkNotNull(url)
+            checkNotNull(url, 'url must not be null')
 
             Node scmNode = new NodeBuilder().scm(class: 'hudson.plugins.mercurial.MercurialSCM') {
                 source url
@@ -78,7 +78,7 @@ class ScmContext extends AbstractExtensibleContext {
         HgContext hgContext = new HgContext(jobManagement)
         executeInContext(hgClosure, hgContext)
 
-        checkArgument(!Strings.isNullOrEmpty(url), 'url must be specified')
+        checkNotNullOrEmpty(url, 'url must be specified')
         checkArgument(!(hgContext.tag && hgContext.branch), 'either tag or branch should be used, not both')
 
         Node scmNode = new NodeBuilder().scm(class: 'hudson.plugins.mercurial.MercurialSCM') {
@@ -236,8 +236,8 @@ class ScmContext extends AbstractExtensibleContext {
     }
 
     void svn(String svnUrl, String localDir, Closure configure = null) {
-        checkNotNull(svnUrl)
-        checkNotNull(localDir)
+        checkNotNull(svnUrl, 'svnUrl must not be null')
+        checkNotNull(localDir, 'localDir must not be null')
 
         svn {
             location(svnUrl) {
@@ -285,7 +285,7 @@ class ScmContext extends AbstractExtensibleContext {
 
     @RequiresPlugin(id = 'perforce')
     void p4(String viewspec, String user, String password, Closure configure = null) {
-        checkNotNull(viewspec)
+        checkNotNull(viewspec, 'viewspec must not be null')
 
         Node p4Node = new NodeBuilder().scm(class: 'hudson.plugins.perforce.PerforceSCM') {
             p4User user
@@ -333,9 +333,11 @@ class ScmContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'clone-workspace-scm')
     void cloneWorkspace(String parentProject, String criteriaArg = 'Any') {
-        checkNotNull(parentProject)
-        checkArgument(validCloneWorkspaceCriteria.contains(criteriaArg),
-                "Clone Workspace Criteria needs to be one of these values: ${validCloneWorkspaceCriteria.join(',')}")
+        checkNotNull(parentProject, 'parentProject must not be null')
+        checkArgument(
+                validCloneWorkspaceCriteria.contains(criteriaArg),
+                "Clone Workspace Criteria needs to be one of these values: ${validCloneWorkspaceCriteria.join(',')}"
+        )
 
         scmNodes << new NodeBuilder().scm(class: 'hudson.plugins.cloneworkspace.CloneWorkspaceSCM') {
             parentJobName(parentProject)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/DownstreamContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/DownstreamContext.groovy
@@ -1,10 +1,10 @@
 package javaposse.jobdsl.dsl.helpers.common
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.helpers.common.DownstreamTriggerContext.BlockingThreshold
 
 class DownstreamContext extends AbstractContext {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/DownstreamTriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/DownstreamTriggerContext.groovy
@@ -1,8 +1,8 @@
 package javaposse.jobdsl.dsl.helpers.common
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.RequiresPlugin
 
 import static DownstreamContext.THRESHOLD_COLOR_MAP

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/PublishOverSshContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/PublishOverSshContext.groovy
@@ -4,7 +4,7 @@ import javaposse.jobdsl.dsl.Context
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class PublishOverSshContext implements Context {
     final List<PublishOverSshServerContext> servers = []

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/PublishOverSshServerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/PublishOverSshServerContext.groovy
@@ -4,8 +4,8 @@ import javaposse.jobdsl.dsl.Context
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 
-import static com.google.common.base.Preconditions.checkArgument
 import static com.google.common.base.Strings.isNullOrEmpty
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class PublishOverSshServerContext implements Context {
     final String name

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/properties/PropertiesContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/properties/PropertiesContext.groovy
@@ -1,11 +1,10 @@
 package javaposse.jobdsl.dsl.helpers.properties
 
-import com.google.common.base.Preconditions
-import com.google.common.base.Strings
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.RequiresPlugin
 import javaposse.jobdsl.dsl.helpers.AbstractExtensibleContext
 
@@ -43,7 +42,7 @@ class PropertiesContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'custom-job-icon', minimumVersion = '0.2')
     void customIcon(String iconFileName) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(iconFileName), 'iconFileName must be specified')
+        Preconditions.checkNotNullOrEmpty(iconFileName, 'iconFileName must be specified')
 
         propertiesNodes << new NodeBuilder().'jenkins.plugins.jobicon.CustomIconProperty' {
             iconfile(iconFileName)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/properties/SidebarLinkContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/properties/SidebarLinkContext.groovy
@@ -1,15 +1,14 @@
 package javaposse.jobdsl.dsl.helpers.properties
 
-import com.google.common.base.Preconditions
-import com.google.common.base.Strings
 import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.Preconditions
 
 class SidebarLinkContext implements Context {
     final List<Node> links = []
 
     void link(String url, String text, String icon = null) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(url), 'url must be specified')
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(text), 'text must be specified')
+        Preconditions.checkNotNullOrEmpty(url, 'url must be specified')
+        Preconditions.checkNotNullOrEmpty(text, 'text must be specified')
 
         links << new NodeBuilder().'hudson.plugins.sidebar__link.LinkAction' {
             delegate.url(url)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/CoberturaContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/CoberturaContext.groovy
@@ -3,8 +3,8 @@ package javaposse.jobdsl.dsl.helpers.publisher
 import groovy.transform.PackageScope
 import javaposse.jobdsl.dsl.Context
 
-import static com.google.common.base.Preconditions.checkArgument
-import static com.google.common.base.Preconditions.checkNotNull
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNull
 
 class CoberturaContext implements Context {
     boolean onlyStable = false

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/EmailContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/EmailContext.groovy
@@ -2,7 +2,7 @@ package javaposse.jobdsl.dsl.helpers.publisher
 
 import javaposse.jobdsl.dsl.Context
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class EmailContext implements Context {
     Set<String> emailTriggerNames = [

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/EmmaContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/EmmaContext.groovy
@@ -2,7 +2,7 @@ package javaposse.jobdsl.dsl.helpers.publisher
 
 import javaposse.jobdsl.dsl.Context
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class EmmaContext implements Context {
     IntRange classRange = 0..100

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/FlowdockPublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/FlowdockPublisherContext.groovy
@@ -1,7 +1,7 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.Preconditions
 
 class FlowdockPublisherContext implements Context {
     List<String> notificationTags = []

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/GitPublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/GitPublisherContext.groovy
@@ -6,8 +6,7 @@ import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.RequiresPlugin
 
-import static com.google.common.base.Preconditions.checkArgument
-import static com.google.common.base.Strings.isNullOrEmpty
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 
 class GitPublisherContext extends AbstractContext {
     boolean pushOnlyIfSuccess
@@ -37,8 +36,8 @@ class GitPublisherContext extends AbstractContext {
     }
 
     void tag(String targetRepo, String name, @DslContext(TagToPushContext) Closure closure = null) {
-        checkArgument(!isNullOrEmpty(targetRepo), 'targetRepo must be specified')
-        checkArgument(!isNullOrEmpty(name), 'name must be specified')
+        checkNotNullOrEmpty(targetRepo, 'targetRepo must be specified')
+        checkNotNullOrEmpty(name, 'name must be specified')
 
         TagToPushContext context = new TagToPushContext()
         ContextHelper.executeInContext(closure, context)
@@ -53,8 +52,8 @@ class GitPublisherContext extends AbstractContext {
     }
 
     void branch(String targetRepo, String name) {
-        checkArgument(!isNullOrEmpty(targetRepo), 'targetRepo must be specified')
-        checkArgument(!isNullOrEmpty(name), 'name must be specified')
+        checkNotNullOrEmpty(targetRepo, 'targetRepo must be specified')
+        checkNotNullOrEmpty(name, 'name must be specified')
 
         branches << NodeBuilder.newInstance().'hudson.plugins.git.GitPublisher_-BranchToPush' {
             targetRepoName(targetRepo)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/HtmlReportContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/HtmlReportContext.groovy
@@ -1,12 +1,10 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import com.google.common.base.Strings
 import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.JobManagement
-
-import static com.google.common.base.Preconditions.checkArgument
+import javaposse.jobdsl.dsl.Preconditions
 
 class HtmlReportContext extends AbstractContext {
     final List<HtmlReportTargetContext> targets = []
@@ -16,7 +14,7 @@ class HtmlReportContext extends AbstractContext {
     }
 
     void report(String reportDir, @DslContext(HtmlReportTargetContext) Closure closure = null) {
-        checkArgument(!Strings.isNullOrEmpty(reportDir), 'Report directory for html publisher is required')
+        Preconditions.checkNotNullOrEmpty(reportDir, 'Report directory for html publisher is required')
 
         HtmlReportTargetContext context = new HtmlReportTargetContext(jobManagement, reportDir)
         ContextHelper.executeInContext(closure, context)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/IrcContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/IrcContext.groovy
@@ -1,8 +1,10 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import com.google.common.base.Preconditions
 import groovy.transform.Canonical
 import javaposse.jobdsl.dsl.Context
+
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 
 class IrcContext implements Context {
     List<IrcPublisherChannel> channels = []
@@ -31,7 +33,7 @@ class IrcContext implements Context {
     }
 
     void channel(String name, String password = '', boolean notificationOnly = false) {
-        Preconditions.checkArgument(name != null && name.length() > 0, 'Channel name for irc channel is required!')
+        checkNotNullOrEmpty(name, 'Channel name for irc channel is required!')
 
         channels << new IrcPublisherChannel(
             name: name,
@@ -45,15 +47,13 @@ class IrcContext implements Context {
     }
 
     void strategy(String strategy) {
-        Preconditions.checkArgument(
-            strategies.contains(strategy), "Possible values: ${strategies.join(',')}"
-        )
+        checkArgument(strategies.contains(strategy), "Possible values: ${strategies.join(',')}")
 
         this.strategy = strategy
     }
 
     void notificationMessage(String notificationMessage) {
-        Preconditions.checkArgument(
+        checkArgument(
             notificationMessages.contains(notificationMessage),
             "Possible values: ${notificationMessages.join(',')}"
         )

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/JoinTriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/JoinTriggerContext.groovy
@@ -1,11 +1,11 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.Preconditions
 
 class JoinTriggerContext extends AbstractContext {
     final List<String> projects = []

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PlotCSVSeriesContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PlotCSVSeriesContext.groovy
@@ -1,6 +1,6 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class PlotCSVSeriesContext extends PlotSeriesContext {
     String inclusionFlag = 'OFF'

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PlotContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PlotContext.groovy
@@ -1,11 +1,11 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import com.google.common.base.Strings
-import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 
 class PlotContext implements Context {
     private static final List<String> STYLE = [
@@ -63,7 +63,7 @@ class PlotContext implements Context {
     }
 
     void csvFile(String fileName, @DslContext(PlotCSVSeriesContext) Closure plotSeriesClosure = null) {
-        checkArgument(!Strings.isNullOrEmpty(fileName), 'fileName must not be null or empty')
+        checkNotNullOrEmpty(fileName, 'fileName must not be null or empty')
 
         PlotSeriesContext plotSeriesContext = new PlotCSVSeriesContext(fileName)
         ContextHelper.executeInContext(plotSeriesClosure, plotSeriesContext)
@@ -72,7 +72,7 @@ class PlotContext implements Context {
     }
 
     void propertiesFile(String fileName, @DslContext(PlotPropertiesSeriesContext) Closure plotSeriesClosure = null) {
-        checkArgument(!Strings.isNullOrEmpty(fileName), 'fileName must not be null or empty')
+        checkNotNullOrEmpty(fileName, 'fileName must not be null or empty')
 
         PlotSeriesContext plotSeriesContext = new PlotPropertiesSeriesContext(fileName)
         ContextHelper.executeInContext(plotSeriesClosure, plotSeriesContext)
@@ -81,7 +81,7 @@ class PlotContext implements Context {
     }
 
     void xmlFile(String fileName, @DslContext(PlotXMLSeriesContext) Closure plotSeriesClosure = null) {
-        checkArgument(!Strings.isNullOrEmpty(fileName), 'fileName must not be null or empty')
+        checkNotNullOrEmpty(fileName, 'fileName must not be null or empty')
 
         PlotSeriesContext plotSeriesContext = new PlotXMLSeriesContext(fileName)
         ContextHelper.executeInContext(plotSeriesClosure, plotSeriesContext)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PlotXMLSeriesContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PlotXMLSeriesContext.groovy
@@ -1,6 +1,6 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class PlotXMLSeriesContext extends PlotSeriesContext {
     private static final List<String> NODE_TYPES = [

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PlotsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PlotsContext.groovy
@@ -1,17 +1,16 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import com.google.common.base.Preconditions
-import com.google.common.base.Strings
-import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
+import javaposse.jobdsl.dsl.Preconditions
 
 class PlotsContext implements Context {
     final List<PlotContext> plots = []
 
     void plot(String group, String dataStore, @DslContext(PlotContext) Closure plotClosure) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(group), 'group must not be null or empty')
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(dataStore), 'dataStore must not be null or empty')
+        Preconditions.checkNotNullOrEmpty(group, 'group must not be null or empty')
+        Preconditions.checkNotNullOrEmpty(dataStore, 'dataStore must not be null or empty')
 
         PlotContext plotContext = new PlotContext(group, dataStore)
         ContextHelper.executeInContext(plotClosure, plotContext)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PostBuildTaskContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PostBuildTaskContext.groovy
@@ -1,15 +1,15 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import com.google.common.base.Preconditions
 import groovy.transform.Canonical
 import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.Preconditions
 
 class PostBuildTaskContext implements Context {
     List<PostBuildTask> tasks = []
 
     void task(String logText, String script, boolean escalate = false, boolean runIfSuccessful = false) {
-        Preconditions.checkArgument(logText != null && logText.length() > 0, 'Log Text to match is required!')
-        Preconditions.checkArgument(script != null && script.length() > 0, 'Script to run is required!')
+        Preconditions.checkNotNullOrEmpty(logText, 'Log Text to match is required!')
+        Preconditions.checkNotNullOrEmpty(script, 'Script to run is required!')
 
         tasks << new PostBuildTask(
             logText: logText,

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1,7 +1,5 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import com.google.common.base.Preconditions
-import com.google.common.base.Strings
 import com.thoughtworks.xstream.io.xml.XmlFriendlyNameCoder
 import hudson.util.VersionNumber
 import javaposse.jobdsl.dsl.ContextHelper
@@ -15,8 +13,8 @@ import javaposse.jobdsl.dsl.helpers.common.BuildPipelineContext
 import javaposse.jobdsl.dsl.helpers.common.DownstreamContext
 import javaposse.jobdsl.dsl.helpers.common.PublishOverSshContext
 
-import static com.google.common.base.Preconditions.checkArgument
-import static com.google.common.base.Strings.isNullOrEmpty
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 
 class PublisherContext extends AbstractExtensibleContext {
     List<Node> publisherNodes = []
@@ -350,11 +348,11 @@ class PublisherContext extends AbstractExtensibleContext {
         ContextHelper.executeInContext(jabberClosure, jabberContext)
 
         // Validate values
-        Preconditions.checkArgument(
+        checkArgument(
                 validJabberStrategyNames.contains(jabberContext.strategyName),
                 "Jabber Strategy needs to be one of these values: ${validJabberStrategyNames.join(',')}"
         )
-        Preconditions.checkArgument(
+        checkArgument(
                 validJabberChannelNotificationNames.contains(jabberContext.channelNotificationName),
                 'Jabber Channel Notification name needs to be one of these values: ' +
                         validJabberChannelNotificationNames.join(',')
@@ -401,7 +399,7 @@ class PublisherContext extends AbstractExtensibleContext {
         ContextHelper.executeInContext(scpClosure, scpContext)
 
         // Validate values
-        Preconditions.checkArgument(!scpContext.entries.empty, 'Scp publish requires at least one entry')
+        checkArgument(!scpContext.entries.empty, 'Scp publish requires at least one entry')
 
         publisherNodes << new NodeBuilder().'be.certipost.hudson.plugin.SCPRepositoryPublisher' {
             siteName site
@@ -448,11 +446,11 @@ class PublisherContext extends AbstractExtensibleContext {
         ContextHelper.executeInContext(cloneWorkspaceClosure, cloneWorkspaceContext)
 
         // Validate values
-        Preconditions.checkArgument(
+        checkArgument(
                 validCloneWorkspaceCriteria.contains(cloneWorkspaceContext.criteria),
                 "Clone Workspace Criteria needs to be one of these values: ${validCloneWorkspaceCriteria.join(',')}"
         )
-        Preconditions.checkArgument(
+        checkArgument(
                 validCloneWorkspaceArchiveMethods.contains(cloneWorkspaceContext.archiveMethod),
                 'Clone Workspace Archive Method needs to be one of these values: ' +
                         validCloneWorkspaceArchiveMethods.join(',')
@@ -474,7 +472,7 @@ class PublisherContext extends AbstractExtensibleContext {
      * Downstream build
      */
     void downstream(String projectName, String thresholdName = 'SUCCESS') {
-        Preconditions.checkArgument(
+        checkArgument(
                 DownstreamContext.THRESHOLD_COLOR_MAP.containsKey(thresholdName),
                 "thresholdName must be one of these values ${DownstreamContext.THRESHOLD_COLOR_MAP.keySet().join(',')}"
         )
@@ -929,11 +927,8 @@ class PublisherContext extends AbstractExtensibleContext {
      * @since 1.23
      */
     void flowdock(String[] tokens, @DslContext(FlowdockPublisherContext) Closure flowdockPublisherClosure = null) {
-        // Validate values
-        Preconditions.checkArgument(
-                tokens != null && tokens.length > 0,
-                'Flowdock publish requires at least one flow token'
-        )
+        checkArgument(tokens != null && tokens.length > 0, 'Flowdock publish requires at least one flow token')
+
         flowdock(tokens.join(','), flowdockPublisherClosure)
     }
 
@@ -969,7 +964,7 @@ class PublisherContext extends AbstractExtensibleContext {
         FlexiblePublisherContext context = new FlexiblePublisherContext(jobManagement, item)
         ContextHelper.executeInContext(flexiblePublishClosure, context)
 
-        Preconditions.checkArgument(!context.actions.empty, 'no publisher or build step specified')
+        checkArgument(!context.actions.empty, 'no publisher or build step specified')
 
         publisherNodes << new NodeBuilder().'org.jenkins__ci.plugins.flexible__publish.FlexiblePublisher' {
             delegate.publishers {
@@ -1032,7 +1027,7 @@ class PublisherContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'rundeck')
     void rundeck(String jobIdentifier, @DslContext(RundeckContext) Closure rundeckClosure = null) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(jobIdentifier), 'jobIdentifier cannot be null or empty')
+        checkNotNullOrEmpty(jobIdentifier, 'jobIdentifier cannot be null or empty')
 
         RundeckContext rundeckContext = new RundeckContext()
         ContextHelper.executeInContext(rundeckClosure, rundeckContext)
@@ -1054,7 +1049,7 @@ class PublisherContext extends AbstractExtensibleContext {
     void s3(String profile, @DslContext(S3BucketPublisherContext) Closure s3PublisherClosure) {
         jobManagement.logPluginDeprecationWarning('s3', '0.7')
 
-        checkArgument(!isNullOrEmpty(profile), 'profile must be specified')
+        checkNotNullOrEmpty(profile, 'profile must be specified')
 
         S3BucketPublisherContext context = new S3BucketPublisherContext(jobManagement)
         ContextHelper.executeInContext(s3PublisherClosure, context)
@@ -1399,7 +1394,7 @@ class PublisherContext extends AbstractExtensibleContext {
         PublishOverSshContext publishOverSshContext = new PublishOverSshContext()
         ContextHelper.executeInContext(publishOverSshClosure, publishOverSshContext)
 
-        Preconditions.checkArgument(!publishOverSshContext.servers.empty, 'At least 1 server must be configured')
+        checkArgument(!publishOverSshContext.servers.empty, 'At least 1 server must be configured')
 
         publisherNodes << new NodeBuilder().'jenkins.plugins.publish__over__ssh.BapSshPublisherPlugin' {
             consolePrefix('SSH: ')

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/RobotFrameworkContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/RobotFrameworkContext.groovy
@@ -1,8 +1,8 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.RequiresPlugin
 
 class RobotFrameworkContext extends AbstractContext {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/S3BucketPublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/S3BucketPublisherContext.groovy
@@ -6,8 +6,8 @@ import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.JobManagement
 
-import static com.google.common.base.Preconditions.checkArgument
-import static com.google.common.base.Strings.isNullOrEmpty
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 
 class S3BucketPublisherContext extends AbstractContext {
     private static final List<String> REGIONS = [
@@ -23,8 +23,8 @@ class S3BucketPublisherContext extends AbstractContext {
     }
 
     void entry(String source, String bucketName, String region, @DslContext(S3EntryContext) Closure closure = null) {
-        checkArgument(!isNullOrEmpty(source), 'source must be specified')
-        checkArgument(!isNullOrEmpty(bucketName), 'bucket must be specified')
+        checkNotNullOrEmpty(source, 'source must be specified')
+        checkNotNullOrEmpty(bucketName, 'bucket must be specified')
 
         if (!jobManagement.getPluginVersion('s3')?.isOlderThan(new VersionNumber('0.7'))) {
             checkArgument(REGIONS.contains(region), "region must be one of ${REGIONS.join(', ')}")

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/S3EntryContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/S3EntryContext.groovy
@@ -1,7 +1,7 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.Preconditions
 
 class S3EntryContext implements Context {
     private static final List<String> STORAGE_CLASSES = ['STANDARD', 'REDUCED_REDUNDANCY']

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/StaticAnalysisContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/StaticAnalysisContext.groovy
@@ -1,7 +1,7 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.Preconditions
 
 class StaticAnalysisContext implements Context {
     private static final List<String> THRESHOLD_LIMITS = ['low', 'normal', 'high']

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/ConditionalStepsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/ConditionalStepsContext.groovy
@@ -7,7 +7,7 @@ import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.helpers.step.condition.RunCondition
 import javaposse.jobdsl.dsl.helpers.step.condition.RunConditionFactory
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class ConditionalStepsContext extends AbstractContext {
     RunCondition runCondition

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/DslContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/DslContext.groovy
@@ -1,7 +1,7 @@
 package javaposse.jobdsl.dsl.helpers.step
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.Preconditions
 
 class DslContext implements Context {
     private static final Set<String> REMOVE_JOB_ACTIONS = ['IGNORE', 'DISABLE', 'DELETE']
@@ -17,7 +17,8 @@ class DslContext implements Context {
     String lookupStrategy = 'JENKINS_ROOT'
 
     void text(String text) {
-        this.scriptText = Preconditions.checkNotNull(text)
+        Preconditions.checkNotNull(text, 'text must be specified')
+        this.scriptText = text
     }
 
     void external(String... dslScripts) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/HttpRequestContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/HttpRequestContext.groovy
@@ -2,7 +2,7 @@ package javaposse.jobdsl.dsl.helpers.step
 
 import javaposse.jobdsl.dsl.Context
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class HttpRequestContext implements Context {
     private static final Set<String> VALID_MODES = ['POST', 'GET', 'DELETE', 'PUT']

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MavenContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MavenContext.groovy
@@ -1,9 +1,9 @@
 package javaposse.jobdsl.dsl.helpers.step
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.ConfigFileType
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.helpers.LocalRepositoryLocation
 
 class MavenContext extends AbstractContext {
@@ -80,7 +80,7 @@ class MavenContext extends AbstractContext {
      */
     void providedSettings(String settingsName) {
         String settingsId = jobManagement.getConfigFileId(ConfigFileType.MavenSettings, settingsName)
-        Preconditions.checkNotNull settingsId, "Managed Maven settings with name '${settingsName}' not found"
+        Preconditions.checkNotNull(settingsId, "Managed Maven settings with name '${settingsName}' not found")
 
         this.providedSettingsId = settingsId
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContext.groovy
@@ -1,11 +1,11 @@
 package javaposse.jobdsl.dsl.helpers.step
 
-import com.google.common.base.Preconditions
 import hudson.util.VersionNumber
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.WithXmlAction
 
 class MultiJobStepContext extends StepContext {
@@ -40,7 +40,7 @@ class MultiJobStepContext extends StepContext {
             validContinuationConditions << 'ALWAYS'
         }
 
-        Preconditions.checkArgument(phaseContext.phaseName as Boolean, 'A phase needs a name')
+        Preconditions.checkNotNullOrEmpty(phaseContext.phaseName, 'A phase needs a name')
         Preconditions.checkArgument(
                 validContinuationConditions.contains(phaseContext.continuationCondition),
                 "Continuation Condition needs to be one of these values: ${validContinuationConditions.join(', ')}"

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/PhaseJobContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/PhaseJobContext.groovy
@@ -1,8 +1,8 @@
 package javaposse.jobdsl.dsl.helpers.step
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.Context
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.RequiresPlugin
 import javaposse.jobdsl.dsl.helpers.common.DownstreamTriggerContext
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/RepositoryConnectorContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/RepositoryConnectorContext.groovy
@@ -4,7 +4,7 @@ import javaposse.jobdsl.dsl.Context
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 /**
  * DSL support for the Repository Connector plugin.

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/RunConditionContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/RunConditionContext.groovy
@@ -1,8 +1,8 @@
 package javaposse.jobdsl.dsl.helpers.step
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.Context
 import javaposse.jobdsl.dsl.DslContext
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.helpers.step.condition.AlwaysRunCondition
 import javaposse.jobdsl.dsl.helpers.step.condition.BinaryLogicOperation
 import javaposse.jobdsl.dsl.helpers.step.condition.FileExistsCondition

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -1,11 +1,11 @@
 package javaposse.jobdsl.dsl.helpers.step
 
-import com.google.common.base.Preconditions
 import hudson.util.VersionNumber
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.RequiresPlugin
 import javaposse.jobdsl.dsl.WithXmlAction
 import javaposse.jobdsl.dsl.helpers.AbstractExtensibleContext
@@ -111,8 +111,10 @@ class StepContext extends AbstractExtensibleContext {
     @RequiresPlugin(id = 'sbt')
     void sbt(String sbtNameArg, String actionsArg = null, String sbtFlagsArg = null, String jvmFlagsArg = null,
              String subdirPathArg = null, Closure configure = null) {
+        Preconditions.checkNotNull(sbtNameArg, 'Please provide the name of the SBT to use')
+
         Node sbtNode = new NodeBuilder().'org.jvnet.hudson.plugins.SbtPluginBuilder' {
-            name Preconditions.checkNotNull(sbtNameArg, 'Please provide the name of the SBT to use' as Object)
+            name sbtNameArg
             jvmFlags jvmFlagsArg ?: ''
             sbtFlags sbtFlagsArg ?: ''
             actions actionsArg ?: ''
@@ -524,8 +526,8 @@ class StepContext extends AbstractExtensibleContext {
     @RequiresPlugin(id = 'Parameterized-Remote-Trigger')
     void remoteTrigger(String remoteJenkins, String jobName,
                        @DslContext(ParameterizedRemoteTriggerContext) Closure closure = null) {
-        Preconditions.checkArgument(!isNullOrEmpty(remoteJenkins), 'remoteJenkins must be specified')
-        Preconditions.checkArgument(!isNullOrEmpty(jobName), 'jobName must be specified')
+        Preconditions.checkNotNullOrEmpty(remoteJenkins, 'remoteJenkins must be specified')
+        Preconditions.checkNotNullOrEmpty(jobName, 'jobName must be specified')
 
         ParameterizedRemoteTriggerContext context = new ParameterizedRemoteTriggerContext()
         ContextHelper.executeInContext(closure, context)
@@ -655,10 +657,9 @@ class StepContext extends AbstractExtensibleContext {
 
     @RequiresPlugin(id = 'vsphere-cloud')
     private vSphereBuildStep(String server, String builder, Closure configuration) {
-        int hash = Preconditions.checkNotNull(
-                jobManagement.getVSphereCloudHash(server),
-                "vSphere server ${server} does not exist"
-        )
+        Integer hash = jobManagement.getVSphereCloudHash(server)
+        Preconditions.checkNotNull(hash, "vSphere server ${server} does not exist")
+
         stepNodes << new NodeBuilder().'org.jenkinsci.plugins.vsphere.VSphereBuildStepContainer' {
             buildStep(class: "org.jenkinsci.plugins.vsphere.builders.${builder}", configuration)
             serverName server
@@ -707,7 +708,7 @@ class StepContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'debian-package-builder', minimumVersion = '1.6.6')
     void debianPackage(String path, @DslContext(DebianContext) Closure closure = null) {
-        Preconditions.checkArgument(!isNullOrEmpty(path), 'path must be specified')
+        Preconditions.checkNotNullOrEmpty(path, 'path must be specified')
 
         DebianContext context = new DebianContext()
         ContextHelper.executeInContext(closure, context)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/condition/RunConditionFactory.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/condition/RunConditionFactory.groovy
@@ -1,7 +1,7 @@
 package javaposse.jobdsl.dsl.helpers.step.condition
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.ContextHelper
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.helpers.step.RunConditionContext
 
 class RunConditionFactory {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/condition/StatusCondition.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/condition/StatusCondition.groovy
@@ -1,6 +1,6 @@
 package javaposse.jobdsl.dsl.helpers.step.condition
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 /**
  * Generate config for a status condition.

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/toplevel/NotificationContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/toplevel/NotificationContext.groovy
@@ -5,9 +5,9 @@ import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.JobManagement
 
-import static com.google.common.base.Preconditions.checkArgument
-import static com.google.common.base.Strings.isNullOrEmpty
 import static javaposse.jobdsl.dsl.ContextHelper.executeInContext
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 
 class NotificationContext extends AbstractContext {
     private static final List<String> PROTOCOLS = ['UDP', 'TCP', 'HTTP']
@@ -25,7 +25,7 @@ class NotificationContext extends AbstractContext {
 
     void endpoint(String url, String protocol = 'HTTP', String format = 'JSON',
                   @DslContext(NotificationEndpointContext) Closure notificationEndpointClosure) {
-        checkArgument(!isNullOrEmpty(url), 'url must be specified')
+        checkNotNullOrEmpty(url, 'url must be specified')
         checkArgument(PROTOCOLS.contains(protocol), "protocol must be one of ${PROTOCOLS.join(', ')}")
         checkArgument(FORMATS.contains(format), "format must be one of ${FORMATS.join(', ')}")
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/toplevel/NotificationEndpointContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/toplevel/NotificationEndpointContext.groovy
@@ -4,7 +4,7 @@ import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.RequiresPlugin
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class NotificationEndpointContext extends AbstractContext {
     private static final List<String> EVENTS = ['all', 'started', 'completed', 'finalized']

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/RundeckTriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/RundeckTriggerContext.groovy
@@ -2,7 +2,7 @@ package javaposse.jobdsl.dsl.helpers.triggers
 
 import javaposse.jobdsl.dsl.Context
 
-import static com.google.common.base.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class RundeckTriggerContext implements Context {
     private static final Set<String> VALID_EXECUTION_STATUSES = [

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
@@ -1,12 +1,11 @@
 package javaposse.jobdsl.dsl.helpers.triggers
 
-import com.google.common.base.Preconditions
-import com.google.common.base.Strings
 import hudson.util.VersionNumber
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.RequiresPlugin
 import javaposse.jobdsl.dsl.WithXmlAction
 import javaposse.jobdsl.dsl.helpers.AbstractExtensibleContext
@@ -94,7 +93,7 @@ class TriggerContext extends AbstractExtensibleContext {
     }
 
     void cron(String cronString) {
-        Preconditions.checkNotNull(cronString)
+        Preconditions.checkNotNull(cronString, 'cronString must be specified')
 
         triggerNodes << new NodeBuilder().'hudson.triggers.TimerTrigger' {
             spec cronString
@@ -102,7 +101,7 @@ class TriggerContext extends AbstractExtensibleContext {
     }
 
     void scm(String cronString, @DslContext(ScmTriggerContext) Closure scmTriggerClosure = null) {
-        Preconditions.checkNotNull(cronString)
+        Preconditions.checkNotNull(cronString, 'cronString must be specified')
 
         ScmTriggerContext scmTriggerContext = new ScmTriggerContext()
         ContextHelper.executeInContext(scmTriggerClosure, scmTriggerContext)
@@ -250,7 +249,7 @@ class TriggerContext extends AbstractExtensibleContext {
      * @since 1.33
      */
     void upstream(String projects, String threshold = 'SUCCESS') {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(projects), 'projects must be specified')
+        Preconditions.checkNotNullOrEmpty(projects, 'projects must be specified')
         Preconditions.checkArgument(
                 DownstreamContext.THRESHOLD_COLOR_MAP.containsKey(threshold),
                 "threshold must be one of ${DownstreamContext.THRESHOLD_COLOR_MAP.keySet().join(', ')}"

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/UrlTriggerEntryContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/UrlTriggerEntryContext.groovy
@@ -1,9 +1,10 @@
 package javaposse.jobdsl.dsl.helpers.triggers
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.Context
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
+import javaposse.jobdsl.dsl.DslScriptException
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.helpers.triggers.UrlTriggerInspectionContext.Inspection
 
 /**
@@ -43,10 +44,8 @@ class UrlTriggerEntryContext implements Context {
      * @param url Required URL to monitor
      */
     UrlTriggerEntryContext(String url) {
-        this.url = Preconditions.checkNotNull(url, 'The URL is required for urlTrigger()')
-        Preconditions.checkArgument(url != '', 'URL must not be empty.')
-        this.statusCode = statusCode
-        this.timeout = timeout
+        Preconditions.checkNotNullOrEmpty(url, 'The URL is required for urlTrigger')
+        this.url = url
     }
 
     /**
@@ -95,15 +94,13 @@ class UrlTriggerEntryContext implements Context {
      * @param performCheck check to perform
      */
     void check(String performCheck) {
-        Check check
+        Preconditions.checkNotNull(performCheck, 'Check must not be null')
 
         try {
-            check = Preconditions.checkNotNull(Check.valueOf(performCheck), 'Check must not be null' as Object)
-        } catch (IllegalArgumentException iae) {
-            throw new IllegalArgumentException("Check must be one of: ${Check.values()}")
+            checks << Check.valueOf(performCheck)
+        } catch (IllegalArgumentException ignore) {
+            throw new DslScriptException("Check must be one of: ${Check.values()}")
         }
-
-        checks << check
     }
 
     /**
@@ -119,11 +116,13 @@ class UrlTriggerEntryContext implements Context {
      * @param inspectionClosure for configuring RegExps/Path expressions for xml, text and json
      */
     void inspection(String type, @DslContext(UrlTriggerInspectionContext) Closure inspectionClosure = null) {
+        Preconditions.checkNotNull(type, 'Inspection must not be null')
+
         Inspection itype
         try {
-            itype = Preconditions.checkNotNull(Inspection.valueOf(type), 'Inspection must not be null' as Object)
-        } catch (IllegalArgumentException iae) {
-            throw new IllegalArgumentException("Inspection must be one of ${Inspection.values()}")
+            itype = Inspection.valueOf(type)
+        } catch (IllegalArgumentException ignore) {
+            throw new DslScriptException("Inspection must be one of ${Inspection.values()}")
         }
 
         UrlTriggerInspectionContext inspection = new UrlTriggerInspectionContext(itype)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/UrlTriggerInspectionContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/UrlTriggerInspectionContext.groovy
@@ -1,7 +1,8 @@
 package javaposse.jobdsl.dsl.helpers.triggers
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.DslScriptException
+import javaposse.jobdsl.dsl.Preconditions
 
 import java.util.regex.Pattern
 import java.util.regex.PatternSyntaxException
@@ -42,7 +43,8 @@ class UrlTriggerInspectionContext implements Context {
     List<String> expressions = []
 
     UrlTriggerInspectionContext(Inspection type) {
-        this.type = Preconditions.checkNotNull(type, 'Inspection type must not be null!')
+        Preconditions.checkNotNull(type, 'Inspection type must not be null!')
+        this.type = type
     }
 
     /**
@@ -50,9 +52,8 @@ class UrlTriggerInspectionContext implements Context {
      * @param path expression to add
      */
     void path(String path) {
-        String p = Preconditions.checkNotNull(path, 'Path must not be null')
-        Preconditions.checkArgument(!p.empty, 'Path given must not be empty')
-        expressions << p
+        Preconditions.checkNotNullOrEmpty(path, 'Path must not be null or empty')
+        expressions << path
     }
 
     /**
@@ -63,12 +64,11 @@ class UrlTriggerInspectionContext implements Context {
      * @param exp regular expression to add
      */
     void regexp(String exp) {
-        String expr = Preconditions.checkNotNull(exp, 'Regular expression must not be null')
-        Preconditions.checkArgument(!expr.empty, 'Regular expressions must not be empty')
+        Preconditions.checkNotNullOrEmpty(exp, 'Regular expression must not be null or empty')
         try {
-            Pattern.compile(expr)
+            Pattern.compile(exp)
         } catch (PatternSyntaxException pse) {
-            throw new IllegalArgumentException("Syntax of pattern ${exp} is invalid: ${pse.message}")
+            throw new DslScriptException("Syntax of pattern ${exp} is invalid: ${pse.message}")
         }
 
         expressions << exp

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/ConfigFilesContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/ConfigFilesContext.groovy
@@ -1,11 +1,11 @@
 package javaposse.jobdsl.dsl.helpers.wrapper
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.ConfigFileType
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.Preconditions
 
 class ConfigFilesContext extends AbstractContext {
     List<ConfigFileContext> configFiles = []

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/LogFileSizeCheckerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/LogFileSizeCheckerContext.groovy
@@ -1,7 +1,7 @@
 package javaposse.jobdsl.dsl.helpers.wrapper
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.Preconditions
 
 /**
  * DSL supporting the Log file size checker plugin.

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -1,12 +1,11 @@
 package javaposse.jobdsl.dsl.helpers.wrapper
 
-import com.google.common.base.Preconditions
-import com.google.common.base.Strings
 import hudson.util.VersionNumber
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.RequiresPlugin
 import javaposse.jobdsl.dsl.WithXmlAction
 import javaposse.jobdsl.dsl.helpers.AbstractExtensibleContext
@@ -215,7 +214,7 @@ class WrapperContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'xvfb')
     void xvfb(String installation, @DslContext(XvfbContext) Closure closure = null) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(installation), 'installation must not be null or empty')
+        Preconditions.checkNotNullOrEmpty(installation, 'installation must not be null or empty')
 
         XvfbContext context = new XvfbContext()
         ContextHelper.executeInContext(closure, context)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/jobs/MavenJob.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/jobs/MavenJob.groovy
@@ -1,11 +1,11 @@
 package javaposse.jobdsl.dsl.jobs
 
-import com.google.common.base.Preconditions
 import javaposse.jobdsl.dsl.ConfigFileType
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.Job
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.WithXmlAction
 import javaposse.jobdsl.dsl.helpers.LocalRepositoryLocation
 import javaposse.jobdsl.dsl.helpers.common.MavenContext

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/BuildPipelineView.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/BuildPipelineView.groovy
@@ -3,8 +3,8 @@ package javaposse.jobdsl.dsl.views
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.View
 
-import static com.google.common.base.Preconditions.checkArgument
-import static com.google.common.base.Preconditions.checkNotNull
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNull
 
 class BuildPipelineView extends View {
     BuildPipelineView(JobManagement jobManagement) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/DeliveryPipelinesContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/DeliveryPipelinesContext.groovy
@@ -2,22 +2,21 @@ package javaposse.jobdsl.dsl.views
 
 import javaposse.jobdsl.dsl.Context
 
-import static com.google.common.base.Preconditions.checkArgument
-import static com.google.common.base.Strings.isNullOrEmpty
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 
 class DeliveryPipelinesContext implements Context {
     Map<String, String> components = [:]
     List<String> regularExpressions = []
 
     void component(String name, String initialJobName) {
-        checkArgument(!isNullOrEmpty(name), 'name must be specified')
-        checkArgument(!isNullOrEmpty(initialJobName), 'initialJobName must be specified')
+        checkNotNullOrEmpty(name, 'name must be specified')
+        checkNotNullOrEmpty(initialJobName, 'initialJobName must be specified')
 
         components[name] = initialJobName
     }
 
     void regex(String regex) {
-        checkArgument(!isNullOrEmpty(regex), 'regex must be specified')
+        checkNotNullOrEmpty(regex, 'regex must be specified')
 
         regularExpressions << regex
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/JobsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/JobsContext.groovy
@@ -2,7 +2,7 @@ package javaposse.jobdsl.dsl.views
 
 import javaposse.jobdsl.dsl.Context
 
-import static com.google.common.base.Preconditions.checkNotNull
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNull
 
 class JobsContext implements Context {
     Set<String> jobNames = []

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ListView.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ListView.groovy
@@ -4,9 +4,9 @@ import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.View
 
-import static com.google.common.base.Preconditions.checkNotNull
 import static java.lang.String.CASE_INSENSITIVE_ORDER
 import static javaposse.jobdsl.dsl.ContextHelper.executeInContext
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNull
 
 class ListView extends View {
     private final JobsContext jobsContext = new JobsContext()

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ListViewSectionContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ListViewSectionContext.groovy
@@ -4,8 +4,8 @@ import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.JobManagement
 
-import static com.google.common.base.Preconditions.checkArgument
 import static javaposse.jobdsl.dsl.ContextHelper.executeInContext
+import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class ListViewSectionContext extends AbstractContext {
     private static final List<String> VALID_WIDTHS = ['FULL', 'HALF', 'THIRD', 'TWO_THIRDS']

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/NestedViewsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/NestedViewsContext.groovy
@@ -1,10 +1,9 @@
 package javaposse.jobdsl.dsl.views
 
-import com.google.common.base.Preconditions
-import com.google.common.base.Strings
 import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.Preconditions
 import javaposse.jobdsl.dsl.RequiresPlugin
 import javaposse.jobdsl.dsl.View
 import javaposse.jobdsl.dsl.ViewFactory
@@ -32,7 +31,7 @@ class NestedViewsContext extends AbstractContext implements ViewFactory {
     void view(Map<String, Object> arguments = [:], String name, @DslContext(View) Closure closure) {
         jobManagement.logDeprecationWarning()
 
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(name), 'name must be specified')
+        Preconditions.checkNotNullOrEmpty(name, 'name must be specified')
 
         ViewType viewType = arguments['type'] as ViewType ?: ViewType.ListView
         View view = viewType.viewClass.newInstance(jobManagement)
@@ -103,7 +102,7 @@ class NestedViewsContext extends AbstractContext implements ViewFactory {
     }
 
     private <T extends View> T processView(String name, Class<T> viewClass, Closure closure) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(name), 'name must be specified')
+        Preconditions.checkNotNullOrEmpty(name, 'name must be specified')
 
         T view = viewClass.newInstance(jobManagement)
         view.name = name

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
@@ -18,7 +18,7 @@ class AbstractJobManagementSpec extends Specification {
         script.run()
 
         then:
-        buffer.toString().trim() == 'Warning: testMethod is deprecated (DSL script, line 1)'
+        buffer.toString().trim() == 'Warning: (DSL script, line 1) testMethod is deprecated'
     }
 
     def 'deprecation warning in source file'() {
@@ -33,7 +33,7 @@ class AbstractJobManagementSpec extends Specification {
         groovyScriptEngine.run('deprecation.groovy', new Binding([jm: jobManagement]))
 
         then:
-        buffer.toString().trim() == 'Warning: testMethod is deprecated (deprecation.groovy, line 1)'
+        buffer.toString().trim() == 'Warning: (deprecation.groovy, line 1) testMethod is deprecated'
     }
 
     def 'deprecation warning with custom subject in DSL script'() {
@@ -49,7 +49,7 @@ class AbstractJobManagementSpec extends Specification {
         script.run()
 
         then:
-        buffer.toString().trim() == 'Warning: foo is deprecated (DSL script, line 3)'
+        buffer.toString().trim() == 'Warning: (DSL script, line 3) foo is deprecated'
     }
 
     def 'deprecation warning with custom subject  in source file'() {
@@ -64,7 +64,7 @@ class AbstractJobManagementSpec extends Specification {
         groovyScriptEngine.run('deprecation-subject.groovy', new Binding([jm: jobManagement]))
 
         then:
-        buffer.toString().trim() == 'Warning: foo is deprecated (deprecation-subject.groovy, line 3)'
+        buffer.toString().trim() == 'Warning: (deprecation-subject.groovy, line 3) foo is deprecated'
     }
 
     def 'custom deprecation warning in DSL script'() {
@@ -76,7 +76,7 @@ class AbstractJobManagementSpec extends Specification {
         jobManagement.logDeprecationWarning('foo', 'script123123123.groovy', 12)
 
         then:
-        buffer.toString().trim() == 'Warning: foo is deprecated (DSL script, line 12)'
+        buffer.toString().trim() == 'Warning: (DSL script, line 12) foo is deprecated'
     }
 
     def 'custom deprecation warning in source file'() {
@@ -88,7 +88,7 @@ class AbstractJobManagementSpec extends Specification {
         jobManagement.logDeprecationWarning('foo', 'test.groovy', 12)
 
         then:
-        buffer.toString().trim() == 'Warning: foo is deprecated (test.groovy, line 12)'
+        buffer.toString().trim() == 'Warning: (test.groovy, line 12) foo is deprecated'
     }
 
     static class TestJobManagement extends MockJobManagement {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/ConfigFileSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/ConfigFileSpec.groovy
@@ -33,7 +33,7 @@ class ConfigFileSpec extends Specification {
         configFile.comment(null)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'set content'() {
@@ -49,6 +49,6 @@ class ConfigFileSpec extends Specification {
         configFile.content(null)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslExceptionSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslExceptionSpec.groovy
@@ -1,0 +1,25 @@
+package javaposse.jobdsl.dsl
+
+import spock.lang.Specification
+
+class DslExceptionSpec extends Specification {
+    def 'constructor with message'() {
+        when:
+        Exception e = new DslException('foo')
+
+        then:
+        e.message == 'foo'
+    }
+
+    def 'constructor with message and cause'() {
+        setup:
+        Throwable cause = new Exception()
+
+        when:
+        Exception e = new DslException('foo', cause)
+
+        then:
+        e.message == 'foo'
+        e.cause == cause
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslScriptExceptionSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslScriptExceptionSpec.groovy
@@ -1,0 +1,25 @@
+package javaposse.jobdsl.dsl
+
+import spock.lang.Specification
+
+class DslScriptExceptionSpec extends Specification {
+    def 'constructor with message'() {
+        when:
+        Exception e = new DslScriptException('foo')
+
+        then:
+        e.message =~ /\(.+, line \d+\) foo/
+    }
+
+    def 'constructor with message and cause'() {
+        setup:
+        Throwable cause = new Exception()
+
+        when:
+        Exception e = new DslScriptException('foo', cause)
+
+        then:
+        e.message =~ /\(.+, line \d+\) foo/
+        e.cause == cause
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobParentSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobParentSpec.groovy
@@ -429,13 +429,13 @@ class JobParentSpec extends Specification {
         parent.readFileFromWorkspace(null)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         parent.readFileFromWorkspace('')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'streamFileFromWorkspace'() {
@@ -452,13 +452,13 @@ class JobParentSpec extends Specification {
         parent.readFileFromWorkspace(null)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         parent.readFileFromWorkspace('')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'readFileInWorkspace from other job'() {
@@ -474,25 +474,25 @@ class JobParentSpec extends Specification {
         parent.readFileFromWorkspace('my-job', null)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         parent.readFileFromWorkspace('my-job', '')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         parent.readFileFromWorkspace(null, 'foo.txt')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         parent.readFileFromWorkspace('', 'foo.txt')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'freeStyleJob deprecated variant'() {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobSpec.groovy
@@ -276,7 +276,7 @@ class JobSpec extends Specification {
         }
 
         then:
-        thrown(IllegalStateException)
+        thrown(DslScriptException)
     }
 
     def 'call wrappers'() {
@@ -887,7 +887,7 @@ class JobSpec extends Specification {
         1 * jobManagement.requirePlugin('notification')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         url        | protocol | format  | event

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.dsl.helpers
 
+import javaposse.jobdsl.dsl.DslScriptException
 import javaposse.jobdsl.dsl.JobManagement
 import spock.lang.Specification
 
@@ -51,7 +52,7 @@ class BuildParametersContextSpec extends Specification {
         context.booleanParam(null, false)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'booleanParam name argument cant be empty'() {
@@ -59,7 +60,7 @@ class BuildParametersContextSpec extends Specification {
         context.booleanParam('', false)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'multiple booleanParams is just fine'() {
@@ -86,7 +87,7 @@ class BuildParametersContextSpec extends Specification {
         context.booleanParam('one')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'base listTagsParam usage'() {
@@ -155,7 +156,7 @@ class BuildParametersContextSpec extends Specification {
         context.listTagsParam(null, 'http://kenai.com/svn/myProject/tags', '^mytagsfilterregex')
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'listTagsParam name argument cant be empty'() {
@@ -163,7 +164,7 @@ class BuildParametersContextSpec extends Specification {
         context.listTagsParam('', 'http://kenai.com/svn/myProject/tags', '^mytagsfilterregex')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'listTagsParam scmUrl argument cant be null'() {
@@ -171,7 +172,7 @@ class BuildParametersContextSpec extends Specification {
         context.listTagsParam('myParameterName', null, '^mytagsfilterregex')
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'listTagsParam scmUrl argument cant be empty'() {
@@ -179,7 +180,7 @@ class BuildParametersContextSpec extends Specification {
         context.listTagsParam('myParameterName', '', '^mytagsfilterregex')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'listTagsParam tagFilterRegex argument can be null or empty'(String filter) {
@@ -210,7 +211,7 @@ class BuildParametersContextSpec extends Specification {
         context.listTagsParam('one', 'http://kenai.com/svn/myProject/tags', '')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'base choiceParam usage'() {
@@ -257,7 +258,7 @@ class BuildParametersContextSpec extends Specification {
         context.choiceParam(null, ['option 1'])
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'choiceParam name argument cant be empty'() {
@@ -265,7 +266,7 @@ class BuildParametersContextSpec extends Specification {
         context.choiceParam('', ['option 1'])
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'choiceParam options argument cant be null'() {
@@ -273,7 +274,7 @@ class BuildParametersContextSpec extends Specification {
         context.choiceParam('myParameterName', null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'choiceParam options argument cant be empty'() {
@@ -281,7 +282,7 @@ class BuildParametersContextSpec extends Specification {
         context.choiceParam('myParameterName', [])
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'choiceParam already defined'() {
@@ -290,7 +291,7 @@ class BuildParametersContextSpec extends Specification {
         context.choiceParam('one', ['foo', 'bar'])
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'base fileParam usage'() {
@@ -322,7 +323,7 @@ class BuildParametersContextSpec extends Specification {
         context.fileParam(null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'fileParam fileLocation argument cant be empty'() {
@@ -330,7 +331,7 @@ class BuildParametersContextSpec extends Specification {
         context.fileParam('')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'fileParam already defined'() {
@@ -339,7 +340,7 @@ class BuildParametersContextSpec extends Specification {
         context.fileParam('one')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'base runParam usage'() {
@@ -387,7 +388,7 @@ class BuildParametersContextSpec extends Specification {
         context.runParam(null, null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'runParam name argument cant be empty'() {
@@ -395,7 +396,7 @@ class BuildParametersContextSpec extends Specification {
         context.runParam('', '')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'runParam jobToRun argument cant be null'() {
@@ -403,7 +404,7 @@ class BuildParametersContextSpec extends Specification {
         context.runParam('myParameterName', null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'runParam jobToRun argument cant be empty'() {
@@ -411,7 +412,7 @@ class BuildParametersContextSpec extends Specification {
         context.runParam('myParameterName', '')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'runParam already defined'() {
@@ -420,7 +421,7 @@ class BuildParametersContextSpec extends Specification {
         context.runParam('one', 'job')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'base stringParam usage'() {
@@ -467,7 +468,7 @@ class BuildParametersContextSpec extends Specification {
         context.stringParam(null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'stringParam name argument cant be empty'() {
@@ -475,7 +476,7 @@ class BuildParametersContextSpec extends Specification {
         context.stringParam('')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'stringParam already defined'() {
@@ -484,7 +485,7 @@ class BuildParametersContextSpec extends Specification {
         context.stringParam('one')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'base textParam usage'() {
@@ -531,7 +532,7 @@ class BuildParametersContextSpec extends Specification {
         context.textParam(null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'textParam name argument cant be empty'() {
@@ -539,7 +540,7 @@ class BuildParametersContextSpec extends Specification {
         context.textParam('')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'textParam already defined'() {
@@ -548,7 +549,7 @@ class BuildParametersContextSpec extends Specification {
         context.textParam('one')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'nodeParam base usage'() {
@@ -613,7 +614,7 @@ class BuildParametersContextSpec extends Specification {
         context.nodeParam(null, null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'nodeParam invalid trigger'() {
@@ -623,7 +624,7 @@ class BuildParametersContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'nodeParam no name'() {
@@ -631,13 +632,13 @@ class BuildParametersContextSpec extends Specification {
         context.nodeParam('')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         context.nodeParam(null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'nodeParam already defined'() {
@@ -646,7 +647,7 @@ class BuildParametersContextSpec extends Specification {
         context.nodeParam('one')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'labelParam base usage'() {
@@ -724,7 +725,7 @@ class BuildParametersContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         trigger    | eligibility
@@ -763,7 +764,7 @@ class BuildParametersContextSpec extends Specification {
         context.labelParam(null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'labelParam name argument cant be empty'() {
@@ -771,7 +772,7 @@ class BuildParametersContextSpec extends Specification {
         context.labelParam('')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'labelParam already defined'() {
@@ -780,7 +781,7 @@ class BuildParametersContextSpec extends Specification {
         context.labelParam('one')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'gitParam already defined'() {
@@ -789,7 +790,7 @@ class BuildParametersContextSpec extends Specification {
         context.gitParam('paramName')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'gitParam name argument cant be null'() {
@@ -797,7 +798,7 @@ class BuildParametersContextSpec extends Specification {
         context.gitParam(null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'gitParam name argument cant be empty'() {
@@ -805,7 +806,7 @@ class BuildParametersContextSpec extends Specification {
         context.gitParam('')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'gitParam minimal options'() {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
@@ -1,6 +1,7 @@
 package javaposse.jobdsl.dsl.helpers
 
 import hudson.util.VersionNumber
+import javaposse.jobdsl.dsl.DslScriptException
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.WithXmlActionSpec
@@ -111,7 +112,7 @@ class ScmContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call hg branch and tag disallowed'() {
@@ -122,7 +123,7 @@ class ScmContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call hg with branch'() {
@@ -1442,7 +1443,7 @@ class ScmContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalStateException)
+        thrown(DslScriptException)
     }
 
     def 'call svn with one location'() {
@@ -1999,7 +2000,7 @@ class ScmContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call rtc with build definition'() {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/properties/PropertiesContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/properties/PropertiesContextSpec.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.dsl.helpers.properties
 
+import javaposse.jobdsl.dsl.DslScriptException
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
 import spock.lang.Specification
@@ -60,7 +61,7 @@ class PropertiesContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         url    | text
@@ -88,7 +89,7 @@ class PropertiesContextSpec extends Specification {
         context.customIcon(fileName)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         fileName << [null, '']

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -2865,7 +2865,7 @@ class PublisherContextSpec extends Specification {
 
         then:
         Exception exception = thrown(DslScriptException)
-        exception.message =~ /jobIdentifier cannot be null or empty \(.+, line \d+\)/
+        exception.message =~ /\(.+, line \d+\) jobIdentifier cannot be null or empty/
 
         where:
         id   | _

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -1,6 +1,7 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
 import hudson.util.VersionNumber
+import javaposse.jobdsl.dsl.DslScriptException
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
 import spock.lang.Specification
@@ -870,13 +871,13 @@ class PublisherContextSpec extends Specification {
         context.publishJabber('me@gmail.com', 'NOPE')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         context.publishJabber('me@gmail.com', 'ALL', 'Nope')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call Clone Workspace publish with minimal args'() {
@@ -914,13 +915,13 @@ class PublisherContextSpec extends Specification {
         context.publishCloneWorkspace('*/**', '*/.svn', 'Quite plainly wrong', 'ZIP', true)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         context.publishCloneWorkspace('*/**', '*/.svn', 'Not Failed', 'ZAP', true)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call Clone Workspace with Closure'() {
@@ -948,7 +949,7 @@ class PublisherContextSpec extends Specification {
         context.publishScp('javadoc', null)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call scp publish with closure'() {
@@ -1060,7 +1061,7 @@ class PublisherContextSpec extends Specification {
         context.downstream('THE-JOB', 'BAD')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call downstream ext with all args'() {
@@ -1157,7 +1158,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call violations plugin with no args has correct defaults'() {
@@ -1300,7 +1301,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'notifyScmFixers is set'() {
@@ -1469,7 +1470,7 @@ class PublisherContextSpec extends Specification {
             target('invalid', 1, 2, 3)
         }
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'checking for invalid cobertura target treshold: negative'() {
@@ -1478,7 +1479,7 @@ class PublisherContextSpec extends Specification {
                 target('invalid', h, u, f)
             }
         then:
-            thrown(IllegalArgumentException)
+            thrown(DslScriptException)
         where:
             h  |  u |  f
             -1 |  1 |  1
@@ -1492,7 +1493,7 @@ class PublisherContextSpec extends Specification {
                 target('invalid', h, u, f)
             }
         then:
-            thrown(IllegalArgumentException)
+            thrown(DslScriptException)
         where:
             h  |  u  |  f
            101 |  1  |  1
@@ -1506,7 +1507,7 @@ class PublisherContextSpec extends Specification {
             sourceEncoding(null)
         }
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'UTF-8 source encoding for cobertura should be the default instead of ASCII'() {
@@ -1937,7 +1938,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         context.emma('coverage-results/coverage.xml') {
@@ -1945,7 +1946,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         context.emma('coverage-results/coverage.xml') {
@@ -1953,7 +1954,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         context.emma('coverage-results/coverage.xml') {
@@ -1961,7 +1962,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         context.emma('coverage-results/coverage.xml') {
@@ -1969,7 +1970,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         context.emma('coverage-results/coverage.xml') {
@@ -1977,7 +1978,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'publish Robot framework report using default values'() {
@@ -2281,7 +2282,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         context.git {
@@ -2289,7 +2290,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call git without tag name'() {
@@ -2299,7 +2300,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         context.git {
@@ -2307,7 +2308,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call git without branch targetRepoName'() {
@@ -2317,7 +2318,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         context.git {
@@ -2325,7 +2326,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call git without branch name'() {
@@ -2335,7 +2336,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         context.git {
@@ -2343,7 +2344,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'flowdock with default notification settings'() {
@@ -2596,7 +2597,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'flowdock with multiple tokens'() {
@@ -2641,7 +2642,7 @@ class PublisherContextSpec extends Specification {
         context.flowdock(null)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'stashNotifier with default configuration'() {
@@ -2863,8 +2864,8 @@ class PublisherContextSpec extends Specification {
         context.rundeck(id)
 
         then:
-        IllegalArgumentException exception = thrown()
-        exception.message == 'jobIdentifier cannot be null or empty'
+        Exception exception = thrown(DslScriptException)
+        exception.message =~ /jobIdentifier cannot be null or empty \(.+, line \d+\)/
 
         where:
         id   | _
@@ -2892,7 +2893,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         profile << [null, '']
@@ -2905,7 +2906,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         source | bucket | region
@@ -2928,7 +2929,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         storageClass << [null, '', 'FOO']
@@ -3229,7 +3230,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call post build scripts with minimal options'() {
@@ -4002,7 +4003,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         type0            | data0 | type1            | data1
@@ -4025,7 +4026,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         group << [null, '']
@@ -4040,7 +4041,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         dataStore << [null, '']
@@ -4055,7 +4056,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         fileName << [null, '']
@@ -4071,7 +4072,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'retryBuild with no options'() {
@@ -4254,7 +4255,7 @@ class PublisherContextSpec extends Specification {
         context.publishOverSsh(null)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call publishOverSsh without transferSet'() {
@@ -4265,7 +4266,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call publishOverSsh without sourceFiles and execCommand'() {
@@ -4278,7 +4279,7 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call publishOverSsh with minimal configuration and check the default values'() {
@@ -4527,6 +4528,6 @@ class PublisherContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/StaticAnalysisContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/StaticAnalysisContextSpec.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
+import javaposse.jobdsl.dsl.DslScriptException
 import spock.lang.Specification
 
 class StaticAnalysisContextSpec extends Specification {
@@ -20,7 +21,7 @@ class StaticAnalysisContextSpec extends Specification {
         when:
         context.thresholds(thresholds)
         then:
-        IllegalArgumentException e = thrown()
+        Exception e = thrown(DslScriptException)
         e.message.contains(thresholds.toString())
         where:
         thresholds  << [

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContextSpec.groovy
@@ -1,6 +1,7 @@
 package javaposse.jobdsl.dsl.helpers.step
 
 import hudson.util.VersionNumber
+import javaposse.jobdsl.dsl.DslScriptException
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
 import spock.lang.Specification
@@ -164,7 +165,7 @@ class MultiJobStepContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalStateException)
+        thrown(DslScriptException)
 
         when:
         context.phase('Third') {
@@ -175,7 +176,7 @@ class MultiJobStepContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalStateException)
+        thrown(DslScriptException)
     }
 
     def 'call phases with plugin version 1.11 options'() {
@@ -214,7 +215,7 @@ class MultiJobStepContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call phase with unsupported condition'(String condition, String version) {
@@ -226,7 +227,7 @@ class MultiJobStepContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         condition | version

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/RunConditionContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/RunConditionContextSpec.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.dsl.helpers.step
 
+import javaposse.jobdsl.dsl.DslScriptException
 import javaposse.jobdsl.dsl.helpers.step.condition.SimpleCondition
 import spock.lang.Specification
 
@@ -12,7 +13,7 @@ class RunConditionContextSpec extends Specification {
         context.time(*args)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         args << [

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
@@ -2,6 +2,7 @@ package javaposse.jobdsl.dsl.helpers.step
 
 import hudson.util.VersionNumber
 import javaposse.jobdsl.dsl.ConfigFileType
+import javaposse.jobdsl.dsl.DslScriptException
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.helpers.LocalRepositoryLocation
@@ -425,7 +426,7 @@ class StepContextSpec extends Specification {
         }
 
         then:
-        Exception e = thrown(NullPointerException)
+        Exception e = thrown(DslScriptException)
         e.message.contains(settingsName)
     }
 
@@ -1177,7 +1178,7 @@ class StepContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call dsl with invalid remove action'() {
@@ -1187,7 +1188,7 @@ class StepContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call dsl with invalid remove view action'() {
@@ -1197,7 +1198,7 @@ class StepContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call dsl with script text and all options'() {
@@ -1368,7 +1369,7 @@ class StepContextSpec extends Specification {
         context.publishOverSsh(null)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call publishOverSsh without transferSet'() {
@@ -1379,7 +1380,7 @@ class StepContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call publishOverSsh without sourceFiles and execCommand'() {
@@ -1392,7 +1393,7 @@ class StepContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call publishOverSsh with minimal configuration and check the default values'() {
@@ -1679,7 +1680,7 @@ class StepContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     @Unroll
@@ -1777,7 +1778,7 @@ class StepContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call conditional steps with no condition'() {
@@ -1792,7 +1793,7 @@ class StepContextSpec extends Specification {
         }
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'call conditional steps with invalid condition'() {
@@ -2049,7 +2050,7 @@ class StepContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         worstResult | bestResult
@@ -2278,13 +2279,13 @@ class StepContextSpec extends Specification {
         context.remoteTrigger(null, 'test')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         context.remoteTrigger('', 'test')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call remoteTrigger without job'() {
@@ -2292,13 +2293,13 @@ class StepContextSpec extends Specification {
         context.remoteTrigger('dev-ci', null)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         when:
         context.remoteTrigger('dev-ci', '')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'critical block'() {
@@ -2454,7 +2455,7 @@ class StepContextSpec extends Specification {
         context.setBuildResult('FOO')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'vSphere power off'() {
@@ -2529,7 +2530,7 @@ class StepContextSpec extends Specification {
         context.vSpherePowerOff('vsphere.acme.org', 'foo')
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'call http request with minimal options'() {
@@ -2576,7 +2577,7 @@ class StepContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call http request with valid HTTP mode'(String mode) {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
@@ -1,6 +1,7 @@
 package javaposse.jobdsl.dsl.helpers.triggers
 
 import hudson.util.VersionNumber
+import javaposse.jobdsl.dsl.DslScriptException
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
 import spock.lang.Specification
@@ -644,7 +645,7 @@ class TriggerContextSpec extends Specification {
         context.upstream(projects, threshold)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         projects | threshold
@@ -703,6 +704,6 @@ class TriggerContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/UrlTriggerEntryContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/UrlTriggerEntryContextSpec.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.dsl.helpers.triggers
 
+import javaposse.jobdsl.dsl.DslScriptException
 import spock.lang.Specification
 
 /**
@@ -11,7 +12,7 @@ class UrlTriggerEntryContextSpec extends Specification {
         new UrlTriggerEntryContext(null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'empty URL causes IllegalArgumentException' () {
@@ -19,7 +20,7 @@ class UrlTriggerEntryContextSpec extends Specification {
         new UrlTriggerEntryContext('')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'check default values'() {
@@ -43,7 +44,7 @@ class UrlTriggerEntryContextSpec extends Specification {
         ctx.inspection('foo')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
     }
 
@@ -55,7 +56,7 @@ class UrlTriggerEntryContextSpec extends Specification {
         ctx.check('foo')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/UrlTriggerInspectionContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/UrlTriggerInspectionContextSpec.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.dsl.helpers.triggers
 
+import javaposse.jobdsl.dsl.DslScriptException
 import spock.lang.Specification
 
 import static javaposse.jobdsl.dsl.helpers.triggers.UrlTriggerInspectionContext.Inspection.json
@@ -14,7 +15,7 @@ class UrlTriggerInspectionContextSpec extends Specification {
         new UrlTriggerInspectionContext(null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'ensure that paths are not null'() {
@@ -24,7 +25,7 @@ class UrlTriggerInspectionContextSpec extends Specification {
         when:
         ctx.path(null)
 
-        then: thrown(NullPointerException)
+        then: thrown(DslScriptException)
     }
 
     def 'ensure that paths are not empty'() {
@@ -34,7 +35,7 @@ class UrlTriggerInspectionContextSpec extends Specification {
         when:
         ctx.path('')
 
-        then: thrown(IllegalArgumentException)
+        then: thrown(DslScriptException)
     }
 
     def 'ensure that RegExps are not null'() {
@@ -45,7 +46,7 @@ class UrlTriggerInspectionContextSpec extends Specification {
         ctx.regexp(null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'ensure that RegExps are not empty'() {
@@ -56,7 +57,7 @@ class UrlTriggerInspectionContextSpec extends Specification {
         ctx.regexp('')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'ensure that RegExps are compileable' () {
@@ -67,6 +68,6 @@ class UrlTriggerInspectionContextSpec extends Specification {
         ctx.regexp('(foo.+')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -2,6 +2,7 @@ package javaposse.jobdsl.dsl.helpers.wrapper
 
 import hudson.util.VersionNumber
 import javaposse.jobdsl.dsl.ConfigFileType
+import javaposse.jobdsl.dsl.DslScriptException
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
 import spock.lang.Specification
@@ -315,7 +316,7 @@ class WrapperContextSpec extends Specification {
         context.sshAgent(null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'sshAgent with invalid credentials'() {
@@ -326,7 +327,7 @@ class WrapperContextSpec extends Specification {
         context.sshAgent('foo')
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'sshAgent'() {
@@ -466,7 +467,7 @@ class WrapperContextSpec extends Specification {
         context.xvfb(installation)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
 
         where:
         installation << [null, '']
@@ -699,7 +700,7 @@ class WrapperContextSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'call injectPasswords'() {
@@ -731,7 +732,7 @@ class WrapperContextSpec extends Specification {
         context.buildName(null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'call codeSigning with no args'() {
@@ -910,7 +911,7 @@ class WrapperContextSpec extends Specification {
         }
 
         then:
-        Exception e = thrown(NullPointerException)
+        Exception e = thrown(DslScriptException)
         e.message.contains(configName)
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/jobs/MavenJobSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/jobs/MavenJobSpec.groovy
@@ -1,6 +1,7 @@
 package javaposse.jobdsl.dsl.jobs
 
 import javaposse.jobdsl.dsl.ConfigFileType
+import javaposse.jobdsl.dsl.DslScriptException
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.helpers.LocalRepositoryLocation
 import javaposse.jobdsl.dsl.helpers.common.MavenContext
@@ -97,7 +98,7 @@ class MavenJobSpec extends Specification {
         job.localRepository((MavenContext.LocalRepositoryLocation) null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'localRepository constructs xml for LocalToExecutor'() {
@@ -121,7 +122,7 @@ class MavenJobSpec extends Specification {
         job.localRepository((LocalRepositoryLocation) null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'localRepository constructs xml for LOCAL_TO_EXECUTOR'() {
@@ -194,7 +195,7 @@ class MavenJobSpec extends Specification {
         }
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'mavenInstallation constructs xml'() {
@@ -214,7 +215,7 @@ class MavenJobSpec extends Specification {
         job.providedSettings(settingsName)
 
         then:
-        Exception e = thrown(NullPointerException)
+        Exception e = thrown(DslScriptException)
         e.message.contains(settingsName)
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/BuildPipelineViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/BuildPipelineViewSpec.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.dsl.views
 
+import javaposse.jobdsl.dsl.DslScriptException
 import spock.lang.Specification
 
 import static javaposse.jobdsl.dsl.views.BuildPipelineView.OutputStyle.Lightbox
@@ -35,7 +36,7 @@ class BuildPipelineViewSpec extends Specification {
         view.displayedBuilds(0)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'displayedBuilds negative'() {
@@ -43,7 +44,7 @@ class BuildPipelineViewSpec extends Specification {
         view.displayedBuilds(-12)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'title'() {
@@ -81,7 +82,7 @@ class BuildPipelineViewSpec extends Specification {
         view.selectedJob(null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'consoleOutputLinkStyle No Arg'() {
@@ -89,7 +90,7 @@ class BuildPipelineViewSpec extends Specification {
         view.consoleOutputLinkStyle()
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'consoleOutputLinkStyle Lightbox'() {
@@ -127,7 +128,7 @@ class BuildPipelineViewSpec extends Specification {
         view.consoleOutputLinkStyle(null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'cssUrl'() {
@@ -245,7 +246,7 @@ class BuildPipelineViewSpec extends Specification {
         view.refreshFrequency(0)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'refreshFrequency negative'() {
@@ -253,7 +254,7 @@ class BuildPipelineViewSpec extends Specification {
         view.refreshFrequency(-12)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'showPipelineDefinitionHeader'() {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
@@ -1,5 +1,6 @@
 package javaposse.jobdsl.dsl.views
 
+import javaposse.jobdsl.dsl.DslScriptException
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.views.jobfilter.RegexMatchValue
 import javaposse.jobdsl.dsl.views.jobfilter.Status
@@ -84,7 +85,7 @@ class ListViewSpec extends Specification {
         view.statusFilter(null)
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'add job by name'() {
@@ -107,7 +108,7 @@ class ListViewSpec extends Specification {
         }
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
     }
 
     def 'add jobs by name'() {
@@ -131,7 +132,7 @@ class ListViewSpec extends Specification {
         }
 
         then:
-        thrown(NullPointerException)
+        thrown(DslScriptException)
 
     }
 

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ContextExtensionPoint.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ContextExtensionPoint.java
@@ -1,12 +1,13 @@
 package javaposse.jobdsl.plugin;
 
-import com.google.common.base.Preconditions;
 import groovy.lang.Closure;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Item;
 import javaposse.jobdsl.dsl.Context;
 import javaposse.jobdsl.dsl.ContextHelper;
+import javaposse.jobdsl.dsl.DslScriptException;
+import javaposse.jobdsl.dsl.Preconditions;
 import jenkins.model.Jenkins;
 
 /**
@@ -39,6 +40,7 @@ public abstract class ContextExtensionPoint implements ExtensionPoint {
      *
      * @param runnable the Groovy closure
      * @param context  the {@link Context} for the {@link Runnable}
+     * @throws DslScriptException if the runnable is not a Groovy closure
      */
     public static void executeInContext(Runnable runnable, Context context) {
         if (runnable != null) {

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
@@ -236,7 +236,7 @@ public class ExecuteDslScripts extends Builder {
                 generator.close();
             }
         } catch (DslException e) {
-            LOGGER.log(Level.FINE, String.format("Exception while processing DSL scripts: %s", e.getMessage()));
+            LOGGER.log(Level.FINE, String.format("Exception while processing DSL scripts: %s", e.getMessage()), e);
             throw new AbortException(e.getMessage());
         }
     }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -66,6 +66,7 @@ import static hudson.model.Result.UNSTABLE;
 import static hudson.model.View.createViewFromXML;
 import static hudson.security.ACL.SYSTEM;
 import static java.lang.String.format;
+import static javaposse.jobdsl.dsl.DslScriptHelper.getSourceDetails;
 import static javaposse.jobdsl.plugin.ConfigFileProviderHelper.createNewConfig;
 import static javaposse.jobdsl.plugin.ConfigFileProviderHelper.findConfig;
 import static javaposse.jobdsl.plugin.ConfigFileProviderHelper.findConfigProvider;
@@ -413,7 +414,7 @@ public final class JenkinsJobManagement extends AbstractJobManagement {
     }
 
     private void markBuildAsUnstable(String message) {
-        getOutputStream().println("Warning: " + message + " (" + getSourceDetails(getStackTrace()) + ")");
+        logWarning(message + " (" + getSourceDetails() + ")");
         build.setResult(UNSTABLE);
     }
 

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -66,7 +66,6 @@ import static hudson.model.Result.UNSTABLE;
 import static hudson.model.View.createViewFromXML;
 import static hudson.security.ACL.SYSTEM;
 import static java.lang.String.format;
-import static javaposse.jobdsl.dsl.DslScriptHelper.getSourceDetails;
 import static javaposse.jobdsl.plugin.ConfigFileProviderHelper.createNewConfig;
 import static javaposse.jobdsl.plugin.ConfigFileProviderHelper.findConfig;
 import static javaposse.jobdsl.plugin.ConfigFileProviderHelper.findConfigProvider;
@@ -414,7 +413,7 @@ public final class JenkinsJobManagement extends AbstractJobManagement {
     }
 
     private void markBuildAsUnstable(String message) {
-        logWarning(message + " (" + getSourceDetails() + ")");
+        logWarningWithDetails(message);
         build.setResult(UNSTABLE);
     }
 

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -31,6 +31,7 @@ import javaposse.jobdsl.dsl.AbstractJobManagement;
 import javaposse.jobdsl.dsl.ConfigFile;
 import javaposse.jobdsl.dsl.ConfigFileType;
 import javaposse.jobdsl.dsl.DslException;
+import javaposse.jobdsl.dsl.DslScriptException;
 import javaposse.jobdsl.dsl.JobConfigurationNotFoundException;
 import javaposse.jobdsl.dsl.NameNotProvidedException;
 import javaposse.jobdsl.dsl.UserContent;
@@ -278,14 +279,14 @@ public final class JenkinsJobManagement extends AbstractJobManagement {
             if (workspace != null) {
                 try {
                     return locateValidFileInWorkspace(workspace, relLocation).readToString();
-                } catch (IllegalStateException e) {
-                    logWarning(Messages.ReadFileFromWorkspace_JobFileNotFound(), relLocation, jobName);
+                } catch (DslScriptException e) {
+                    logWarning(format(Messages.ReadFileFromWorkspace_JobFileNotFound(), relLocation, jobName));
                 }
             } else {
-                logWarning(Messages.ReadFileFromWorkspace_WorkspaceNotFound(), relLocation, jobName);
+                logWarning(format(Messages.ReadFileFromWorkspace_WorkspaceNotFound(), relLocation, jobName));
             }
         } else {
-            logWarning(Messages.ReadFileFromWorkspace_JobNotFound(), relLocation, jobName);
+            logWarning(format(Messages.ReadFileFromWorkspace_JobNotFound(), relLocation, jobName));
         }
         return null;
     }
@@ -413,7 +414,7 @@ public final class JenkinsJobManagement extends AbstractJobManagement {
     }
 
     private void markBuildAsUnstable(String message) {
-        logWarningWithDetails(message);
+        logWarning(message);
         build.setResult(UNSTABLE);
     }
 
@@ -421,7 +422,7 @@ public final class JenkinsJobManagement extends AbstractJobManagement {
         FilePath filePath = workspace.child(relLocation);
         try {
             if (!filePath.exists()) {
-                throw new IllegalStateException(format("File %s does not exist in workspace", relLocation));
+                throw new DslScriptException(format("File %s does not exist in workspace", relLocation));
             }
         } catch (InterruptedException ie) {
             throw new IOException(ie);

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ContextExtensionPointSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ContextExtensionPointSpec.groovy
@@ -2,6 +2,7 @@ package javaposse.jobdsl.plugin
 
 import hudson.ExtensionList
 import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.DslScriptException
 import org.junit.Rule
 import org.jvnet.hudson.test.JenkinsRule
 import spock.lang.Specification
@@ -31,7 +32,7 @@ class ContextExtensionPointSpec extends Specification {
         ContextExtensionPoint.executeInContext(Mock(Runnable), Mock(Context))
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(DslScriptException)
     }
 
     def 'executeInContext no closure'() {

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
@@ -17,6 +17,7 @@ import javaposse.jobdsl.dsl.ConfigFile
 import javaposse.jobdsl.dsl.ConfigFileType
 import javaposse.jobdsl.dsl.ConfigurationMissingException
 import javaposse.jobdsl.dsl.DslException
+import javaposse.jobdsl.dsl.DslScriptException
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.NameNotProvidedException
@@ -582,7 +583,7 @@ class JenkinsJobManagementSpec extends Specification {
         jobManagement.readFileInWorkspace(fileName)
 
         then:
-        Exception e = thrown(IllegalStateException)
+        Exception e = thrown(DslScriptException)
         e.message.contains(fileName)
     }
 

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
@@ -95,7 +95,7 @@ class JenkinsJobManagementSpec extends Specification {
         jobManagement.logPluginDeprecationWarning('ldap', '20.0')
 
         then:
-        buffer.toString() =~ /Warning: support for LDAP Plugin versions older than 20.0 is deprecated \(.+, line \d+\)/
+        buffer.toString() =~ /Warning: \(.+, line \d+\) support for LDAP Plugin versions older than 20.0 is deprecated/
     }
 
     def 'logPluginDeprecationWarning does not log anything if plugin version is newer'() {


### PR DESCRIPTION
Added `DslScriptException` for user-level problems like invalid or missing arguments. And instead of logging a stack trace, the exception will be logged with a pointer to the DSL script source which caused the exception.

So the build log will contain this message:
```
Started by user anonymous
Building in workspace /var/lib/jenkins/jobs/seed/workspace
Processing provided DSL script
ERROR: jobIdentifier cannot be null or empty (DSL script, line 3)
Finished: FAILURE
```

And not a stack trace as before:
```
Started by user anonymous
Building in workspace /var/lib/jenkins/jobs/seed/workspace
Processing provided DSL script
FATAL: jobIdentifier cannot be null or empty
java.lang.IllegalArgumentException: jobIdentifier cannot be null or empty
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:88)
	at com.google.common.base.Preconditions$checkArgument.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:42)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:120)
	at javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.rundeck(PublisherContext.groovy:1039)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:233)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:361)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:903)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.callCurrent(PogoMetaClassSite.java:66)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:46)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:133)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:145)
	at script1435952638962357436272$_run_closure1_closure2.doCall(script1435952638962357436272.groovy:3)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:233)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:272)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:903)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.callCurrent(PogoMetaClassSite.java:66)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:46)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:133)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:141)
	at script1435952638962357436272$_run_closure1_closure2.doCall(script1435952638962357436272.groovy)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:233)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:272)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:903)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:39)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:42)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:112)
	at javaposse.jobdsl.dsl.ContextHelper.executeInContext(ContextHelper.groovy:14)
	at javaposse.jobdsl.dsl.ContextHelper$executeInContext.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:42)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:120)
	at javaposse.jobdsl.dsl.Job.publishers(Job.groovy:512)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:233)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:361)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:903)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.callCurrent(PogoMetaClassSite.java:66)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:46)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:133)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:141)
	at script1435952638962357436272$_run_closure1.doCall(script1435952638962357436272.groovy:2)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:233)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:272)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:903)
	at groovy.lang.Closure.call(Closure.java:415)
	at groovy.lang.Closure.call(Closure.java:428)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.with(DefaultGroovyMethods.java:196)
	at org.codehaus.groovy.runtime.dgm$926.invoke(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoMetaMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:313)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.call(PogoMetaMethodSite.java:64)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:42)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116)
	at javaposse.jobdsl.dsl.JobParent.processJob(JobParent.groovy:100)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:272)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:52)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:46)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:133)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:149)
	at javaposse.jobdsl.dsl.JobParent.freeStyleJob(JobParent.groovy:42)
	at javaposse.jobdsl.dsl.JobParent$freeStyleJob.callCurrent(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:46)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:133)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:145)
	at javaposse.jobdsl.dsl.JobParent.job(JobParent.groovy:34)
	at javaposse.jobdsl.dsl.DslFactory$job.callCurrent(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:46)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:133)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:145)
	at script1435952638962357436272.run(script1435952638962357436272.groovy:1)
	at javaposse.jobdsl.dsl.DslScriptLoader.runDslEngineForParent(DslScriptLoader.java:72)
	at javaposse.jobdsl.dsl.DslScriptLoader.runDslEngine(DslScriptLoader.java:92)
	at javaposse.jobdsl.plugin.ExecuteDslScripts.perform(ExecuteDslScripts.java:215)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:745)
	at hudson.model.Build$BuildExecution.build(Build.java:198)
	at hudson.model.Build$BuildExecution.doRun(Build.java:159)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:518)
	at hudson.model.Run.execute(Run.java:1706)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:88)
	at hudson.model.Executor.run(Executor.java:231)
```