### PR TITLE
Feature/jenkins 30221 missing delivery pipeline configuration items

### DIFF
--- a/docs/View-Reference.md
+++ b/docs/View-Reference.md
@@ -261,11 +261,11 @@ deliveryPipelineView(String name) {  // since 1.30
     enableManualTriggers(boolean enable = true)
     showAvatars(boolean showAvatars = true)
     showChangeLog(boolean showChangeLog = true)
-    showTotalBuildTime(boolean value = true)
-    allowRebuild(boolean value = true)
-    allowPipelineStart(boolean value = true)
-    showDescription(boolean value = true)
-    showPromotions(boolean value = true)
+    showTotalBuildTime(boolean value = true)    // since 1.38
+    allowRebuild(boolean value = true)          // since 1.38
+    allowPipelineStart(boolean value = true)    // since 1.38
+    showDescription(boolean value = true)       // since 1.38
+    showPromotions(boolean value = true)        // since 1.38
     pipelines {
         component(String name, String initialJob)
         regex(String regex)

--- a/docs/View-Reference.md
+++ b/docs/View-Reference.md
@@ -261,6 +261,11 @@ deliveryPipelineView(String name) {  // since 1.30
     enableManualTriggers(boolean enable = true)
     showAvatars(boolean showAvatars = true)
     showChangeLog(boolean showChangeLog = true)
+    showTotalBuildTime(boolean value = true)
+    allowRebuild(boolean value = true)
+    allowPipelineStart(boolean value = true)
+    showDescription(boolean value = true)
+    showPromotions(boolean value = true)
     pipelines {
         component(String name, String initialJob)
         regex(String regex)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/DeliveryPipelineView.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/DeliveryPipelineView.groovy
@@ -59,6 +59,36 @@ class DeliveryPipelineView extends View {
         }
     }
 
+    void showTotalBuildTime(boolean value = true) {
+        execute {
+            it / methodMissing('showTotalBuildTime', value)
+        }
+    }
+
+    void allowRebuild(boolean value = true) {
+        execute {
+            it / methodMissing('allowRebuild', value)
+        }
+    }
+
+    void allowPipelineStart(boolean value = true) {
+        execute {
+            it / methodMissing('allowPipelineStart', value)
+        }
+    }
+
+    void showDescription(boolean value = true) {
+        execute {
+            it / methodMissing('showDescription', value)
+        }
+    }
+
+    void showPromotions(boolean value = true) {
+        execute {
+            it / methodMissing('showPromotions', value)
+        }
+    }
+
     void pipelines(@DslContext(DeliveryPipelinesContext) Closure pipelinesClosure) {
         DeliveryPipelinesContext context = new DeliveryPipelinesContext()
         executeInContext(pipelinesClosure, context)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/DeliveryPipelineViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/DeliveryPipelineViewSpec.groovy
@@ -49,6 +49,12 @@ class DeliveryPipelineViewSpec extends Specification {
             updateInterval(60)
             showChangeLog()
             enableManualTriggers()
+            showTotalBuildTime()
+            allowRebuild()
+            allowPipelineStart()
+            showDescription()
+            showPromotions()
+
             pipelines {
                 component('test', 'compile-a')
                 regex(/compile-(.*)/)
@@ -102,6 +108,11 @@ class DeliveryPipelineViewSpec extends Specification {
     <updateInterval>60</updateInterval>
     <showChanges>true</showChanges>
     <allowManualTriggers>true</allowManualTriggers>
+    <showTotalBuildTime>true</showTotalBuildTime>
+    <allowRebuild>true</allowRebuild>
+    <allowPipelineStart>true</allowPipelineStart>
+    <showDescription>true</showDescription>
+    <showPromotions>true</showPromotions>
     <componentSpecs>
         <se.diabol.jenkins.pipeline.DeliveryPipelineView_-ComponentSpec>
             <name>test</name>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-30221

Adds the following options to the DSL to support features in DeliveryPipeline plugin 0.9.5

    showTotalBuildTime(boolean value = true)    // since 1.38
    allowRebuild(boolean value = true)          // since 1.38
    allowPipelineStart(boolean value = true)    // since 1.38
    showDescription(boolean value = true)       // since 1.38
    showPromotions(boolean value = true)        // since 1.38
