### PR TITLE
method to add childCustomWorkspace to MatrixJob

### DIFF
--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -43,7 +43,7 @@ freeStyleJob(String name) { // since 1.30
         permission(String permission, String user)
         permission(Permissions perm, String user) // deprecated since 1.31
         permissionAll(String user)
-        blocksInheritance(boolean blocksInheritance = true) // since 1.35 
+        blocksInheritance(boolean blocksInheritance = true) // since 1.35
     }
     parameters {
         booleanParam(String parameterName, boolean defaultValue = false,
@@ -327,6 +327,7 @@ matrixJob(String name) { // since 1.30
     runSequentially(boolean runSequentially = true)
     touchStoneFilter(String expression, boolean continueOnFailure = false)
     combinationFilter(String expression)
+    childCustomWorkspace(String workspace)
 }
 
 job(type: Matrix, Closure closure) // deprecated since 1.30
@@ -479,7 +480,7 @@ job {
 
 Block build if certain jobs are running. Requires the
 [Build Blocker Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build+Blocker+Plugin).
- 
+
 Regular expressions can be used for the project names, e.g. `/.*-maintenance/` will match all maintenance jobs.
 
 Possible values for `blockLevel` are `'GLOBAL'` and `'NODE'` (default). Possible values for `scanQueueFor` are `'ALL'`,
@@ -637,7 +638,7 @@ job {
         permission(String permission, String user)
         permissionAll(String user)
         permission(Permissions perm, String user) // deprecated since 1.31
-        blocksInheritance(boolean blocksInheritance = true) // since 1.35 
+        blocksInheritance(boolean blocksInheritance = true) // since 1.35
     }
 }
 ```
@@ -3443,6 +3444,22 @@ matrixJob('example') {
     combinationFilter('jdk=="jdk-6" || label=="linux"')
 }
 ```
+### Child custom workspace
+
+Requires [Matrix Project Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Matrix+Project+Plugin)
+
+Explicitly specify custom workspace name for individual child workspaces created for individual axes.
+
+Example:
+
+```groovy
+matrixJob('example') {
+    customWorkspace('example')
+    childCustomWorkspace('.') // Reuse the same custom workspace for every axis.
+}
+```
+
+(Since 1.36)
 
 # [Prerequisite Build Step](https://wiki.jenkins-ci.org/display/JENKINS/Prerequisite+build+step+plugin)
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/jobs/MatrixJob.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/jobs/MatrixJob.groovy
@@ -7,6 +7,8 @@ import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.WithXmlAction
 import javaposse.jobdsl.dsl.helpers.AxisContext
 
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNull
+
 class MatrixJob extends Job {
     MatrixJob(JobManagement jobManagement) {
         super(jobManagement)
@@ -24,6 +26,19 @@ class MatrixJob extends Job {
             context.configureBlocks.each {
                 new WithXmlAction(it).execute(axesNode)
             }
+        }
+    }
+
+    /**
+     * Configures a child custom workspace for the matrix project.
+     *
+     * @param workspacePath workspace path to use
+     */
+    void childCustomWorkspace(String workspacePath) {
+        checkNotNull(workspacePath, 'Workspace path must not be null')
+        withXmlActions << WithXmlAction.create { Node project ->
+            Node node = methodMissing('childCustomWorkspace', workspacePath)
+            project / node
         }
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/jobs/MatrixJobSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/jobs/MatrixJobSpec.groovy
@@ -89,4 +89,19 @@ class MatrixJobSpec extends Specification {
         job.node.axes[0].children().size() == 1
         job.node.axes[0].children()[0].name() == 'FooAxis'
     }
+
+    def 'can set child custom workspace'() {
+        when:
+        job.childCustomWorkspace('test')
+
+        then:
+        job.node.childCustomWorkspace[0].value() == 'test'
+
+        when:
+        job.childCustomWorkspace('test2')
+
+        then:
+        job.node.childCustomWorkspace.size() == 1
+        job.node.childCustomWorkspace[0].value() == 'test2'
+    }
 }


### PR DESCRIPTION
Matrix job does not have a convinience method to add
childCustomWorkspace. Define it.

--Define childCustomWorkspace method in MatrixJob
--Add a unit test for it
--Update job reference

[JENKINS-29375]