### PR TITLE
removed dependency on Guava from job-dsl-core module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ subprojects {
 
     dependencies {
         compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
-        compile 'com.google.guava:guava:11.0.1'
         testCompile 'org.spockframework:spock-core:0.7-groovy-1.8'
         testCompile 'junit:junit-dep:4.10'
         testCompile 'cglib:cglib-nodep:2.2.2' // used by Spock

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -1,23 +1,22 @@
 package javaposse.jobdsl.dsl;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import groovy.lang.Binding;
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.Script;
 import groovy.util.GroovyScriptEngine;
 import org.codehaus.groovy.control.CompilationFailedException;
 import org.codehaus.groovy.control.CompilerConfiguration;
-import org.codehaus.groovy.control.customizers.ASTTransformationCustomizer;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
 import org.codehaus.groovy.runtime.InvokerHelper;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -114,9 +113,9 @@ public class DslScriptLoader {
 
     private static Set<GeneratedJob> extractGeneratedJobs(JobParent jp, boolean ignoreExisting) throws IOException {
         // Iterate jobs which were setup, save them, and convert to a serializable form
-        Set<GeneratedJob> generatedJobs = Sets.newLinkedHashSet();
+        Set<GeneratedJob> generatedJobs = new LinkedHashSet<GeneratedJob>();
         if (jp != null) {
-            List<Item> referencedItems = Lists.newArrayList(jp.getReferencedJobs()); // As List
+            List<Item> referencedItems = new ArrayList<Item>(jp.getReferencedJobs()); // As List
             Collections.sort(referencedItems, ITEM_COMPARATOR);
             for (Item item : referencedItems) {
                 String xml = item.getXml();
@@ -136,7 +135,7 @@ public class DslScriptLoader {
     }
 
     private static Set<GeneratedView> extractGeneratedViews(JobParent jp, boolean ignoreExisting) {
-        Set<GeneratedView> generatedViews = Sets.newLinkedHashSet();
+        Set<GeneratedView> generatedViews = new LinkedHashSet<GeneratedView>();
         for (View view : jp.getReferencedViews()) {
             String xml = view.getXml();
             LOGGER.log(Level.FINE, String.format("Saving view %s as %s", view.getName(), xml));
@@ -148,7 +147,7 @@ public class DslScriptLoader {
     }
 
     private static Set<GeneratedConfigFile> extractGeneratedConfigFiles(JobParent jp, boolean ignoreExisting) {
-        Set<GeneratedConfigFile> generatedConfigFiles = Sets.newLinkedHashSet();
+        Set<GeneratedConfigFile> generatedConfigFiles = new LinkedHashSet<GeneratedConfigFile>();
         for (ConfigFile configFile : jp.getReferencedConfigFiles()) {
             LOGGER.log(Level.FINE, String.format("Saving config file %s", configFile.getName()));
             String id = jp.getJm().createOrUpdateConfigFile(configFile, ignoreExisting);
@@ -158,7 +157,7 @@ public class DslScriptLoader {
     }
 
     private static Set<GeneratedUserContent> extractGeneratedUserContents(JobParent jp, boolean ignoreExisting) {
-        Set<GeneratedUserContent> generatedUserContents = Sets.newLinkedHashSet();
+        Set<GeneratedUserContent> generatedUserContents = new LinkedHashSet<GeneratedUserContent>();
         for (UserContent userContent : jp.getReferencedUserContents()) {
             LOGGER.log(Level.FINE, String.format("Saving user content %s", userContent.getPath()));
             jp.getJm().createOrUpdateUserContent(userContent, ignoreExisting);
@@ -168,7 +167,7 @@ public class DslScriptLoader {
     }
 
     static void scheduleJobsToRun(List<String> jobNames, JobManagement jobManagement) {
-        Map<String, Throwable> exceptions = Maps.newHashMap();
+        Map<String, Throwable> exceptions = new HashMap<String, Throwable>();
         for (String jobName : jobNames) {
             try {
                 jobManagement.queueJob(jobName);

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
@@ -1,6 +1,5 @@
 package javaposse.jobdsl.dsl
 
-import com.google.common.collect.Sets
 import javaposse.jobdsl.dsl.jobs.BuildFlowJob
 import javaposse.jobdsl.dsl.jobs.FreeStyleJob
 import javaposse.jobdsl.dsl.jobs.MatrixJob
@@ -20,10 +19,10 @@ import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 
 abstract class JobParent extends Script implements DslFactory {
     JobManagement jm
-    Set<Item> referencedJobs = Sets.newLinkedHashSet()
-    Set<View> referencedViews = Sets.newLinkedHashSet()
-    Set<ConfigFile> referencedConfigFiles = Sets.newLinkedHashSet()
-    Set<UserContent> referencedUserContents = Sets.newLinkedHashSet()
+    Set<Item> referencedJobs = new LinkedHashSet<>()
+    Set<View> referencedViews = new LinkedHashSet<>()
+    Set<ConfigFile> referencedConfigFiles = new LinkedHashSet<>()
+    Set<UserContent> referencedUserContents = new LinkedHashSet<>()
     List<String> queueToBuild = []
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/PublishOverSshServerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/PublishOverSshServerContext.groovy
@@ -4,7 +4,6 @@ import javaposse.jobdsl.dsl.Context
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 
-import static com.google.common.base.Strings.isNullOrEmpty
 import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class PublishOverSshServerContext implements Context {
@@ -47,7 +46,7 @@ class PublishOverSshServerContext implements Context {
         ContextHelper.executeInContext(transferSetClosure, transferSetContext)
 
         checkArgument(
-                !isNullOrEmpty(transferSetContext.sourceFiles) || !isNullOrEmpty(transferSetContext.execCommand),
+                (transferSetContext.sourceFiles as boolean) || (transferSetContext.execCommand as boolean),
                 'sourceFiles or execCommand must be specified'
         )
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -12,7 +12,6 @@ import javaposse.jobdsl.dsl.helpers.AbstractExtensibleContext
 import javaposse.jobdsl.dsl.helpers.common.DownstreamContext
 import javaposse.jobdsl.dsl.helpers.common.PublishOverSshContext
 
-import static com.google.common.base.Strings.isNullOrEmpty
 import static javaposse.jobdsl.dsl.helpers.LocalRepositoryLocation.LOCAL_TO_WORKSPACE
 
 class StepContext extends AbstractExtensibleContext {
@@ -138,7 +137,7 @@ class StepContext extends AbstractExtensibleContext {
 
         stepNodes << new NodeBuilder().'javaposse.jobdsl.plugin.ExecuteDslScripts' {
             targets(context.externalScripts.join('\n'))
-            usingScriptText(!isNullOrEmpty(context.scriptText))
+            usingScriptText(context.scriptText as boolean)
             scriptText(context.scriptText ?: '')
             ignoreExisting(context.ignoreExisting)
             removedJobAction(context.removedJobAction)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslScriptLoaderSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslScriptLoaderSpec.groovy
@@ -1,6 +1,5 @@
 package javaposse.jobdsl.dsl
 
-import com.google.common.collect.Iterables
 import javaposse.jobdsl.dsl.jobs.FreeStyleJob
 import spock.lang.Ignore
 import spock.lang.Specification
@@ -86,7 +85,7 @@ job {
         jp != null
         def jobs = jp.referencedJobs
         jobs.size() == 2
-        def job = Iterables.get(jobs, 0)
+        def job = jobs.first()
         // If this one fails periodically, then it is because the referenced jobs are
         // Not in definition order, but rather in hash order. Hence, predictability.
         job.name == 'project-a'
@@ -128,7 +127,7 @@ job {
         jp != null
         def jobs = jp.referencedJobs
         jobs.size() == 1
-        def job = Iterables.get(jobs, 0)
+        def job = jobs.first()
         job.name == 'test'
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/WithXmlActionSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/WithXmlActionSpec.groovy
@@ -1,12 +1,14 @@
 package javaposse.jobdsl.dsl
 
-import com.google.common.base.Preconditions
 import spock.lang.Specification
 
 import java.util.logging.Handler
 import java.util.logging.Level
 import java.util.logging.LogManager
 import java.util.logging.Logger
+
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertTrue
 
 /**
  * Work through the additional functionality we're offer over node
@@ -54,8 +56,8 @@ class WithXmlActionSpec extends Specification {
         when:
         def builders = 'build'
         execute { project ->
-            Preconditions.checkNotNull(project)
-            Preconditions.checkArgument(project instanceof Node)
+            assertNotNull(project)
+            assertTrue(project instanceof Node)
 
             project / builders / builder
         }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
@@ -43,6 +43,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
@@ -205,10 +206,10 @@ public class ExecuteDslScripts extends Builder {
                         targets, usingScriptText, scriptText, ignoreExisting, additionalClasspath
                 );
 
-                Set<GeneratedJob> freshJobs = Sets.newLinkedHashSet();
-                Set<GeneratedView> freshViews = Sets.newLinkedHashSet();
-                Set<GeneratedConfigFile> freshConfigFiles = Sets.newLinkedHashSet();
-                Set<GeneratedUserContent> freshUserContents = Sets.newLinkedHashSet();
+                Set<GeneratedJob> freshJobs = new LinkedHashSet<GeneratedJob>();
+                Set<GeneratedView> freshViews = new LinkedHashSet<GeneratedView>();
+                Set<GeneratedConfigFile> freshConfigFiles = new LinkedHashSet<GeneratedConfigFile>();
+                Set<GeneratedUserContent> freshUserContents = new LinkedHashSet<GeneratedUserContent>();
                 for (ScriptRequest request : scriptRequests) {
                     LOGGER.log(Level.FINE, String.format("Request for %s", request.getLocation()));
 
@@ -449,7 +450,7 @@ public class ExecuteDslScripts extends Builder {
                 return input.getTemplateName();
             }
         });
-        return Sets.newLinkedHashSet(Collections2.filter(templateNames, Predicates.notNull()));
+        return new LinkedHashSet<String>(Collections2.filter(templateNames, Predicates.notNull()));
     }
 
     private static class SeedNamePredicate implements Predicate<SeedReference> {

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ScriptRequestGenerator.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ScriptRequestGenerator.groovy
@@ -1,6 +1,5 @@
 package javaposse.jobdsl.plugin
 
-import com.google.common.collect.Sets
 import hudson.EnvVars
 import hudson.FilePath
 import hudson.model.AbstractBuild
@@ -21,7 +20,7 @@ class ScriptRequestGenerator implements Closeable {
     Set<ScriptRequest> getScriptRequests(String targets, boolean usingScriptText, String scriptText,
                                          boolean ignoreExisting,
                                          String additionalClasspath) throws IOException, InterruptedException {
-        Set<ScriptRequest> scriptRequests = Sets.newLinkedHashSet()
+        Set<ScriptRequest> scriptRequests = new LinkedHashSet<ScriptRequest>()
 
         List<URL> classpath = []
         if (additionalClasspath) {

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedJobsAction.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedJobsAction.java
@@ -1,11 +1,11 @@
 package javaposse.jobdsl.plugin.actions;
 
-import com.google.common.collect.Sets;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Item;
 import javaposse.jobdsl.dsl.GeneratedJob;
 
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class GeneratedJobsAction extends GeneratedObjectsAction<GeneratedJob, GeneratedJobsBuildAction> {
@@ -14,7 +14,7 @@ public class GeneratedJobsAction extends GeneratedObjectsAction<GeneratedJob, Ge
     }
 
     public Set<Item> getItems() {
-        Set<Item> result = Sets.newLinkedHashSet();
+        Set<Item> result = new LinkedHashSet<Item>();
         for (AbstractBuild build : project.getBuilds()) {
             GeneratedJobsBuildAction action = build.getAction(GeneratedJobsBuildAction.class);
             if (action != null) {

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedJobsBuildAction.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedJobsBuildAction.java
@@ -1,11 +1,11 @@
 package javaposse.jobdsl.plugin.actions;
 
-import com.google.common.collect.Sets;
 import hudson.model.Item;
 import javaposse.jobdsl.dsl.GeneratedJob;
 import javaposse.jobdsl.plugin.LookupStrategy;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class GeneratedJobsBuildAction extends GeneratedObjectsBuildRunAction<GeneratedJob> {
@@ -24,7 +24,7 @@ public class GeneratedJobsBuildAction extends GeneratedObjectsBuildRunAction<Gen
     }
 
     public Set<Item> getItems() {
-        Set<Item> result = Sets.newLinkedHashSet();
+        Set<Item> result = new LinkedHashSet<Item>();
         for (GeneratedJob job : getModifiedObjects()) {
             Item item = getLookupStrategy().getItem(owner.getProject(), job.getJobName(), Item.class);
             if (item != null) {

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedObjectsAction.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedObjectsAction.java
@@ -1,13 +1,11 @@
 package javaposse.jobdsl.plugin.actions;
 
-import com.google.common.collect.Sets;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
 
+import java.util.LinkedHashSet;
 import java.util.Set;
-
-import static com.google.common.collect.Sets.newLinkedHashSet;
 
 public abstract class GeneratedObjectsAction<T, B extends GeneratedObjectsBuildAction<T>> implements Action {
     protected final AbstractProject<?, ?> project;
@@ -37,15 +35,15 @@ public abstract class GeneratedObjectsAction<T, B extends GeneratedObjectsBuildA
         for (AbstractBuild<?, ?> b = project.getLastBuild(); b != null; b = b.getPreviousBuild()) {
             B action = b.getAction(buildActionClass);
             if (action != null && action.getModifiedObjects() != null) {
-                return newLinkedHashSet(action.getModifiedObjects());
+                return new LinkedHashSet<T>(action.getModifiedObjects());
             }
         }
-        return newLinkedHashSet();
+        return new LinkedHashSet<T>();
     }
 
     @SuppressWarnings("unused") // used by some Jelly views
     public Set<T> findAllGeneratedObjects() {
-        Set<T> result = Sets.newLinkedHashSet();
+        Set<T> result = new LinkedHashSet<T>();
         for (AbstractBuild build : project.getBuilds()) {
             B action = build.getAction(buildActionClass);
             if (action != null && action.getModifiedObjects() != null) {
@@ -57,6 +55,6 @@ public abstract class GeneratedObjectsAction<T, B extends GeneratedObjectsBuildA
 
     public static <T, A extends GeneratedObjectsAction<T, ?>> Set<T> extractGeneratedObjects(AbstractProject<?, ?> project, Class<A> actionType) {
         A action = project.getAction(actionType);
-        return action == null ? Sets.<T>newLinkedHashSet() : action.findLastGeneratedObjects();
+        return action == null ? new LinkedHashSet<T>() : action.findLastGeneratedObjects();
     }
 }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedObjectsBuildAction.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedObjectsBuildAction.java
@@ -1,16 +1,16 @@
 package javaposse.jobdsl.plugin.actions;
 
-import com.google.common.collect.Sets;
 import hudson.model.Action;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public abstract class GeneratedObjectsBuildAction<T> implements Action {
     private final Set<T> modifiedObjects;
 
     public GeneratedObjectsBuildAction(Collection<T> modifiedObjects) {
-        this.modifiedObjects = Sets.newLinkedHashSet(modifiedObjects);
+        this.modifiedObjects = new LinkedHashSet<T>(modifiedObjects);
     }
 
     @Override
@@ -29,6 +29,6 @@ public abstract class GeneratedObjectsBuildAction<T> implements Action {
     }
 
     public Collection<T> getModifiedObjects() {
-        return modifiedObjects == null ? Sets.<T>newLinkedHashSet() : modifiedObjects;
+        return modifiedObjects == null ? new LinkedHashSet<T>() : modifiedObjects;
     }
 }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedViewsAction.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedViewsAction.java
@@ -5,9 +5,8 @@ import hudson.model.AbstractProject;
 import hudson.model.View;
 import javaposse.jobdsl.dsl.GeneratedView;
 
+import java.util.LinkedHashSet;
 import java.util.Set;
-
-import static com.google.common.collect.Sets.newLinkedHashSet;
 
 public class GeneratedViewsAction extends GeneratedObjectsAction<GeneratedView, GeneratedViewsBuildAction> {
     public GeneratedViewsAction(AbstractProject<?, ?> project) {
@@ -15,7 +14,7 @@ public class GeneratedViewsAction extends GeneratedObjectsAction<GeneratedView, 
     }
 
     public Set<View> getViews() {
-        Set<View> result = newLinkedHashSet();
+        Set<View> result = new LinkedHashSet<View>();
         for (AbstractBuild build : project.getBuilds()) {
             GeneratedViewsBuildAction action = build.getAction(GeneratedViewsBuildAction.class);
             if (action != null) {

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedViewsBuildAction.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedViewsBuildAction.java
@@ -1,6 +1,5 @@
 package javaposse.jobdsl.plugin.actions;
 
-import com.google.common.collect.Sets;
 import hudson.model.ItemGroup;
 import hudson.model.View;
 import hudson.model.ViewGroup;
@@ -9,6 +8,7 @@ import javaposse.jobdsl.plugin.LookupStrategy;
 import org.apache.commons.io.FilenameUtils;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class GeneratedViewsBuildAction extends GeneratedObjectsBuildRunAction<GeneratedView> {
@@ -27,7 +27,7 @@ public class GeneratedViewsBuildAction extends GeneratedObjectsBuildRunAction<Ge
     }
 
     public Set<View> getViews() {
-        Set<View> allGeneratedViews = Sets.newLinkedHashSet();
+        Set<View> allGeneratedViews = new LinkedHashSet<View>();
         for (GeneratedView generatedView : getModifiedObjects()) {
             ItemGroup itemGroup = getLookupStrategy().getParent(owner.getProject(), generatedView.getName());
             if (itemGroup instanceof ViewGroup) {

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ExecuteDslScriptsSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ExecuteDslScriptsSpec.groovy
@@ -1,7 +1,6 @@
 package javaposse.jobdsl.plugin
 
 import com.cloudbees.hudson.plugins.folder.Folder
-import com.google.common.collect.Lists
 import hudson.FilePath
 import hudson.maven.MavenModuleSet
 import hudson.model.AbstractItem
@@ -45,7 +44,7 @@ class ExecuteDslScriptsSpec extends Specification {
     @WithoutJenkins
     def 'getProjectActions'() {
         when:
-        List<? extends Action> actions = Lists.newArrayList(executeDslScripts.getProjectActions(project))
+        List<? extends Action> actions = new ArrayList<? extends Action>(executeDslScripts.getProjectActions(project))
 
         then:
         actions != null


### PR DESCRIPTION
job-dsl-plugin uses transitive dependency from Jenkins core.

This should avoid problem if Jenkins core uses a different of Guava than the Job DSL plugin.