### PR TITLE
Implented "Use NoExitSecurityManager as System.securityManager" option

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JobDSLConfig.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JobDSLConfig.java
@@ -1,0 +1,84 @@
+package javaposse.jobdsl.plugin;
+
+import hudson.Extension;
+
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+
+import javaposse.jobdsl.dsl.helpers.step.SystemGroovyContext;
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import jenkins.model.GlobalConfiguration;
+
+@Extension
+public class JobDSLConfig extends GlobalConfiguration {
+
+    private static String noExitSecurityManager;
+
+    public JobDSLConfig() {
+        // load configfile
+        load();
+    }
+
+    @Override
+    public synchronized void load() {
+        super.load();
+        initSecurityManager();
+    }
+
+    @Override
+    public synchronized void save() {
+        super.save();
+        initSecurityManager();
+    }
+
+    public void initSecurityManager() {
+        // create Configfile if not exists
+        if (noExitSecurityManager == null) {
+            noExitSecurityManager = "false"; //default
+            save();
+        } else {
+
+            if (noExitSecurityManager.toUpperCase().equals("TRUE")) {
+                System.setSecurityManager(new org.codehaus.groovy.tools.shell.util.NoExitSecurityManager());
+            } else {
+                if ((System.getSecurityManager()
+                        instanceof org.codehaus.groovy.tools.shell.util.NoExitSecurityManager)) {
+                    System.setSecurityManager(null);
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json)
+            throws FormException {
+        req.bindJSON(this, json);
+        save();
+        return true;
+    }
+
+    public String getNoExitSecurityManager() {
+        return noExitSecurityManager;
+    }
+
+    public void setNoExitSecurityManager(String noExitSecurityManager) {
+        this.noExitSecurityManager = noExitSecurityManager;
+        initSecurityManager();
+    }
+
+    public FormValidation doCheckNoExitSecurityManager(
+            @QueryParameter String noExitSecurityManager) {
+        if (noExitSecurityManager.toUpperCase().equals("TRUE")) {
+            if (!(System.getSecurityManager()
+                    instanceof org.codehaus.groovy.tools.shell.util.NoExitSecurityManager)) {
+                return FormValidation.warning(System.getSecurityManager() +
+                        " is actually set as SecurityManager for the Jenkins JVM. This will be overwritten on save!");
+            }
+        }
+        return FormValidation.ok();
+    }
+}

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/JobDSLConfig/config.jelly
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/JobDSLConfig/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:section title="${%JobDSLConfig}">
+    <f:entry title="${%Use NoExitSecurityManager as SecurityManager}" field="noExitSecurityManager">
+        <f:checkbox/>
+    </f:entry>
+  </f:section>
+</j:jelly>

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/JobDSLConfig/help-noExitSecurityManager.html
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/JobDSLConfig/help-noExitSecurityManager.html
@@ -1,0 +1,9 @@
+<p>
+    <strong>System.setSecurityManager(..)</strong><br><br>
+
+    Uses <b>System.setSecurityManager(..);</b> to set org.codehaus.groovy.tools.shell.util.<b>NoExitSecurityManager()</b> as the new SecurityManagerfor the whole Jenkins Master JVM.<br>
+    This will <b>prevent a System.exit()</b>; call in JobDSL GroovyScripts to prevent a Jenkins shutdown.<br><br>
+
+    <b>If the box is unchecked</b>, the System SecurityManagager will be set to "null".<br>
+    This will only happen if the previous SecurityManager was an instance of org.codehaus.groovy.tools.shell.util.NoExitSecurityManager.
+</p>


### PR DESCRIPTION
This request enables you to set the NoExitSecurityManager as SecurityManager for your Jenkins JVM in the global configurations.
This should be an easy way to prevent System.exit calls in JobDSL groovy scripts.