### PR TITLE
Added support for new options introduced in build-blocker-plugin

### DIFF
--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -460,11 +460,14 @@ If the number of seconds to wait is omitted from the call the job will be config
 
 ### Block build
 ```groovy
-blockOn(String projectName)
-blockOn(Iterable<String> projectNames)
+blockOn(String projectName) {
+  blockLevel(String blockLevel)
+  scanQueueFor(String scanQueueFor)
+}
+blockOn(Iterable<String> projectNames, String blockLevel = 'UNDEFINED', String scanQueueFor = 'DISABLED')
 ```
 
-Block build if certain jobs are running, supported by the <a href="https://wiki.jenkins-ci.org/display/JENKINS/Build+Blocker+Plugin">Build Blocker Plugin</a>. If more than one name is provided to projectName, it is newline separated. Per the plugin, regular expressions can be used for the projectNames, e.g. ".*-maintenance" will match all maintenance jobs.
+Block build if certain jobs are running, supported by the <a href="https://wiki.jenkins-ci.org/display/JENKINS/Build+Blocker+Plugin">Build Blocker Plugin</a>. If more than one name is provided to projectName, it is newline separated. Per the plugin, regular expressions can be used for the projectNames, e.g. ".*-maintenance" will match all maintenance jobs. `blockLevel` and `scanQueueFor` requires `build-blocker-plugin 1.7.0+`.
 
 ### Block on upstream/downstream projects
 ```groovy

--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -464,7 +464,10 @@ blockOn(String projectName) {
   blockLevel(String blockLevel)
   scanQueueFor(String scanQueueFor)
 }
-blockOn(Iterable<String> projectNames, String blockLevel = 'UNDEFINED', String scanQueueFor = 'DISABLED')
+blockOn(Iterable<String> projectNames) {
+  blockLevel(String blockLevel)
+  scanQueueFor(String scanQueueFor)
+}
 ```
 
 Block build if certain jobs are running, supported by the <a href="https://wiki.jenkins-ci.org/display/JENKINS/Build+Blocker+Plugin">Build Blocker Plugin</a>. If more than one name is provided to projectName, it is newline separated. Per the plugin, regular expressions can be used for the projectNames, e.g. ".*-maintenance" will match all maintenance jobs. `blockLevel` and `scanQueueFor` requires `build-blocker-plugin 1.7.0+`.

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/BuildBlockerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/BuildBlockerContext.groovy
@@ -1,0 +1,14 @@
+package javaposse.jobdsl.dsl
+
+class BuildBlockerContext implements Context {
+    String blockLevel = 'UNDEFINED'
+    String scanQueueFor = 'DISABLED'
+
+    void blockLevel(String blockLevel) {
+        this.blockLevel = blockLevel
+    }
+
+    void scanQueueFor(String scanQueueFor) {
+        this.scanQueueFor = scanQueueFor
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/BuildBlockerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/BuildBlockerContext.groovy
@@ -1,14 +1,29 @@
 package javaposse.jobdsl.dsl
 
+import static com.google.common.base.Preconditions.checkArgument
+
 class BuildBlockerContext implements Context {
+
+    private static final Set<String> VALID_BLOCK_LEVELS = [
+            'UNDEFINED', 'GLOBAL', 'NODE'
+    ]
+
+    private static final Set<String> VALID_QUEUE_SCAN_SCOPES = [
+            'ALL', 'BUILDABLE', 'DISABLED'
+    ]
+
     String blockLevel = 'UNDEFINED'
     String scanQueueFor = 'DISABLED'
 
     void blockLevel(String blockLevel) {
+        checkArgument(VALID_BLOCK_LEVELS.contains(blockLevel),
+                "blockLevel must be one of ${VALID_BLOCK_LEVELS.join(', ')}")
         this.blockLevel = blockLevel
     }
 
     void scanQueueFor(String scanQueueFor) {
+        checkArgument(VALID_QUEUE_SCAN_SCOPES.contains(scanQueueFor),
+                "scanQueueFor must be one of ${VALID_QUEUE_SCAN_SCOPES.join(', ')}")
         this.scanQueueFor = scanQueueFor
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
@@ -187,11 +187,8 @@ abstract class Job extends Item {
     /**
      * Block build if certain jobs are running.
      */
-    void blockOn(Iterable<String> projectNames, String blockLevel = 'UNDEFINED', String scanQueueFor = 'DISABLED') {
-        blockOn(projectNames.join('\n')) {
-            delegate.blockLevel(blockLevel)
-            delegate.scanQueueFor(scanQueueFor)
-        }
+    void blockOn(Iterable<String> projectNames, @DslContext(BuildBlockerContext) Closure closure = null) {
+        blockOn(projectNames.join('\n'), closure)
     }
 
     /**

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobSpec.groovy
@@ -633,6 +633,42 @@ class JobSpec extends Specification {
         with(job.node.properties[0].'hudson.plugins.buildblocker.BuildBlockerProperty'[0]) {
             useBuildBlocker[0].value() == 'true'
             blockingJobs[0].value() == 'MyProject'
+            blockLevel[0].value() == 'UNDEFINED'
+            scanQueueFor[0].value() == 'DISABLED'
+        }
+        1 * jobManagement.requirePlugin('build-blocker-plugin')
+    }
+
+    def 'build blocker xml with options'() {
+        when:
+        job.blockOn('MyProject2') {
+            blockLevel 'GLOBAL'
+            scanQueueFor 'ALL'
+        }
+
+        then:
+        with(job.node.properties[0].'hudson.plugins.buildblocker.BuildBlockerProperty'[0]) {
+            useBuildBlocker[0].value() == 'true'
+            blockingJobs[0].value() == 'MyProject2'
+            blockLevel[0].value() == 'GLOBAL'
+            scanQueueFor[0].value() == 'ALL'
+        }
+        1 * jobManagement.requirePlugin('build-blocker-plugin')
+    }
+
+    def 'build blocker xml with iterator'() {
+        when:
+        job.blockOn(['MyProject', 'MyProject2', 'MyProject3']) {
+            blockLevel 'GLOBAL'
+            scanQueueFor 'ALL'
+        }
+
+        then:
+        with(job.node.properties[0].'hudson.plugins.buildblocker.BuildBlockerProperty'[0]) {
+            useBuildBlocker[0].value() == 'true'
+            blockingJobs[0].value() == 'MyProject\nMyProject2\nMyProject3'
+            blockLevel[0].value() == 'GLOBAL'
+            scanQueueFor[0].value() == 'ALL'
         }
         1 * jobManagement.requirePlugin('build-blocker-plugin')
     }


### PR DESCRIPTION
- support for job blocking on global or node level
- support for job blocking based on status of queued jobs
  (buildable only/all jobs in queue)