### PR TITLE
Support remote job tokens.

### DIFF
--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -3768,6 +3768,7 @@ job {
             pollInterval(int pollInterval)                                  // since 1.29
             preventRemoteBuildQueue(boolean preventRemoteBuildQueue = true) // since 1.29
             blockBuildUntilComplete(boolean blockBuildUntilComplete = true) // since 1.29
+            token(String token = '')
         }
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/ParameterizedRemoteTriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/ParameterizedRemoteTriggerContext.groovy
@@ -8,6 +8,7 @@ class ParameterizedRemoteTriggerContext implements Context {
     int pollInterval = 10
     boolean preventRemoteBuildQueue = false
     boolean blockBuildUntilComplete = false
+    String token = ''
 
     void parameter(String name, String value) {
         this.parameters[name] = value
@@ -43,5 +44,9 @@ class ParameterizedRemoteTriggerContext implements Context {
      */
     boolean blockBuildUntilComplete(boolean blockUntilBuildComplete = true) {
         this.blockBuildUntilComplete = blockUntilBuildComplete
+    }
+
+    void token(String token = '') {
+        this.token = token
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -535,7 +535,7 @@ class StepContext extends AbstractExtensibleContext {
         List<String> jobParameters = context.parameters.collect { String key, String value -> "$key=$value" }
 
         stepNodes << new NodeBuilder().'org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration' {
-            token()
+            token(context.token)
             remoteJenkinsName(remoteJenkins)
             job(jobName)
             shouldNotFailBuild(context.shouldNotFailBuild)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
@@ -2192,7 +2192,7 @@ class StepContextSpec extends Specification {
         with(context.stepNodes[0]) {
             name() == 'org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration'
             children().size() == 14
-            token[0].value() == []
+            token[0].value() == ''
             remoteJenkinsName[0].value() == 'dev-ci'
             job[0].value() == 'test'
             shouldNotFailBuild[0].value() == false
@@ -2229,7 +2229,7 @@ class StepContextSpec extends Specification {
         with(context.stepNodes[0]) {
             name() == 'org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration'
             children().size() == 14
-            token[0].value() == []
+            token[0].value() == ''
             remoteJenkinsName[0].value() == 'dev-ci'
             job[0].value() == 'test'
             shouldNotFailBuild[0].value() == false
@@ -2265,6 +2265,7 @@ class StepContextSpec extends Specification {
             pollInterval 100
             preventRemoteBuildQueue true
             blockBuildUntilComplete true
+            token 'test'
         }
 
         then:
@@ -2272,7 +2273,7 @@ class StepContextSpec extends Specification {
         with(context.stepNodes[0]) {
             name() == 'org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration'
             children().size() == 14
-            token[0].value() == []
+            token[0].value() == 'test'
             remoteJenkinsName[0].value() == 'dev-ci'
             job[0].value() == 'test'
             shouldNotFailBuild[0].value() == true


### PR DESCRIPTION
This pull request adds support for the Parameterized Remote Trigger Plugin's ability to call a remote job utilizing a script token.

Support for the token appeared to already be available, but was being forced to empty-string. This change defaults it to empty string and allows it to be overridden with some arbitrary token.