### PR TITLE
[JENKINS-29498] added the primaryView option to Folders

### DIFF
--- a/docs/Folder-Reference.md
+++ b/docs/Folder-Reference.md
@@ -76,6 +76,24 @@ folder('project-a') {
 }
 ```
 
+### Primary View
+
+```groovy
+folder {
+    primaryView(String primaryView)
+}
+```
+
+Change the initial view to show when the folder contains multiple views (defaults to the 'All' view, which cannot be removed).
+
+```groovy
+folder('project-a') {
+    primaryView('InitialView')
+}
+listView('project-a/InitialView') {
+    description('shown by default')
+}
+```
 ### Authorization
 
 ```groovy

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -17,6 +17,7 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
 
 ## Release Notes
 * 1.36 (unreleased)
+ * Added support for `primaryView` of [Folders Plugin](https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Folders+Plugin) ([JENKINS-29498](https://issues.jenkins-ci.org/browse/JENKINS-29498))
  * Enhanced support for the [Build Blocker Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build+Blocker+Plugin)
  * Improved error logging
    ([JENKINS-16354](https://issues.jenkins-ci.org/browse/JENKINS-16354))

--- a/docs/Job-DSL-Commands.md
+++ b/docs/Job-DSL-Commands.md
@@ -1,4 +1,4 @@
-**NOTE: See the [[Job Reference]] and [[View Reference]] pages for details about all options.**
+**NOTE: See the [[Job Reference]], [[View Reference]] and [[Folder Reference]] pages for details about all options.**
 
 # DSL Methods
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Folder.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Folder.groovy
@@ -26,6 +26,15 @@ class Folder extends Item {
     }
 
     /**
+     * @since 1.36
+     */
+    void primaryView(String primaryViewArg) {
+        execute {
+            it / methodMissing('primaryView', primaryViewArg)
+        }
+    }
+
+    /**
      * @since 1.31
      */
     void authorization(@DslContext(AuthorizationContext) Closure closure) {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/FolderSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/FolderSpec.groovy
@@ -42,6 +42,16 @@ class FolderSpec extends Specification {
         root.description[0].text() == 'test folder'
     }
 
+    def 'primaryView'() {
+        when:
+        folder.primaryView('test primaryView')
+
+        then:
+        Node root = folder.node
+        root.primaryView.size() == 1
+        root.primaryView[0].text() == 'test primaryView'
+    }
+
     def 'call authorization'() {
         setup:
         String propertyName = 'com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty'
@@ -82,6 +92,7 @@ class FolderSpec extends Specification {
         setup:
         folder.displayName('Test Folder')
         folder.description('la la la')
+        folder.primaryView('Some View')
 
         when:
         String xml = folder.xml
@@ -107,7 +118,7 @@ class FolderSpec extends Specification {
         </hudson.model.AllView>
     </views>
     <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
-    <primaryView>All</primaryView>
+    <primaryView>Some View</primaryView>
     <healthMetrics>
         <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric/>
     </healthMetrics>


### PR DESCRIPTION
The Folders Plugin allows to set one of the views in the folder as the default initial view (called primaryView). Job-Dsl-Plugin hardcoded this to the "All" view. This `primaryView` option allows you to change it.