### PR TITLE
add functionality to use freestyle templates for matrix jobs

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
@@ -13,6 +13,7 @@ import javaposse.jobdsl.dsl.helpers.toplevel.NotificationContext
 import javaposse.jobdsl.dsl.helpers.toplevel.ThrottleConcurrentBuildsContext
 import javaposse.jobdsl.dsl.helpers.triggers.TriggerContext
 import javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext
+import javaposse.jobdsl.dsl.coercion.Template
 
 import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 import static javaposse.jobdsl.dsl.Preconditions.checkNotNull
@@ -592,7 +593,11 @@ abstract class Job extends Item {
         Node emptyTemplateNode = executeEmptyTemplate()
 
         if (emptyTemplateNode.name() != templateNode.name()) {
-            throw new JobTypeMismatchException(name, templateName)
+            //maybe we can coerce the template into our required type
+            templateNode = new Template().coerce(templateNode, emptyTemplateNode.name())
+            if (emptyTemplateNode.name() != templateNode.name()) {
+                throw new JobTypeMismatchException(name, templateName)
+            }
         }
 
         templateNode

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/coercion/AbstractCoercer.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/coercion/AbstractCoercer.groovy
@@ -1,0 +1,9 @@
+package javaposse.jobdsl.dsl.coercion
+
+/**
+ *
+ */
+abstract class AbstractCoercer {
+
+    abstract coerce(Node original)
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/coercion/Template.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/coercion/Template.groovy
@@ -1,0 +1,30 @@
+package javaposse.jobdsl.dsl.coercion
+
+/**
+ * class to coerce templates from one job type to another
+ * coercion helper classes need to be called javaposse.jobdsl.dsl.coercion.<from>.To
+ * and inherit from {@link AbstractCoercer}
+ *
+ * hyphens need to be swallowed
+ *
+ * e.g. javaposse.jobdsl.dsl.coercion.project.MatrixProject
+ * for the class to coerce project to matrix-project
+ */
+ class Template {
+
+     final Node coerce(Node existing, String to) {
+
+         String  toCamel = to.capitalize().replaceAll(/-\w/) { it[1].toUpperCase() }
+         String  fromClean = existing.name().replaceAll(/-/) { '' }
+
+         try {
+             String coercer = "javaposse.jobdsl.dsl.coercion.${fromClean}.${toCamel}"
+             AbstractCoercer instance = this.class.classLoader.loadClass(coercer)?.newInstance()
+             instance.coerce(existing)
+         } catch (ClassNotFoundException ex) {
+             //there is no class to coerce from to to
+             existing
+         }
+    }
+
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/coercion/matrixproject/Project.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/coercion/matrixproject/Project.groovy
@@ -1,0 +1,24 @@
+package javaposse.jobdsl.dsl.coercion.matrixproject
+
+import javaposse.jobdsl.dsl.coercion.AbstractCoercer
+
+/**
+ * convert a matrix-project to a project
+ */
+class Project extends AbstractCoercer {
+
+    @Override
+    Node coerce(Node existing) {
+
+        existing.name = 'project'
+        existing.attributes().remove('plugin')
+
+        existing.findAll { node ->
+            node.name() =~ /(axes|executionStrategy|childCustomWorkspace|combinationFilter)/ }.each {
+                existing.remove(it)
+        }
+
+        existing
+    }
+
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/coercion/project/MatrixProject.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/coercion/project/MatrixProject.groovy
@@ -1,0 +1,27 @@
+package javaposse.jobdsl.dsl.coercion.project
+
+import javaposse.jobdsl.dsl.coercion.AbstractCoercer
+
+/**
+ * convert a project to a matrixproject
+ */
+class MatrixProject extends AbstractCoercer {
+
+    @Override
+    @SuppressWarnings('UnusedObject')
+    Node coerce(Node existing) {
+        //Node coerced = existing.clone()
+
+        existing.name = 'matrix-project'
+        existing.attributes().remove('plugin')
+
+        new Node(existing, 'axes')
+
+        Node es = new Node(existing, 'executionStrategy', [class: 'hudson.matrix.DefaultMatrixExecutionStrategyImpl'])
+        Node rs = new Node(es, 'runSequentially' )
+        rs.setValue('false')
+
+        existing
+    }
+
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/CoerceSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/CoerceSpec.groovy
@@ -1,0 +1,49 @@
+package javaposse.jobdsl.dsl
+
+import javaposse.jobdsl.dsl.jobs.FreeStyleJob
+import javaposse.jobdsl.dsl.jobs.MatrixJob
+import org.custommonkey.xmlunit.XMLUnit
+import spock.lang.Specification
+
+class CoerceSpec extends Specification {
+    private final resourcesDir = new File(getClass().getResource('/simple.dsl').toURI()).parentFile
+    private final JobManagement jm = new FileJobManagement(resourcesDir)
+
+    def setup() {
+        XMLUnit.setIgnoreWhitespace(true)
+    }
+
+    def 'Matrix job coerces to FreeStyleJob'() {
+        setup:
+        JobManagement jm = new FileJobManagement(resourcesDir)
+        FreeStyleJob job = new FreeStyleJob(jm)
+
+        when:
+        job.using('matrix')
+        String project = job.xml
+
+        then:
+        project.contains('<project>')
+        ! project.contains('<matrix-project>')
+        ! project.contains('<axes>')
+        ! project.contains('executionStrategy')
+        ! project.contains('<childCustomWorkspace>')
+        ! project.contains('<combinationFilter>')
+    }
+
+    def 'FreeStyle job coerces to MatrixJob'() {
+        setup:
+        JobManagement jm = new FileJobManagement(resourcesDir)
+        MatrixJob job = new MatrixJob(jm)
+
+        when:
+        job.using('job')
+        String project = job.xml
+
+        then:
+        project.contains('<matrix-project>')
+        ! project.contains('<project>')
+        project.contains('<axes>')
+        project.contains('executionStrategy')
+    }
+}

--- a/job-dsl-core/src/test/resources/matrix.xml
+++ b/job-dsl-core/src/test/resources/matrix.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<matrix-project plugin="matrix-project@1.4">
+    <actions/>
+    <description>Build and test the app.</description>
+    <keepDependencies>false</keepDependencies>
+    <properties/>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <customWorkspace>matrix</customWorkspace>
+    <axes>
+        <hudson.matrix.TextAxis>
+            <name>ddd</name>
+            <values>
+                <string>a</string>
+                <string>b</string>
+                <string>c</string>
+            </values>
+        </hudson.matrix.TextAxis>
+        <hudson.matrix.TextAxis>
+            <name>eee</name>
+            <values>
+                <string>a</string>
+                <string>b</string>
+                <string>c</string>
+            </values>
+        </hudson.matrix.TextAxis>
+    </axes>
+    <combinationFilter>eee=='a'||ddd=='c'</combinationFilter>
+    <builders>
+        <hudson.tasks.Shell>
+            <command>ps</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+            <command>env |sort</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+            <command>ps</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+            <command>env |sort</command>
+        </hudson.tasks.Shell>
+    </builders>
+    <publishers/>
+    <buildWrappers/>
+    <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
+        <runSequentially>true</runSequentially>
+        <touchStoneCombinationFilter>eee=='b'</touchStoneCombinationFilter>
+        <touchStoneResultCondition>
+            <name>SUCCESS</name>
+            <ordinal>0</ordinal>
+            <color>BLUE</color>
+            <completeBuild>true</completeBuild>
+        </touchStoneResultCondition>
+    </executionStrategy>
+    <childCustomWorkspace>matrix2</childCustomWorkspace>
+</matrix-project>


### PR DESCRIPTION
Whist you can't change a job type once it exists, what is possible is to create a new job based on a template of a different type. I did this for freestyle and matrix jobs as that seemed the most obvious.

It works by adding or removing elements and changing the type. Hopefully it is extendible to swap between other job types by writing the class to coerce it