### PR TITLE
Fixed deprecation warning in getCredentialsId.

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -236,10 +236,10 @@ public final class JenkinsJobManagement extends AbstractJobManagement {
         if (credentialsPlugin != null && !credentialsPlugin.getWrapper().getVersionNumber().isOlderThan(new VersionNumber("1.6"))) {
             for (CredentialsProvider credentialsProvider : jenkins.getExtensionList(CredentialsProvider.class)) {
                 for (StandardCredentials credentials : credentialsProvider.getCredentials(StandardCredentials.class, jenkins, SYSTEM)) {
-                    if (credentials.getDescription().equals(credentialsDescription)) {
-                        logDeprecationWarning("finding credentials by description");
+                    if (credentials.getId().equals(credentialsDescription)) {
                         return credentials.getId();
-                    } else if (credentials.getId().equals(credentialsDescription)) {
+                    } else if (credentials.getDescription().equals(credentialsDescription)) {
+                        logDeprecationWarning("finding credentials by description");
                         return credentials.getId();
                     }
                 }


### PR DESCRIPTION
If ID and description are the same for a credential, a misleading deprecation warning was logged.
Changing the order of checks prevents the warning for this case.