### PR TITLE
Fix NPE When GeneratedJobs is out of Date.

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
@@ -355,7 +355,9 @@ public class ExecuteDslScripts extends Builder {
                 SeedReference newSeedReference = new SeedReference(seedJob.getFullName());
                 if (generatedJob.getTemplateName() != null) {
                     Item template = getLookupStrategy().getItem(seedJob, generatedJob.getTemplateName(), Item.class);
-                    newSeedReference.setTemplateJobName(template.getFullName());
+                    if (template != null) {
+                        newSeedReference.setTemplateJobName(template.getFullName());
+                    }
                 }
                 newSeedReference.setDigest(Util.getDigestOf(Items.getConfigFile(item).getFile()));
 


### PR DESCRIPTION
`job-dsl` should gracefully continue when a template no longer exists.

For background, this is what happened, we had a build which threw an exception unexpectedly:

```
07:02:52 ERROR: Build step failed with exception
07:02:52 java.util.ConcurrentModificationException
07:02:52 	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1429)
07:02:52 	at java.util.HashMap$KeyIterator.next(HashMap.java:1453)
07:02:52 	at com.google.common.collect.AbstractMultimap$WrappedCollection$WrappedIterator.next(AbstractMultimap.java:531)
07:02:52 	at com.google.common.collect.Iterators$7.computeNext(Iterators.java:648)
07:02:52 	at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:143)
07:02:52 	at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:138)
07:02:52 	at java.util.AbstractSet.removeAll(AbstractSet.java:173)
07:02:52 	at com.google.common.collect.AbstractMultimap$WrappedCollection.removeAll(AbstractMultimap.java:617)
07:02:52 	at javaposse.jobdsl.plugin.ExecuteDslScripts.updateTemplates(ExecuteDslScripts.java:272)
07:02:52 	at javaposse.jobdsl.plugin.ExecuteDslScripts.perform(ExecuteDslScripts.java:223)
07:02:52 	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
07:02:52 	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:779)
07:02:52 	at hudson.model.Build$BuildExecution.build(Build.java:205)
07:02:52 	at hudson.model.Build$BuildExecution.doRun(Build.java:162)
07:02:52 	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:537)
07:02:52 	at hudson.model.Run.execute(Run.java:1741)
07:02:52 	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
07:02:52 	at hudson.model.ResourceController.execute(ResourceController.java:98)
07:02:52 	at hudson.model.Executor.run(Executor.java:408)
```

Subsequent builds seemed to fail because `GeneratedJobs` were out of date.

```
9:49:31 ERROR: Build step failed with exception
19:49:31 java.lang.NullPointerException
19:49:31 	at javaposse.jobdsl.plugin.ExecuteDslScripts.updateGeneratedJobMap(ExecuteDslScripts.java:358)
19:49:31 	at javaposse.jobdsl.plugin.ExecuteDslScripts.updateGeneratedJobs(ExecuteDslScripts.java:343)
19:49:31 	at javaposse.jobdsl.plugin.ExecuteDslScripts.perform(ExecuteDslScripts.java:224)
19:49:31 	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
19:49:31 	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:779)
19:49:31 	at hudson.model.Build$BuildExecution.build(Build.java:205)
19:49:31 	at hudson.model.Build$BuildExecution.doRun(Build.java:162)
19:49:31 	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:537)
19:49:31 	at hudson.model.Run.execute(Run.java:1741)
19:49:31 	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
19:49:31 	at hudson.model.ResourceController.execute(ResourceController.java:98)
19:49:31 	at hudson.model.Executor.run(Executor.java:408)
19:49:31 Build step 'Process Job DSLs' marked build as failure
```
