### PR TITLE
[JENKINS-29753] Add support for gtester of xUnit plugin

### DIFF
--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -5526,6 +5526,7 @@ job {
             embUnit { ... }                                 // see aUnit closure above
             fpcUnit { ... }                                 // see aUnit closure above
             googleTest { ... }                              // see aUnit closure above
+            gtester { ... }                                 // see aUnit closure above
             jUnit { ... }                                   // see aUnit closure above
             msTest { ... }                                  // see aUnit closure above
             mbUnit { ... }                                  // see aUnit closure above

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/ArchiveXUnitContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/ArchiveXUnitContext.groovy
@@ -63,6 +63,10 @@ class ArchiveXUnitContext implements Context {
         addResultFile('GoogleTestType', resultFileClosure)
     }
 
+    void gtester(@DslContext(ArchiveXUnitResultFileContext) Closure resultFileClosure) {
+        addResultFile('GTesterJunitHudsonTestType', resultFileClosure)
+    }
+
     void jUnit(@DslContext(ArchiveXUnitResultFileContext) Closure resultFileClosure) {
         addResultFile('JUnitType', resultFileClosure)
     }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -447,6 +447,7 @@ class PublisherContextSpec extends Specification {
         'embUnit'    | 'EmbUnitType'
         'fpcUnit'    | 'FPCUnitJunitHudsonTestType'
         'googleTest' | 'GoogleTestType'
+        'gtester'    | 'GTesterJunitHudsonTestType'
         'jUnit'      | 'JUnitType'
         'msTest'     | 'MSTestJunitHudsonTestType'
         'mbUnit'     | 'MbUnitType'


### PR DESCRIPTION
1.95 and above supports gtester/glib2

https://wiki.jenkins-ci.org/display/JENKINS/xUnit+Plugin
