### PR TITLE
method to add Elastic axis to MatrixJob

### DIFF
--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -330,6 +330,7 @@ matrixJob(String name) { // since 1.30
         labelExpression(String name, Iterable<String> expressions)
         jdk(String... jdks)
         jdk(Iterable<String> jdks)
+        elastic(String name, String values)
         configure(Closure configBlock)
     }
     runSequentially(boolean runSequentially = true)
@@ -3432,6 +3433,23 @@ matrixJob('example') {
     }
 }
 ```
+
+### Elastic Axis
+
+Requires [Elastic Axis Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Elastic+Axis)
+
+Adds support for Elastic axis, which allows the same job to be run on a number of slaves across a label.
+This is useful for distributing tests, as well as running jobs related to slave setup.
+
+```groovy
+matrixJob {
+    axes {
+        elastic(String name, String values, boolean ignoreOffline=true)
+    }
+}
+```
+
+(Since 1.38)
 
 ### Run Sequentially
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/AxisContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/AxisContext.groovy
@@ -48,6 +48,16 @@ class AxisContext extends AbstractExtensibleContext {
         simpleAxis('JDK', 'jdk', axisValues)
     }
 
+    void elastic(String axisName, String axisValues, boolean ignoreOffline = true) {
+        NodeBuilder nodeBuilder = new NodeBuilder()
+
+        Node node = nodeBuilder.'org.jenkinsci.plugins.elasticaxisplugin.ElasticAxis'(plugin: 'elastic-axis@1.2')
+        node.appendNode('name', axisName)
+        node.appendNode('label', axisValues)
+        node.appendNode('ignoreOffline', ignoreOffline)
+        axisNodes << node
+    }
+
     void configure(Closure closure) {
         configureBlocks << closure
     }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/jobs/MatrixJobSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/jobs/MatrixJobSpec.groovy
@@ -76,6 +76,18 @@ class MatrixJobSpec extends Specification {
         job.node.axes[0].children()[0].name() == 'hudson.matrix.LabelAxis'
     }
 
+    def 'can set leastic axis'() {
+        when:
+        job.axes {
+            elastic('AXIS NAME1', 'label1')
+        }
+
+        then:
+        job.node.axes.size() == 1
+        job.node.axes[0].children().size() == 1
+        job.node.axes[0].children()[0].name() == 'org.jenkinsci.plugins.elasticaxisplugin.ElasticAxis'
+    }
+
     def 'axes configure block constructs xml'() {
         when:
         job.axes {


### PR DESCRIPTION
Hi,

This PR contains the code, unit tests and job reference update. I hope that it's in order.

Cheers,
Aleks

MatrixJob does not have a convinience method to add elastic axis. Define
it.

--Define elastic method under Axis node.
--Add a basic unit test.
--Update job reference

[JENKINS-29866]