### PR TITLE
[Jenkins 21880] weblogic deployer plugin support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ project(':job-dsl-core') {
         compile 'xmlunit:xmlunit:1.4' // for runtime use, not just for testing
         compile 'org.jenkins-ci:version-number:1.1'
         compile 'org.jvnet.hudson:xstream:1.4.7-jenkins-1'
+        compile 'commons-lang:commons-lang:2.6' // For WeblogicDeployerPlugin task id generation
     }
 
     codenarcExamples {

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -19,6 +19,7 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
 
 ## Release Notes
 * 1.39 (unreleased)
+ * Added support for the [WebLogic Deployer Plugin](https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin)
  * Increased the minimum supported Jenkins version to 1.596
  * Enhanced support for the [Subversion Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Subversion+Plugin)
  * Enhanced support for the

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/deployToWeblogic.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/deployToWeblogic.groovy
@@ -1,6 +1,6 @@
 job('example') {
     publishers {
-        deployToWeblogic {
+        deployToWeblogic() {
             // these are the default values used for optional fields, when not overridden by closure
             mustExitOnFailure false
             forceStopOnFirstFailure false

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/deployToWeblogic.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/deployToWeblogic.groovy
@@ -1,0 +1,43 @@
+job('example') {
+    publishers {
+        deployToWeblogic {
+            // these are the default values used for optional fields, when not overridden by closure
+            mustExitOnFailure false
+            forceStopOnFirstFailure false
+            deployingOnlyWhenUpdates false
+
+            deployedProjectsDependencies ''
+
+            // min. one task is required
+            task {
+                // required
+                weblogicEnvironmentTargetedName 'dev_environment'
+                // required
+                deploymentName 'myApplicationName'
+
+                deploymentTargets 'AdminServer'
+
+                // required
+                builtResourceRegexToDeploy 'myApp\\.ear'
+                // required
+                baseResourcesGeneratedDirectory ''
+                // required
+                taskName 'Deploy myApp to DEV Server'
+
+                jdkName 'JDK_7'
+                jdkHome 'C:\\Program Files\\Java\\jdk1.7.0_65'
+
+                // one of: WeblogicDeploymentStageModes
+                stageMode WeblogicDeploymentStageModes.BY_DEFAULT
+                commandLine '-debug -remote -verbose -name {wl.deployment_name} -targets {wl.targets} ' +
+                        '-adminurl t3://{wl.host}:{wl.port} -user {wl.login} -password {wl.password} ' +
+                        '-undeploy -noexit;\n' +
+
+                        '-debug -remote -verbose -name {wl.deployment_name} -source {wl.source}' +
+                        ' -targets {wl.targets} -adminurl t3://{wl.host}:{wl.port} -user {wl.login}' +
+                        ' -password {wl.password} -deploy -stage -upload;'
+                deploymentPlan ''
+            }
+        }
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -44,6 +44,8 @@ public class DslScriptLoader {
         icz.addStaticStars("javaposse.jobdsl.dsl.ViewType");
         icz.addStaticStars("javaposse.jobdsl.dsl.ConfigFileType");
         icz.addStaticStars("javaposse.jobdsl.dsl.helpers.common.MavenContext.LocalRepositoryLocation");
+        icz.addImports("javaposse.jobdsl.dsl.helpers.publisher.WeblogicDeployerContext.WeblogicDeploymentStageModes");
+        icz.addImports("javaposse.jobdsl.dsl.helpers.publisher.WeblogicDeployerPolicyContext.WeblogicDeploymentPolicies");
         config.addCompilationCustomizers(icz);
 
         GroovyScriptEngine engine = new GroovyScriptEngine(scriptRequest.getUrlRoots(), cl);

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -682,7 +682,7 @@ class PublisherContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'description-setter')
     void buildDescription(String regularExpression, String description = '', String regularExpressionForFailed = '',
-                         String descriptionForFailed = '', boolean multiConfigurationBuild = false) {
+                          String descriptionForFailed = '', boolean multiConfigurationBuild = false) {
         publisherNodes << new NodeBuilder().'hudson.plugins.descriptionsetter.DescriptionSetterPublisher' {
             regexp(regularExpression)
             regexpForFailed(regularExpressionForFailed)
@@ -703,7 +703,7 @@ class PublisherContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'text-finder')
     void textFinder(String regularExpression, String fileSet = '', boolean alsoCheckConsoleOutput = false,
-                   boolean succeedIfFound = false, unstableIfFound = false) {
+                    boolean succeedIfFound = false, unstableIfFound = false) {
         publisherNodes << new NodeBuilder().'hudson.plugins.textfinder.TextFinderPublisher' {
             if (fileSet) {
                 delegate.fileSet(fileSet)
@@ -799,10 +799,10 @@ class PublisherContext extends AbstractExtensibleContext {
             if (jobManagement.getPluginVersion('groovy-postbuild')?.isOlderThan(new VersionNumber('2.2'))) {
                 groovyScript(groovyPostbuildContext.script ?: '')
             } else {
-              script {
-                script(groovyPostbuildContext.script ?: '')
-                sandbox(groovyPostbuildContext.sandbox)
-              }
+                script {
+                    script(groovyPostbuildContext.script ?: '')
+                    sandbox(groovyPostbuildContext.sandbox)
+                }
             }
             behavior(groovyPostbuildContext.behavior.value)
         }
@@ -1306,11 +1306,11 @@ class PublisherContext extends AbstractExtensibleContext {
     void warnings(List consoleParsers, Map parserConfigurations = [:],
                   @DslContext(WarningsContext) Closure warningsClosure = null) {
         WarningsContext warningsContext = new WarningsContext()
-        ContextHelper.executeInContext(warningsClosure,  warningsContext)
+        ContextHelper.executeInContext(warningsClosure, warningsContext)
 
         NodeBuilder nodeBuilder = new NodeBuilder()
         publisherNodes << nodeBuilder.'hudson.plugins.warnings.WarningsPublisher' {
-            addStaticAnalysisContext(delegate,  warningsContext)
+            addStaticAnalysisContext(delegate, warningsContext)
             includePattern(warningsContext.includePattern)
             excludePattern(warningsContext.excludePattern)
             nodeBuilder.consoleParsers {
@@ -1339,7 +1339,7 @@ class PublisherContext extends AbstractExtensibleContext {
     @RequiresPlugin(id = 'analysis-collector')
     void analysisCollector(@DslContext(AnalysisCollectorContext) Closure analysisCollectorClosure = null) {
         AnalysisCollectorContext analysisCollectorContext = new AnalysisCollectorContext()
-        ContextHelper.executeInContext(analysisCollectorClosure,  analysisCollectorContext)
+        ContextHelper.executeInContext(analysisCollectorClosure, analysisCollectorContext)
 
         publisherNodes << new NodeBuilder().'hudson.plugins.analysis.collector.AnalysisPublisher' {
             addStaticAnalysisContext(delegate, analysisCollectorContext)
@@ -1608,77 +1608,38 @@ class PublisherContext extends AbstractExtensibleContext {
         }
     }
 
-        /**
-          * <p>Configures a Weblogic deployment using the weblogic-deployer-plugin</p>
-          * <p>By default the following values are applied. If an instance of a
-          * closure is provided, the values from the closure will take effect.</p>
-          *
-          * <pre>
-          * {@code
-          * <org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin>
-          *     <mustExitOnFailure>false</mustExitOnFailure>
-          *     <forceStopOnFirstFailure>false</forceStopOnFirstFailure>
-          *     <selectedDeploymentStrategyIds/>
-          *     <isDeployingOnlyWhenUpdates>false</isDeployingOnlyWhenUpdates>
-          *     <deployedProjectsDependencies></deployedProjectsDependencies>
-          *     <tasks>
-          *         <org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask>
-          *             <id>qGVVG2aOeF</id>
-          *             <taskName>Deploy myApp</taskName>
-          *
-          *             <weblogicEnvironmentTargetedName>environment name</weblogicEnvironmentTargetedName>
-          *             <deploymentName>application name</deploymentName>
-          *             <deploymentTargets>myManagedServer, AdminServer</deploymentTargets>
-          *             <isLibrary>false</isLibrary>
-          *             <builtResourceRegexToDeploy>myApp\.ear</builtResourceRegexToDeploy>
-          *             <baseResourcesGeneratedDirectory></baseResourcesGeneratedDirectory>
-          *
-          *             <jdk>
-          *               <!-- When leaving these tags empty, the default JDK should be used.
-          *                    Otherwise name and home must be set. -->
-          *               <name>JDK 7u51</name>
-          *               <home></home>
-          *               <properties/>
-          *             </jdk>
-          *
-          *             <stageMode>stage</stageMode>
-          *             <commandLine></commandLine>
-          *             <deploymentPlan></deploymentPlan>
-          *         </org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask>
-          *         <org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask>
-          *           ...
-          *         </org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask>
-          *     </tasks>
-          * </org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin>
-          *}
-          * </pre>
-          *
-          * @since 1.39
-          * @see https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
-          */
-        @RequiresPlugin(id = 'weblogic-deployer-plugin', minimumVersion = '2.9.1')
-        void deployToWeblogic(Closure weblogicClosure) {
+    /**
+     * Configures a Weblogic deployment using the weblogic-deployer-plugin.
+     *
+     * By default the following values are applied. If an instance of a
+     * closure is provided, the values from the closure will take effect.
+     *
+     * @since 1.39
+     * @see https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
+     */
+    @RequiresPlugin(id = 'weblogic-deployer-plugin', minimumVersion = '2.9.1')
+    void deployToWeblogic(Closure weblogicClosure) {
 
-            WeblogicDeployerContext context = new WeblogicDeployerContext()
-            ContextHelper.executeInContext(weblogicClosure, context)
+        WeblogicDeployerContext context = new WeblogicDeployerContext()
+        ContextHelper.executeInContext(weblogicClosure, context)
 
-            NodeBuilder nodeBuilder = NodeBuilder.newInstance()
-            Node weblogicDeployerNode = nodeBuilder.'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin' {
+        NodeBuilder nodeBuilder = NodeBuilder.newInstance()
+        Node weblogicDeployerNode = nodeBuilder.'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin' {
 
-                mustExitOnFailure context.mustExitOnFailure
-                forceStopOnFirstFailure context.forceStopOnFirstFailure
-                isDeployingOnlyWhenUpdates context.deployingOnlyWhenUpdates
-                deployedProjectsDependencies context.deployedProjectsDependencies
+            mustExitOnFailure context.mustExitOnFailure
+            forceStopOnFirstFailure context.forceStopOnFirstFailure
+            isDeployingOnlyWhenUpdates context.deployingOnlyWhenUpdates
+            deployedProjectsDependencies context.deployedProjectsDependencies
 
-                selectedDeploymentStrategyIds context.deploymentPoliciesIdsNodes
+            selectedDeploymentStrategyIds context.deploymentPoliciesIdsNodes
 
-                if (context.taskNodes) {
-                    tasks context.taskNodes
-                }
+            if (context.taskNodes) {
+                tasks context.taskNodes
             }
-
-            publisherNodes << weblogicDeployerNode
         }
+
+        publisherNodes << weblogicDeployerNode
+    }
 
     @SuppressWarnings('NoDef')
     private static addStaticAnalysisContext(def nodeBuilder, StaticAnalysisContext context) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1653,6 +1653,7 @@ class PublisherContext extends AbstractExtensibleContext {
           *}
           * </pre>
           *
+          * @since 1.39
           * @see https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
           */
         @RequiresPlugin(id = 'weblogic-deployer-plugin', minimumVersion = '2.9.1')

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1608,6 +1608,77 @@ class PublisherContext extends AbstractExtensibleContext {
         }
     }
 
+        /**
+          * <p>Configures a Weblogic deployment using the weblogic-deployer-plugin</p>
+          * <p>By default the following values are applied. If an instance of a
+          * closure is provided, the values from the closure will take effect.</p>
+          *
+          * <pre>
+          * {@code
+          * <org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin>
+          *     <mustExitOnFailure>false</mustExitOnFailure>
+          *     <forceStopOnFirstFailure>false</forceStopOnFirstFailure>
+          *     <selectedDeploymentStrategyIds/>
+          *     <isDeployingOnlyWhenUpdates>false</isDeployingOnlyWhenUpdates>
+          *     <deployedProjectsDependencies></deployedProjectsDependencies>
+          *     <tasks>
+          *         <org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask>
+          *             <id>qGVVG2aOeF</id>
+          *             <taskName>Deploy myApp</taskName>
+          *
+          *             <weblogicEnvironmentTargetedName>environment name</weblogicEnvironmentTargetedName>
+          *             <deploymentName>application name</deploymentName>
+          *             <deploymentTargets>myManagedServer, AdminServer</deploymentTargets>
+          *             <isLibrary>false</isLibrary>
+          *             <builtResourceRegexToDeploy>myApp\.ear</builtResourceRegexToDeploy>
+          *             <baseResourcesGeneratedDirectory></baseResourcesGeneratedDirectory>
+          *
+          *             <jdk>
+          *               <!-- When leaving these tags empty, the default JDK should be used.
+          *                    Otherwise name and home must be set. -->
+          *               <name>JDK 7u51</name>
+          *               <home></home>
+          *               <properties/>
+          *             </jdk>
+          *
+          *             <stageMode>stage</stageMode>
+          *             <commandLine></commandLine>
+          *             <deploymentPlan></deploymentPlan>
+          *         </org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask>
+          *         <org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask>
+          *           ...
+          *         </org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask>
+          *     </tasks>
+          * </org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin>
+          *}
+          * </pre>
+          *
+          * @see https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
+          */
+        @RequiresPlugin(id = 'weblogic-deployer-plugin', minimumVersion = '2.9.1')
+        void deployToWeblogic(Closure weblogicClosure) {
+
+            WeblogicDeployerContext context = new WeblogicDeployerContext()
+            ContextHelper.executeInContext(weblogicClosure, context)
+
+            NodeBuilder nodeBuilder = NodeBuilder.newInstance()
+            Node weblogicDeployerNode = nodeBuilder.'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin' {
+
+                mustExitOnFailure context.mustExitOnFailure
+                forceStopOnFirstFailure context.forceStopOnFirstFailure
+                isDeployingOnlyWhenUpdates context.deployingOnlyWhenUpdates
+                deployedProjectsDependencies context.deployedProjectsDependencies
+
+                selectedDeploymentStrategyIds context.deploymentPoliciesIdsNodes
+
+                if (context.taskNodes) {
+                    tasks context.taskNodes
+                }
+            }
+
+            publisherNodes << weblogicDeployerNode
+        }
+
     @SuppressWarnings('NoDef')
     private static addStaticAnalysisContext(def nodeBuilder, StaticAnalysisContext context) {
         nodeBuilder.with {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1615,7 +1615,6 @@ class PublisherContext extends AbstractExtensibleContext {
      * closure is provided, the values from the closure will take effect.
      *
      * @since 1.39
-     * @see https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
      */
     @RequiresPlugin(id = 'weblogic-deployer-plugin', minimumVersion = '2.9.1')
     void deployToWeblogic(Closure weblogicClosure) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerContext.groovy
@@ -6,8 +6,6 @@ import org.apache.commons.lang.RandomStringUtils
 
 /**
  * DSL Support for the weblogic-deployment-plugin.
- *
- * https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
  */
 class WeblogicDeployerContext implements Context {
 
@@ -100,9 +98,6 @@ class WeblogicDeployerContext implements Context {
      *
      * These are the default values, which are used if they are not overridden by closure.
      * All other properties must be set via closure for each task definition, as there are no default values.
-     *
-     *
-     * @see https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
      */
     void task(Closure taskClosure) {
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerContext.groovy
@@ -1,0 +1,151 @@
+package javaposse.jobdsl.dsl.helpers.publisher
+
+import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.ContextHelper
+import org.apache.commons.lang.RandomStringUtils
+
+/**
+ * <p>DSL Support for the weblogic-deployment-plugin.</p>
+ * <p><a href="https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin">WebLogic Deployer Plugin</a></p>
+ */
+class WeblogicDeployerContext implements Context {
+
+    /**
+     * <p>Enumeration of available deployment stage modes.</p>
+     */
+    static enum WeblogicDeploymentStageModes {
+
+        BY_DEFAULT('bydefault'),
+
+        STAGE('stage'),
+
+        NO_STAGE('nostage'),
+
+        EXTERNAL_STAGE('external_stage')
+
+        private final String stringRepresentation
+
+        WeblogicDeploymentStageModes(String stringRepresentation) {
+            this.stringRepresentation = stringRepresentation
+        }
+
+        @Override
+        String toString() {
+            this.stringRepresentation
+        }
+    }
+
+    List<Node> taskNodes = []
+    List<Node> deploymentPoliciesIdsNodes = []
+
+    boolean mustExitOnFailure = false
+    boolean forceStopOnFirstFailure = false
+    boolean deployingOnlyWhenUpdates = false
+    String deployedProjectsDependencies = ''
+
+    /**
+     * <p>Fails the build if the deployment fails.</p>
+     *
+     * @param mustExitOnFailure true, false (default)
+     */
+    void mustExitOnFailure(boolean mustExitOnFailure = true) {
+        this.mustExitOnFailure = mustExitOnFailure
+    }
+
+    /**
+     * <p>Stop the job on first deployment failure. No other defined
+     * deployment task of this job will be executed.</p>
+     * @param forceStopOnFirstFailure true, false (default)
+     */
+    void forceStopOnFirstFailure(boolean forceStopOnFirstFailure = true) {
+        this.forceStopOnFirstFailure = forceStopOnFirstFailure
+    }
+
+    /**
+     * <p>Deploy only if the build was triggered by a parameterized
+     * cause AND the SCM detects changes.</p>
+     * @param deployingOnlyWhenUpdates true, false (default)
+     */
+    void deployingOnlyWhenUpdates(boolean deployingOnlyWhenUpdates = true) {
+        this.deployingOnlyWhenUpdates = deployingOnlyWhenUpdates
+    }
+
+    /**
+     * <p>(experimental plugin feature) Defines a dependency to other deployment jobs.</p>
+     * @param deployedProjectsDependencies job name of an other deployment job
+     */
+    void deployedProjectsDependencies(String deployedProjectsDependencies) {
+        this.deployedProjectsDependencies = deployedProjectsDependencies
+    }
+
+    void deploymentPolicies(Closure deploymentPoliciesClosure = null) {
+
+        WeblogicDeployerPolicyContext context = new WeblogicDeployerPolicyContext()
+        ContextHelper.executeInContext(deploymentPoliciesClosure, context)
+
+        NodeBuilder nodeBuilder = NodeBuilder.newInstance()
+
+        context.deploymentPolicies.each {
+            policy -> deploymentPoliciesIdsNodes << nodeBuilder.createNode('string', policy)
+        }
+    }
+
+    /**
+     * <p>Configures a Weblogic deployment task using the weblogic-deployer-plugin</p>
+     * <p>These are the default values, which are used if they are not overridden by closure.
+     * All other properties must be set via closure for each task definition, as there are no default values.</p>
+     *
+     * <pre>
+     * {@code
+     * <org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask>
+     *     <id>_generated_</id>
+     *
+     *     <deploymentTargets>AdminServer</deploymentTargets>
+     *     <isLibrary>false</isLibrary>
+     *
+     *     <jdk>
+     *         <!-- When leaving these tags empty, the default JDK should be used.
+     *              Otherwise name and home must be set. -->
+     *         <name></name>
+     *         <home></home>
+     *         <properties></properties>
+     *     </jdk>
+     *
+     *     <stageMode>bydefault</stageMode>
+     *     <commandLine></commandLine>
+     *     <deploymentPlan></deploymentPlan>
+     * </org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask>
+     *}
+     * </pre>
+     *
+     * @see <a href="https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin">WebLogic Deployer Plugin</a>
+     */
+    void task(Closure taskClosure) {
+
+        WeblogicDeployerTaskContext context = new WeblogicDeployerTaskContext()
+        ContextHelper.executeInContext(taskClosure, context)
+
+        NodeBuilder nodeBuilder = NodeBuilder.newInstance()
+        Node tasksNode = nodeBuilder.'org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask' {
+            id RandomStringUtils.randomAlphanumeric(10)
+            weblogicEnvironmentTargetedName context.weblogicEnvironmentTargetedName
+            deploymentName context.deploymentName
+            deploymentTargets context.deploymentTargets
+            isLibrary context.isLibrary
+            builtResourceRegexToDeploy context.builtResourceRegexToDeploy
+            baseResourcesGeneratedDirectory context.baseResourcesGeneratedDirectory
+            taskName context.taskName
+
+            jdk {
+                name context.jdkName
+                home context.jdkHome
+                properties context.jdkProperties
+            }
+            stageMode context.stageMode.toString()
+            commandLine context.commandLine
+            deploymentPlan context.deploymentPlan
+        }
+
+        this.taskNodes << tasksNode
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerContext.groovy
@@ -5,13 +5,14 @@ import javaposse.jobdsl.dsl.ContextHelper
 import org.apache.commons.lang.RandomStringUtils
 
 /**
- * <p>DSL Support for the weblogic-deployment-plugin.</p>
- * <p><a href="https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin">WebLogic Deployer Plugin</a></p>
+ * DSL Support for the weblogic-deployment-plugin.
+ *
+ * https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
  */
 class WeblogicDeployerContext implements Context {
 
     /**
-     * <p>Enumeration of available deployment stage modes.</p>
+     * Enumeration of available deployment stage modes.
      */
     static enum WeblogicDeploymentStageModes {
 
@@ -44,7 +45,7 @@ class WeblogicDeployerContext implements Context {
     String deployedProjectsDependencies = ''
 
     /**
-     * <p>Fails the build if the deployment fails.</p>
+     * Fails the build if the deployment fails. Defaults to {@code false}.
      *
      * @param mustExitOnFailure true, false (default)
      */
@@ -53,8 +54,9 @@ class WeblogicDeployerContext implements Context {
     }
 
     /**
-     * <p>Stop the job on first deployment failure. No other defined
-     * deployment task of this job will be executed.</p>
+     * Stop the job on first deployment failure. No other defined deployment task of this job will be executed.
+     * Defaults to {@code false}.
+     *
      * @param forceStopOnFirstFailure true, false (default)
      */
     void forceStopOnFirstFailure(boolean forceStopOnFirstFailure = true) {
@@ -62,8 +64,9 @@ class WeblogicDeployerContext implements Context {
     }
 
     /**
-     * <p>Deploy only if the build was triggered by a parameterized
-     * cause AND the SCM detects changes.</p>
+     * Deploy only if the build was triggered by a parameterized cause AND the SCM detects changes.
+     * Defaults to {@code false}.
+     *
      * @param deployingOnlyWhenUpdates true, false (default)
      */
     void deployingOnlyWhenUpdates(boolean deployingOnlyWhenUpdates = true) {
@@ -71,8 +74,10 @@ class WeblogicDeployerContext implements Context {
     }
 
     /**
-     * <p>(experimental plugin feature) Defines a dependency to other deployment jobs.</p>
-     * @param deployedProjectsDependencies job name of an other deployment job
+     * (experimental plugin feature) Defines a dependency to other deployment jobs.
+     * Defaults to {@code ''}.
+     *
+     * @param deployedProjectsDependencies job name of an other deployment job.
      */
     void deployedProjectsDependencies(String deployedProjectsDependencies) {
         this.deployedProjectsDependencies = deployedProjectsDependencies
@@ -91,34 +96,13 @@ class WeblogicDeployerContext implements Context {
     }
 
     /**
-     * <p>Configures a Weblogic deployment task using the weblogic-deployer-plugin</p>
-     * <p>These are the default values, which are used if they are not overridden by closure.
-     * All other properties must be set via closure for each task definition, as there are no default values.</p>
+     * Configures a Weblogic deployment task using the weblogic-deployer-plugin.
      *
-     * <pre>
-     * {@code
-     * <org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask>
-     *     <id>_generated_</id>
+     * These are the default values, which are used if they are not overridden by closure.
+     * All other properties must be set via closure for each task definition, as there are no default values.
      *
-     *     <deploymentTargets>AdminServer</deploymentTargets>
-     *     <isLibrary>false</isLibrary>
      *
-     *     <jdk>
-     *         <!-- When leaving these tags empty, the default JDK should be used.
-     *              Otherwise name and home must be set. -->
-     *         <name></name>
-     *         <home></home>
-     *         <properties></properties>
-     *     </jdk>
-     *
-     *     <stageMode>bydefault</stageMode>
-     *     <commandLine></commandLine>
-     *     <deploymentPlan></deploymentPlan>
-     * </org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask>
-     *}
-     * </pre>
-     *
-     * @see <a href="https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin">WebLogic Deployer Plugin</a>
+     * @see https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
      */
     void task(Closure taskClosure) {
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerPolicyContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerPolicyContext.groovy
@@ -3,49 +3,50 @@ package javaposse.jobdsl.dsl.helpers.publisher
 import javaposse.jobdsl.dsl.Context
 
 /**
- * <p>DSL Support for the weblogic-deployment-plugin's deployment policies subsection.</p>
- * <p><a href="https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin">WebLogic Deployer Plugin</a></p>
+ * DSL Support for the weblogic-deployment-plugin's deployment policies subsection.
+ *
+ * https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
  */
 class WeblogicDeployerPolicyContext implements Context {
 
     /**
-     * <p>Enumeration of available deployment policies.</p>
+     * Enumeration of available deployment policies.
      */
     static enum WeblogicDeploymentPolicies {
 
         /**
-         * Legacy code started this job.  No cause information is available
+         * Legacy code started this job.  No cause information is available.
          */
         LEGACY_CODE('hudson.model.Cause\\\\\$LegacyCodeCause'),
 
         /**
-         * Started by user
+         * Started by user.
          */
         USER('hudson.model.Cause\\\\\$UserCause'),
 
         /**
-         * Started by user
+         * Started by user.
          */
         USER_ID('hudson.model.Cause\\\\\$UserIdCause'),
 
         /**
-         * Started by remote host
+         * Started by remote host.
          */
         REMOTE_HOST('hudson.model.Cause\\\\\$RemoteCause'),
 
         /**
-         * Built after other projects are built or whenever a SNAPSHOT dependency is built
+         * Built after other projects are built or whenever a SNAPSHOT dependency is built.
          */
         UPSTREAM('hudson.model.Cause\\\\\$UpstreamCause'),
 
         /**
-         * Started by deployment timer
+         * Started by deployment timer.
          */
         DEPLOYMENT_TRIGGER(
                 'org.jenkinsci.plugins.deploy.weblogic.trigger.DeploymentTrigger\\\\\$DeploymentTriggerCause'),
 
         /**
-         * Started by an SCM change
+         * Started by an SCM change.
          */
         SCM_CHANGE('hudson.triggers.SCMTrigger\\\\\$SCMTriggerCause'),
 
@@ -62,13 +63,14 @@ class WeblogicDeployerPolicyContext implements Context {
     }
 
     /**
-     * Deployment policy
+     * Deployment policy.
      */
     List<String> deploymentPolicies = []
 
     /**
-     * <p>Define a deployment policy</p>
-     * @param deploymentPolicy one of: {@link WeblogicDeploymentPolicies}
+     * Define a deployment policy.
+     *
+     * @param deploymentPolicy one of: {@link WeblogicDeploymentPolicies}.
      */
     void policy(WeblogicDeploymentPolicies deploymentPolicy) {
         this.deploymentPolicies.add(deploymentPolicy.toString())

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerPolicyContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerPolicyContext.groovy
@@ -4,8 +4,6 @@ import javaposse.jobdsl.dsl.Context
 
 /**
  * DSL Support for the weblogic-deployment-plugin's deployment policies subsection.
- *
- * https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
  */
 class WeblogicDeployerPolicyContext implements Context {
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerPolicyContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerPolicyContext.groovy
@@ -1,0 +1,76 @@
+package javaposse.jobdsl.dsl.helpers.publisher
+
+import javaposse.jobdsl.dsl.Context
+
+/**
+ * <p>DSL Support for the weblogic-deployment-plugin's deployment policies subsection.</p>
+ * <p><a href="https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin">WebLogic Deployer Plugin</a></p>
+ */
+class WeblogicDeployerPolicyContext implements Context {
+
+    /**
+     * <p>Enumeration of available deployment policies.</p>
+     */
+    static enum WeblogicDeploymentPolicies {
+
+        /**
+         * Legacy code started this job.  No cause information is available
+         */
+        LEGACY_CODE('hudson.model.Cause\\\\\$LegacyCodeCause'),
+
+        /**
+         * Started by user
+         */
+        USER('hudson.model.Cause\\\\\$UserCause'),
+
+        /**
+         * Started by user
+         */
+        USER_ID('hudson.model.Cause\\\\\$UserIdCause'),
+
+        /**
+         * Started by remote host
+         */
+        REMOTE_HOST('hudson.model.Cause\\\\\$RemoteCause'),
+
+        /**
+         * Built after other projects are built or whenever a SNAPSHOT dependency is built
+         */
+        UPSTREAM('hudson.model.Cause\\\\\$UpstreamCause'),
+
+        /**
+         * Started by deployment timer
+         */
+        DEPLOYMENT_TRIGGER(
+                'org.jenkinsci.plugins.deploy.weblogic.trigger.DeploymentTrigger\\\\\$DeploymentTriggerCause'),
+
+        /**
+         * Started by an SCM change
+         */
+        SCM_CHANGE('hudson.triggers.SCMTrigger\\\\\$SCMTriggerCause'),
+
+        private final String stringRepresentation
+
+        WeblogicDeploymentPolicies(String stringRepresentation) {
+            this.stringRepresentation = stringRepresentation
+        }
+
+        @Override
+        String toString() {
+            this.stringRepresentation
+        }
+    }
+
+    /**
+     * Deployment policy
+     */
+    List<String> deploymentPolicies = []
+
+    /**
+     * <p>Define a deployment policy</p>
+     * @param deploymentPolicy one of: {@link WeblogicDeploymentPolicies}
+     */
+    void policy(WeblogicDeploymentPolicies deploymentPolicy) {
+        this.deploymentPolicies.add(deploymentPolicy.toString())
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerTaskContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerTaskContext.groovy
@@ -6,8 +6,6 @@ import static javaposse.jobdsl.dsl.helpers.publisher.WeblogicDeployerContext.Web
 
 /**
  * DSL Support for the weblogic-deployment-plugin's task subsection.
- *
- * https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
  */
 class WeblogicDeployerTaskContext implements Context {
 
@@ -136,8 +134,7 @@ class WeblogicDeployerTaskContext implements Context {
      * Defines custom commands to be executed instead of the default ones (undeploy/deploy).
      * Defaults to {@code ''}.
      *
-     * Can contain tokens which will be replaced:
-     * https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
+     * Can contain tokens which will be replaced. See plugin website.
      *
      * @param commandLine commands to be executed separated by semicolon.
      */
@@ -146,9 +143,8 @@ class WeblogicDeployerTaskContext implements Context {
     }
 
     /**
-     * Path to the deployment plan to use. Must be referenced in command line.
-     * see https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
-     * Defaults to {@code ''}.
+     * Path to the deployment plan to use. Must be referenced in command line
+     * (See plugin website). Defaults to {@code ''}.
      *
      * @param deploymentPlan deployment plan to use.
      */

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerTaskContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerTaskContext.groovy
@@ -5,8 +5,9 @@ import javaposse.jobdsl.dsl.Context
 import static javaposse.jobdsl.dsl.helpers.publisher.WeblogicDeployerContext.WeblogicDeploymentStageModes
 
 /**
- * <p>DSL Support for the weblogic-deployment-plugin's task subsection.</p>
- * <p><a href="https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin">WebLogic Deployer Plugin</a></p>
+ * DSL Support for the weblogic-deployment-plugin's task subsection.
+ *
+ * https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
  */
 class WeblogicDeployerTaskContext implements Context {
 
@@ -27,45 +28,45 @@ class WeblogicDeployerTaskContext implements Context {
     String deploymentPlan = ''
 
     /**
-     * <p>Server environment to deploy to</p>
-     * @param weblogicEnvironmentTargetedName
+     * Server environment to deploy to.
+     *
+     * @param weblogicEnvironmentTargetedName.
      */
     void weblogicEnvironmentTargetedName(String weblogicEnvironmentTargetedName) {
         this.weblogicEnvironmentTargetedName = weblogicEnvironmentTargetedName
     }
 
     /**
-     * <p>Name of the deployed Application</p>
-     * @param deploymentName application name
+     * Name of the deployed Application.
+     *
+     * @param deploymentName application name.
      */
     void deploymentName(String deploymentName) {
         this.deploymentName = deploymentName
     }
 
     /**
-     * <p>Targets to deploy to</p>
+     * Targets to deploy to.
+     *
      * @param deploymentTargets Comma separated String of targets
-     * (e.g. AdminServer, myManagedServer, myCluster)
+     * (e.g. AdminServer, myManagedServer, myCluster).
      */
     void deploymentTargets(String deploymentTargets) {
         this.deploymentTargets = deploymentTargets
     }
 
     /**
-     * <p>Type of deployment</p>
+     * Type of deployment. Defaults to {@code false}.
      *
-     * @param isLibrary true, false (default)
-     *  <ul>
-     *    <li><strong>true</strong>: deploy as shared library</li>
-     *    <li><strong>false</strong>: deploy as application</li>
-     * </ul>
+     * @param isLibrary true, false (default).
      */
     void isLibrary(boolean isLibrary = true) {
         this.isLibrary = isLibrary
     }
 
     /**
-     * <p>Regex matching the artifact to deploy</p>
+     * Regex matching the artifact to deploy.
+     *
      * @param builtResourceRegexToDeploy e.g. myApp\.ear
      */
     void builtResourceRegexToDeploy(String builtResourceRegexToDeploy) {
@@ -73,8 +74,9 @@ class WeblogicDeployerTaskContext implements Context {
     }
 
     /**
-     * <p>Base directory where to search for the deployment artifact.</p>
-     * <p><strong>NOTE: Can only be used in FreeStyle projects!</strong></p>
+     * Base directory where to search for the deployment artifact.
+     * NOTE: Can only be used in FreeStyle projects!
+     *
      * @param baseResourcesGeneratedDirectory
      */
     void baseResourcesGeneratedDirectory(String baseResourcesGeneratedDirectory) {
@@ -82,52 +84,74 @@ class WeblogicDeployerTaskContext implements Context {
     }
 
     /**
-     * <p>Task name to identify deployment task (optional)</p>
-     * @param taskName optional task name
+     * Task name to identify deployment task (optional).
+     *
+     * @param taskName optional task name.
      */
     void taskName(String taskName) {
         this.taskName = taskName
     }
 
     /**
-     * <p>Name of the JDK to use (optional). If not specified,
-     * the default JDK defined in plugin settings will be used.</p>
-     * @param jdkName Name of the JDK to use
+     * Name of the JDK to use (optional). If not specified, the default JDK defined in plugin settings will be used.
+     * Defaults to {@code ''}.
+     *
+     * @param jdkName Name of the JDK to use.
      */
     void jdkName(String jdkName) {
         this.jdkName = jdkName
     }
 
     /**
-     * <p>Path to the JDK home to use</p>
-     * @param jdkHome JDK home
+     * Path to the JDK home to use.
+     * Defaults to {@code ''}.
+     *
+     * @param jdkHome JDK home.
      */
     void jdkHome(String jdkHome) {
         this.jdkHome = jdkHome
     }
 
+    /**
+     * JDK Properties to use.
+     * Defaults to {@code ''}.
+     *
+     * @param jdkProperties JDK Properties.
+     */
     void jdkProperties(String jdkProperties) {
         this.jdkProperties = jdkProperties
     }
 
     /**
-     * <p>Staging method to use</p>
-     * @param stageMode one of {@link WeblogicDeploymentStageModes}
+     * Staging method to use.
+     * Defaults to {@code WeblogicDeploymentStageModes.BY_DEFAULT}.
+     *
+     * @param stageMode one of {@link WeblogicDeploymentStageModes}.
      */
     void stageMode(WeblogicDeploymentStageModes stageMode) {
         this.stageMode = stageMode
     }
 
     /**
-     * <p>Defines custom commands to be executed instead of the default ones (undeploy/deploy).
+     * Defines custom commands to be executed instead of the default ones (undeploy/deploy).
+     * Defaults to {@code ''}.
+     *
      * Can contain tokens which will be replaced:
-     * <a href="https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin">WebLogic Deployer Plugin</a></p>
-     * @param commandLine commands to be executed separated by semicolon
+     * https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
+     *
+     * @param commandLine commands to be executed separated by semicolon.
      */
     void commandLine(String commandLine) {
         this.commandLine = commandLine
     }
 
+    /**
+     * Path to the deployment plan to use. Must be referenced in command line.
+     * see https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin
+     * Defaults to {@code ''}.
+     *
+     * @param deploymentPlan deployment plan to use.
+     */
     void deploymentPlan(String deploymentPlan) {
         this.deploymentPlan = deploymentPlan
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerTaskContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerTaskContext.groovy
@@ -1,0 +1,134 @@
+package javaposse.jobdsl.dsl.helpers.publisher
+
+import javaposse.jobdsl.dsl.Context
+
+import static javaposse.jobdsl.dsl.helpers.publisher.WeblogicDeployerContext.WeblogicDeploymentStageModes
+
+/**
+ * <p>DSL Support for the weblogic-deployment-plugin's task subsection.</p>
+ * <p><a href="https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin">WebLogic Deployer Plugin</a></p>
+ */
+class WeblogicDeployerTaskContext implements Context {
+
+    String weblogicEnvironmentTargetedName
+    String deploymentName
+    String deploymentTargets = 'AdminServer'
+    boolean isLibrary = false
+    String builtResourceRegexToDeploy
+    String baseResourcesGeneratedDirectory
+    String taskName
+
+    String jdkName = ''
+    String jdkHome = ''
+    String jdkProperties = ''
+
+    WeblogicDeploymentStageModes stageMode = WeblogicDeploymentStageModes.BY_DEFAULT
+    String commandLine = ''
+    String deploymentPlan = ''
+
+    /**
+     * <p>Server environment to deploy to</p>
+     * @param weblogicEnvironmentTargetedName
+     */
+    void weblogicEnvironmentTargetedName(String weblogicEnvironmentTargetedName) {
+        this.weblogicEnvironmentTargetedName = weblogicEnvironmentTargetedName
+    }
+
+    /**
+     * <p>Name of the deployed Application</p>
+     * @param deploymentName application name
+     */
+    void deploymentName(String deploymentName) {
+        this.deploymentName = deploymentName
+    }
+
+    /**
+     * <p>Targets to deploy to</p>
+     * @param deploymentTargets Comma separated String of targets
+     * (e.g. AdminServer, myManagedServer, myCluster)
+     */
+    void deploymentTargets(String deploymentTargets) {
+        this.deploymentTargets = deploymentTargets
+    }
+
+    /**
+     * <p>Type of deployment</p>
+     *
+     * @param isLibrary true, false (default)
+     *  <ul>
+     *    <li><strong>true</strong>: deploy as shared library</li>
+     *    <li><strong>false</strong>: deploy as application</li>
+     * </ul>
+     */
+    void isLibrary(boolean isLibrary = true) {
+        this.isLibrary = isLibrary
+    }
+
+    /**
+     * <p>Regex matching the artifact to deploy</p>
+     * @param builtResourceRegexToDeploy e.g. myApp\.ear
+     */
+    void builtResourceRegexToDeploy(String builtResourceRegexToDeploy) {
+        this.builtResourceRegexToDeploy = builtResourceRegexToDeploy
+    }
+
+    /**
+     * <p>Base directory where to search for the deployment artifact.</p>
+     * <p><strong>NOTE: Can only be used in FreeStyle projects!</strong></p>
+     * @param baseResourcesGeneratedDirectory
+     */
+    void baseResourcesGeneratedDirectory(String baseResourcesGeneratedDirectory) {
+        this.baseResourcesGeneratedDirectory = baseResourcesGeneratedDirectory
+    }
+
+    /**
+     * <p>Task name to identify deployment task (optional)</p>
+     * @param taskName optional task name
+     */
+    void taskName(String taskName) {
+        this.taskName = taskName
+    }
+
+    /**
+     * <p>Name of the JDK to use (optional). If not specified,
+     * the default JDK defined in plugin settings will be used.</p>
+     * @param jdkName Name of the JDK to use
+     */
+    void jdkName(String jdkName) {
+        this.jdkName = jdkName
+    }
+
+    /**
+     * <p>Path to the JDK home to use</p>
+     * @param jdkHome JDK home
+     */
+    void jdkHome(String jdkHome) {
+        this.jdkHome = jdkHome
+    }
+
+    void jdkProperties(String jdkProperties) {
+        this.jdkProperties = jdkProperties
+    }
+
+    /**
+     * <p>Staging method to use</p>
+     * @param stageMode one of {@link WeblogicDeploymentStageModes}
+     */
+    void stageMode(WeblogicDeploymentStageModes stageMode) {
+        this.stageMode = stageMode
+    }
+
+    /**
+     * <p>Defines custom commands to be executed instead of the default ones (undeploy/deploy).
+     * Can contain tokens which will be replaced:
+     * <a href="https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin">WebLogic Deployer Plugin</a></p>
+     * @param commandLine commands to be executed separated by semicolon
+     */
+    void commandLine(String commandLine) {
+        this.commandLine = commandLine
+    }
+
+    void deploymentPlan(String deploymentPlan) {
+        this.deploymentPlan = deploymentPlan
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -9,6 +9,8 @@ import spock.lang.Specification
 
 import static javaposse.jobdsl.dsl.helpers.publisher.ArchiveXUnitContext.ThresholdMode
 import static javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.Behavior.MarkUnstable
+import static javaposse.jobdsl.dsl.helpers.publisher.WeblogicDeployerContext.WeblogicDeploymentStageModes
+import static javaposse.jobdsl.dsl.helpers.publisher.WeblogicDeployerPolicyContext.WeblogicDeploymentPolicies
 
 class PublisherContextSpec extends Specification {
     JobManagement jobManagement = Mock(JobManagement)
@@ -4917,5 +4919,249 @@ class PublisherContextSpec extends Specification {
         message                       | commit
         ''                            | false
         'automatic commit by Jenkins' | true
+    }
+
+    def 'publish deployment to WebLogic with least args'() {
+        when:
+        context.deployToWeblogic()
+
+        then:
+        context.publisherNodes.size() == 1
+        context.publisherNodes[0].name() == 'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin'
+        context.publisherNodes[0].mustExitOnFailure[0].value() == false
+        context.publisherNodes[0].forceStopOnFirstFailure[0].value() == false
+        context.publisherNodes[0].isDeployingOnlyWhenUpdates[0].value() == false
+    }
+
+    def 'publish one deployment to WebLogic with all required args'() {
+        when:
+        context.deployToWeblogic {
+
+            task {
+                weblogicEnvironmentTargetedName 'test_environment'
+                deploymentName 'myApp'
+                deploymentTargets 'ms_one'
+                builtResourceRegexToDeploy 'myApp.ear'
+                baseResourcesGeneratedDirectory ''
+                taskName 'test_deploy_task'
+
+                jdkName 'JDK 7'
+
+                stageMode WeblogicDeploymentStageModes.BY_DEFAULT
+            }
+
+        }
+
+        then:
+        context.publisherNodes.size() == 1
+        context.publisherNodes[0].name() == 'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin'
+        context.publisherNodes[0].mustExitOnFailure[0].value() == false
+        context.publisherNodes[0].forceStopOnFirstFailure[0].value() == false
+        context.publisherNodes[0].isDeployingOnlyWhenUpdates[0].value() == false
+        context.publisherNodes[0].deployedProjectsDependencies[0].value() == ''
+
+        context.publisherNodes[0].tasks.size() == 1
+        def task = context.publisherNodes[0].tasks[0].'org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask'
+        task.size() == 1
+
+        task[0].id[0].value().size() == 10
+        task[0].weblogicEnvironmentTargetedName[0].value() == 'test_environment'
+        task[0].deploymentName[0].value() == 'myApp'
+        task[0].deploymentTargets[0].value() == 'ms_one'
+        task[0].isLibrary[0].value() == false
+        task[0].builtResourceRegexToDeploy[0].value() == 'myApp.ear'
+        task[0].baseResourcesGeneratedDirectory[0].value() == ''
+        task[0].taskName[0].value() == 'test_deploy_task'
+
+        task[0].jdk[0].name[0].value() == 'JDK 7'
+        task[0].jdk[0].home[0].value() == ''
+        task[0].jdk[0].properties[0].value() == ''
+
+        task[0].stageMode[0].value() == WeblogicDeploymentStageModes.BY_DEFAULT.toString()
+        task[0].commandLine[0].value() == ''
+        task[0].deploymentPlan[0].value() == ''
+    }
+
+    def 'publish one deployment to WebLogic with all args'() {
+        when:
+        context.deployToWeblogic {
+            mustExitOnFailure()
+            forceStopOnFirstFailure()
+            deployingOnlyWhenUpdates()
+            deployedProjectsDependencies 'abc,def'
+
+            deploymentPolicies {
+                policy WeblogicDeploymentPolicies.SCM_CHANGE
+                policy WeblogicDeploymentPolicies.USER
+            }
+
+            task {
+                weblogicEnvironmentTargetedName 'test_environment'
+                deploymentName 'myApp'
+                deploymentTargets 'ms_one'
+                isLibrary()
+                builtResourceRegexToDeploy 'myApp.ear'
+                baseResourcesGeneratedDirectory ''
+                taskName 'test_deploy_task'
+
+                jdkName 'JDK 7'
+                jdkHome ''
+                jdkProperties ''
+
+                stageMode WeblogicDeploymentStageModes.BY_DEFAULT
+                commandLine ''
+                deploymentPlan ''
+            }
+
+        }
+
+        then:
+        context.publisherNodes.size() == 1
+        context.publisherNodes[0].name() == 'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin'
+        context.publisherNodes[0].mustExitOnFailure[0].value() == true
+        context.publisherNodes[0].forceStopOnFirstFailure[0].value() == true
+        context.publisherNodes[0].isDeployingOnlyWhenUpdates[0].value() == true
+        context.publisherNodes[0].deployedProjectsDependencies[0].value() == 'abc,def'
+
+        def selectedDeploymentStrategyId = context.publisherNodes[0].selectedDeploymentStrategyIds[0]
+        selectedDeploymentStrategyId.children().size() == 2
+        selectedDeploymentStrategyId.string[0].value() == WeblogicDeploymentPolicies.SCM_CHANGE.toString()
+        selectedDeploymentStrategyId.string[1].value() == WeblogicDeploymentPolicies.USER.toString()
+
+        context.publisherNodes[0].tasks.size() == 1
+        def task = context.publisherNodes[0].tasks[0].'org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask'
+        task.size() == 1
+
+        task[0].id[0].value().size() == 10
+        task[0].weblogicEnvironmentTargetedName[0].value() == 'test_environment'
+        task[0].deploymentName[0].value() == 'myApp'
+        task[0].deploymentTargets[0].value() == 'ms_one'
+        task[0].isLibrary[0].value() == true
+        task[0].builtResourceRegexToDeploy[0].value() == 'myApp.ear'
+        task[0].baseResourcesGeneratedDirectory[0].value() == ''
+        task[0].taskName[0].value() == 'test_deploy_task'
+
+        task[0].jdk[0].name[0].value() == 'JDK 7'
+        task[0].jdk[0].home[0].value() == ''
+        task[0].jdk[0].properties[0].value() == ''
+
+        task[0].stageMode[0].value() == WeblogicDeploymentStageModes.BY_DEFAULT.toString()
+        task[0].commandLine[0].value() == ''
+        task[0].deploymentPlan[0].value() == ''
+    }
+
+    def 'publish to WebLogic without task definition'() {
+        when:
+        context.deployToWeblogic {
+            mustExitOnFailure()
+            forceStopOnFirstFailure()
+            deployingOnlyWhenUpdates()
+            deployedProjectsDependencies 'abc,def'
+        }
+
+        then:
+        context.publisherNodes.size() == 1
+        context.publisherNodes[0].name() == 'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin'
+        context.publisherNodes[0].mustExitOnFailure[0].value() == true
+        context.publisherNodes[0].forceStopOnFirstFailure[0].value() == true
+        context.publisherNodes[0].isDeployingOnlyWhenUpdates[0].value() == true
+        context.publisherNodes[0].deployedProjectsDependencies[0].value() == 'abc,def'
+
+        context.publisherNodes[0].tasks.size() == 0
+    }
+
+    def 'publish two deployment to WebLogic with all args'() {
+        when:
+        context.deployToWeblogic {
+            mustExitOnFailure()
+            forceStopOnFirstFailure()
+            deployingOnlyWhenUpdates()
+            deployedProjectsDependencies 'abc,def'
+
+            task {
+                weblogicEnvironmentTargetedName 'test_environment'
+                deploymentName 'myApp'
+                deploymentTargets 'ms_one'
+                isLibrary()
+                builtResourceRegexToDeploy 'myApp.ear'
+                baseResourcesGeneratedDirectory ''
+                taskName 'test_deploy_task'
+
+                jdkName 'JDK 7'
+                jdkHome ''
+                jdkProperties ''
+
+                stageMode WeblogicDeploymentStageModes.BY_DEFAULT
+                commandLine ''
+                deploymentPlan ''
+            }
+
+            task {
+                weblogicEnvironmentTargetedName 'test_environment_two'
+                deploymentName 'myApp2'
+                deploymentTargets 'ms_two'
+                isLibrary()
+                builtResourceRegexToDeploy 'myApp2.ear'
+                baseResourcesGeneratedDirectory ''
+                taskName 'test_deploy_task_two'
+
+                jdkName 'JDK 6'
+                jdkHome ''
+                jdkProperties ''
+
+                stageMode WeblogicDeploymentStageModes.BY_DEFAULT
+                commandLine ''
+                deploymentPlan ''
+            }
+
+        }
+
+        then:
+        context.publisherNodes.size() == 1
+        context.publisherNodes[0].name() == 'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin'
+        context.publisherNodes[0].mustExitOnFailure[0].value() == true
+        context.publisherNodes[0].forceStopOnFirstFailure[0].value() == true
+        context.publisherNodes[0].isDeployingOnlyWhenUpdates[0].value() == true
+        context.publisherNodes[0].deployedProjectsDependencies[0].value() == 'abc,def'
+
+        context.publisherNodes[0].tasks.size() == 1
+        def task = context.publisherNodes[0].tasks[0].'org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask'
+        task.size() == 2
+
+        // first task
+        task[0].id[0].value().size() == 10
+        task[0].weblogicEnvironmentTargetedName[0].value() == 'test_environment'
+        task[0].deploymentName[0].value() == 'myApp'
+        task[0].deploymentTargets[0].value() == 'ms_one'
+        task[0].isLibrary[0].value() == true
+        task[0].builtResourceRegexToDeploy[0].value() == 'myApp.ear'
+        task[0].baseResourcesGeneratedDirectory[0].value() == ''
+        task[0].taskName[0].value() == 'test_deploy_task'
+
+        task[0].jdk[0].name[0].value() == 'JDK 7'
+        task[0].jdk[0].home[0].value() == ''
+        task[0].jdk[0].properties[0].value() == ''
+
+        task[0].stageMode[0].value() == WeblogicDeploymentStageModes.BY_DEFAULT.toString()
+        task[0].commandLine[0].value() == ''
+        task[0].deploymentPlan[0].value() == ''
+
+        // second task
+        task[1].id[0].value().size() == 10
+        task[1].weblogicEnvironmentTargetedName[0].value() == 'test_environment_two'
+        task[1].deploymentName[0].value() == 'myApp2'
+        task[1].deploymentTargets[0].value() == 'ms_two'
+        task[1].isLibrary[0].value() == true
+        task[1].builtResourceRegexToDeploy[0].value() == 'myApp2.ear'
+        task[1].baseResourcesGeneratedDirectory[0].value() == ''
+        task[1].taskName[0].value() == 'test_deploy_task_two'
+
+        task[1].jdk[0].name[0].value() == 'JDK 6'
+        task[1].jdk[0].home[0].value() == ''
+        task[1].jdk[0].properties[0].value() == ''
+
+        task[1].stageMode[0].value() == WeblogicDeploymentStageModes.BY_DEFAULT.toString()
+        task[1].commandLine[0].value() == ''
+        task[1].deploymentPlan[0].value() == ''
     }
 }


### PR DESCRIPTION
New rebased/updated version of PR https://github.com/jenkinsci/job-dsl-plugin/pull/158:

This pull request adds support for the weblogic-deployer-plugin:

```groovy
publishers {
	deployToWeblogic {
		// these are the default values used for optional fields, when not overridden by closure
		mustExitOnFailure false
		forceStopOnFirstFailure false
		deployingOnlyWhenUpdates false
		
		deployedProjectsDependencies ''

		deploymentPolicies {
			// multiple policies allowed
			// policy WeblogicDeploymentPolicies.SCM_CHANGE
			// policy WeblogicDeploymentPolicies.USER

			// default: no policies set
		}

		// required one
		task {
			// required
			weblogicEnvironmentTargetedName 'dev_environment'
			// required
			deploymentName 'myApplicationName'

			deploymentTargets 'AdminServer'

			// required
			builtResourceRegexToDeploy 'myApp\\.ear'
			// required
			baseResourcesGeneratedDirectory ''
			// required
			taskName 'Deploy myApp to DEV Server'

			jdkName ''
			jdkHome ''
			jdkProperties ''
			
			// one of: WeblogicDeploymentStageModes
			stageMode WeblogicDeploymentStageModes.BY_DEFAULT
			commandLine ''
			deploymentPlan ''
		}
		
		// multiple tasks allowed
		// NOTE: artifacts get deployed in order of definition!
		task {
			//...
		}
	}
}
```