### PR TITLE
Adding parameters node for active choice parameters

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -220,6 +220,7 @@ class BuildParametersContext extends AbstractContext {
 
         Node node = createActiveChoiceNode('org.biouno.unochoice.CascadeChoiceParameter', parameterName, context)
         node.appendNode('referencedParameters', context.referencedParameters.join(', '))
+        node.appendNode('parameters').attributes().put('class', 'linked-hash-map')
 
         buildParameterNodes[parameterName] = node
     }
@@ -239,6 +240,7 @@ class BuildParametersContext extends AbstractContext {
         node.appendNode('referencedParameters', context.referencedParameters.join(', '))
         node.appendNode('choiceType', "ET_${context.choiceType}")
         node.appendNode('omitValueField', context.omitValueField)
+        node.appendNode('parameters').attributes().put('class', 'linked-hash-map')
 
         buildParameterNodes[parameterName] = node
     }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -981,7 +981,8 @@ class BuildParametersContextSpec extends Specification {
         context.buildParameterNodes.size() == 1
         with(context.buildParameterNodes['activeChoiceReferenceParam']) {
             name() == 'org.biouno.unochoice.CascadeChoiceParameter'
-            children().size() == 7
+            children().size() == 8
+            parameters[0].attributes()['class'] == 'linked-hash-map'
             description.text() == ''
             randomName.text() =~ /choice-parameter-\d+/
             visibleItemCount.text() == '1'
@@ -1009,7 +1010,8 @@ class BuildParametersContextSpec extends Specification {
         then:
         context.buildParameterNodes.size() == 1
         with(context.buildParameterNodes['activeChoiceReferenceScriptlerParam']) {
-            children().size() == 8
+            children().size() == 9
+            parameters[0].attributes()['class'] == 'linked-hash-map'
             name() == 'org.biouno.unochoice.CascadeChoiceParameter'
             description.text() == 'Active choice param test'
             randomName.text() =~ /choice-parameter-\d+/
@@ -1035,7 +1037,8 @@ class BuildParametersContextSpec extends Specification {
         context.buildParameterNodes.size() == 1
         with(context.buildParameterNodes['activeChoiceReactiveReferenceParam']) {
             name() == 'org.biouno.unochoice.DynamicReferenceParameter'
-            children().size() == 7
+            children().size() == 8
+            parameters[0].attributes()['class'] == 'linked-hash-map'
             description.text() == ''
             randomName.text() =~ /choice-parameter-\d+/
             visibleItemCount.text() == '1'
@@ -1062,7 +1065,8 @@ class BuildParametersContextSpec extends Specification {
         then:
         context.buildParameterNodes.size() == 1
         with(context.buildParameterNodes['activeChoiceReactiveReferenceScriptlerParam']) {
-            children().size() == 8
+            children().size() == 9
+            parameters[0].attributes()['class'] == 'linked-hash-map'
             name() == 'org.biouno.unochoice.DynamicReferenceParameter'
             description.text() == 'Active choice reactive reference param test with scriptler script'
             randomName.text() =~ /choice-parameter-\d+/


### PR DESCRIPTION
`<parameters class="linked-hash-map"/>` is required in active choice
parameters definition for proper function of reactive variants.
Without this parameters node generated by job-dsl, reference
variants do not work properly and you need to open job configuration
and save it.