### PR TITLE
[JENKINS-30013] Add support for later versions of config-file-provider-plugin

### DIFF
--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -62,5 +62,5 @@ dependencies {
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:cloudbees-folder:4.4@jar'
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:credentials:1.9.4@jar'
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:vsphere-cloud:1.1.11@jar'
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.7@jar'
+    optionalJenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.8.1@jar'
 }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ConfigFileProviderHelper.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ConfigFileProviderHelper.groovy
@@ -35,6 +35,7 @@ class ConfigFileProviderHelper {
                         configFile.name,
                         configFile.comment,
                         configFile.content,
+                        null,
                         null
                 )
             default:


### PR DESCRIPTION
More recent version (starting with 2.8.1) have a different constructor signature for `MavenSettingsConfig` causing the DSL plugin to fail with later version of the plugin (was failing yesterday with 2.9.2).

Switched to using a data binder similar to StaplerRequest.bind to support any constructor signature as long as it is annotated with `@DataBoundConstructor`. Constructor parameters are now provided as a Map and all supported parameters will be passed to the constructor.