### PR TITLE
Support for Active Choice Reference Parameter

### DIFF
--- a/docs/Job-reference.md
+++ b/docs/Job-reference.md
@@ -66,6 +66,7 @@ freeStyleJob(String name) { // since 1.30
         textParam(String parameterName, String defaultValue = null,
                   String description = null)
         activeChoiceParam(String paramName, Closure closure) // since 1.36
+        activeChoiceReferenceParam(String paramName, Closure closure) // since 1.38
     }
     scm {
         baseClearCase(Closure closure) // since 1.24
@@ -6067,6 +6068,70 @@ job('example-2') {
 ```
 
 (since 1.36)
+
+### Active Choice Reference Parameter
+
+```groovy
+job {
+    parameters {
+        activeChoiceReferenceParam(String paramName) {
+            description(String description)
+            filterable(boolean filterable = true)
+            choiceType(String choiceType)
+            groovyScript {
+                script(String script)
+                fallbackScript(String fallbackScript)
+            }
+            scriptlerScript(String scriptId) {
+                parameter(String name, String value)
+            }
+            referencedParameter('referenced-param1')
+            referencedParameter('referenced-param2')
+        }
+    }
+}
+```
+
+Defines a Active Choice parameter with groovy script as source of parameter options. Requires the
+[Active Choices Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Active+Choices+Plugin).
+
+Valid values for `choiceType` are `'SINGLE_SELECT'` (default), `'MULTI_SELECT'`, `'CHECKBOX'` and `'RADIO'`.
+
+```groovy
+job('example-1') {
+    parameters {
+        booleanParam('BOOLEAN-PARAM-1')
+        activeChoiceReferenceParam('CHOICE-1') {
+            description('Allows user choose from multiple choices')
+            filterable()
+            choiceType('SINGLE_SELECT')
+            groovyScript {
+                script('["choice1", "choice2"]')
+                fallbackScript('"fallback choice"')
+            }
+            referencedParameter('BOOLEAN-PARAM-1')
+        }
+    }
+}
+
+job('example-2') {
+    parameters {
+        booleanParam('BOOLEAN-PARAM-1')
+        activeChoiceReferenceParam('CHOICE-1') {
+            description('Allows user choose from multiple choices')
+            filterable()
+            choiceType('SINGLE_SELECT')
+            scriptlerScript('scriptler-script1.groovy') {
+                parameter('param1', 'value1')
+                parameter('param2', 'value2')
+            }
+            referencedParameter('BOOLEAN-PARAM-1')
+        }
+    }
+}
+```
+
+(since 1.38)
 
 ### Label Parameter
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -6,6 +6,7 @@ import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.RequiresPlugin
 import javaposse.jobdsl.dsl.helpers.parameter.ActiveChoiceContext
+import javaposse.jobdsl.dsl.helpers.parameter.ActiveChoiceReferenceContext
 
 import static java.util.UUID.randomUUID
 import static javaposse.jobdsl.dsl.Preconditions.checkArgument
@@ -206,22 +207,26 @@ class BuildParametersContext extends AbstractContext {
     @RequiresPlugin(id = 'uno-choice', minimumVersion = '1.2')
     void activeChoiceParam(String paramName, @DslContext(ActiveChoiceContext) Closure closure) {
         checkNotNull(paramName, 'paramName cannot be null')
-        checkArgument(!buildParameterNodes.containsKey(paramName), 'parameter $paramName already defined')
+        checkArgument(!buildParameterNodes.containsKey(paramName), "parameter $paramName already defined")
 
         ActiveChoiceContext context = new ActiveChoiceContext()
         ContextHelper.executeInContext(closure, context)
 
-        Node node = new NodeBuilder().'org.biouno.unochoice.ChoiceParameter' {
-            name(paramName)
-            description(context.description ?: '')
-            randomName("choice-parameter-${System.nanoTime()}")
-            visibleItemCount(1)
-            choiceType("PT_${context.choiceType}")
-            filterable(context.filterable)
-        }
-        if (context.script) {
-            node.children().add(context.script)
-        }
-        buildParameterNodes[paramName] = node
+        buildParameterNodes[paramName] = context.createActiveChoiceNode(paramName)
+    }
+
+    /**
+     * @since 1.38
+     */
+    @RequiresPlugin(id = 'uno-choice', minimumVersion = '1.2')
+    void activeChoiceReferenceParam(String paramName,
+                                    @DslContext(ActiveChoiceReferenceContext) Closure closure = null) {
+        checkNotNull(paramName, 'paramName cannot be null')
+        checkArgument(!buildParameterNodes.containsKey(paramName), "parameter $paramName already defined")
+
+        ActiveChoiceReferenceContext context = new ActiveChoiceReferenceContext()
+        ContextHelper.executeInContext(closure, context)
+
+        buildParameterNodes[paramName] = context.createActiveChoiceNode(paramName)
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/ActiveChoiceContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/ActiveChoiceContext.groovy
@@ -11,6 +11,8 @@ class ActiveChoiceContext implements Context {
         'SINGLE_SELECT', 'MULTI_SELECT', 'CHECKBOX', 'RADIO'
     ]
 
+    final boolean supportsFilterable = true
+
     String description
     boolean filterable
     String choiceType = 'SINGLE_SELECT'
@@ -57,5 +59,28 @@ class ActiveChoiceContext implements Context {
                 }
             }
         }
+    }
+
+    static Node createGenericActiveChoiceNode(String type, String paramName, ActiveChoiceContext context, String
+            choiceTypePrefix, Closure additionalParams = {}) {
+        Node newNode = new NodeBuilder()."${type}" additionalParams << {
+            name(paramName)
+            description(context.description ?: '')
+            randomName("choice-parameter-${System.nanoTime()}")
+            visibleItemCount(1)
+            //parameters(class: 'linked-hash-map')
+            choiceType(choiceTypePrefix + context.choiceType)
+            if (context.supportsFilterable) {
+                filterable(context.filterable)
+            }
+        }
+        if (context.script) {
+            newNode.children().add(context.script)
+        }
+        newNode
+    }
+
+    Node createActiveChoiceNode(String paramName) {
+        createGenericActiveChoiceNode('org.biouno.unochoice.ChoiceParameter', paramName, this, 'PT_')
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/ActiveChoiceReferenceContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/ActiveChoiceReferenceContext.groovy
@@ -1,0 +1,19 @@
+package javaposse.jobdsl.dsl.helpers.parameter
+
+class ActiveChoiceReferenceContext extends ActiveChoiceContext {
+    Set<String> referencedParameters = []
+
+    void referencedParameter(String referencedParameters) {
+        this.referencedParameters << referencedParameters
+    }
+
+    @Override
+    Node createActiveChoiceNode(String paramName) {
+        Closure additionalParams = {
+            referencedParameters(referencedParameters.join(','))
+        }
+
+        createGenericActiveChoiceNode('org.biouno.unochoice.CascadeChoiceParameter', paramName, this, 'PT_',
+                additionalParams)
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -971,4 +971,57 @@ class BuildParametersContextSpec extends Specification {
         }
         1 * jobManagement.requireMinimumPluginVersion('uno-choice', '1.2')
     }
+
+    def 'active choice reference without options'() {
+        when:
+        context.activeChoiceReferenceParam('activeChoiceReferenceParam') {
+        }
+
+        then:
+        context.buildParameterNodes != null
+        context.buildParameterNodes.size() == 1
+        with(context.buildParameterNodes['activeChoiceReferenceParam']) {
+            name() == 'org.biouno.unochoice.CascadeChoiceParameter'
+            children().size() == 7
+            description.text() == ''
+            visibleItemCount.text() == '1'
+            filterable.text() == 'false'
+            choiceType.text() == 'PT_SINGLE_SELECT'
+            script.text() == ''
+            referencedParameters.text() == ''
+        }
+    }
+
+    def 'active choice reference with all options and groovy script'() {
+        when:
+        context.activeChoiceReferenceParam('activeChoiceReferenceScriptlerParam') {
+            description('Active choice param test')
+            filterable()
+            choiceType('SINGLE_SELECT')
+            groovyScript {
+                script('x1')
+                fallbackScript('x2')
+            }
+            referencedParameter('param1')
+            referencedParameter('param2')
+        }
+
+        then:
+        context.buildParameterNodes != null
+        context.buildParameterNodes.size() == 1
+        with(context.buildParameterNodes['activeChoiceReferenceScriptlerParam']) {
+            name() == 'org.biouno.unochoice.CascadeChoiceParameter'
+            description.text() == 'Active choice param test'
+            visibleItemCount.text() == '1'
+            filterable.text() == 'true'
+            choiceType.text() == 'PT_SINGLE_SELECT'
+            with(script[0]) {
+                attributes()['class'] == 'org.biouno.unochoice.model.GroovyScript'
+                children().size() == 2
+                script.text() == 'x1'
+                fallbackScript.text() == 'x2'
+            }
+            referencedParameters.text().split(',') == ['param1', 'param2']
+        }
+    }
 }


### PR DESCRIPTION
Support for additional type of Active Choice Parameter - Active Choice Reference Parameter. Added tests, documentation and one new class `ActiveChoiceReferenceContext` extending `ActiveChoiceContext`. As `activeChoiceReferenceParam` differs from `activeChoiceParam` in reference part and XML element name, XML part is moved to parametrized `createGenericActiveChoiceNode`.