### PR TITLE
deprecated support for the JSHint Checkstyle Plugin

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -28,6 +28,8 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
  * Support for older versions of the
    [Parameterized Trigger Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Parameterized+Trigger+Plugin) is
    deprecated, see [Migration](Migration#migrating-to-139)
+ * Support for the [JSHint Checkstyle Plugin](https://wiki.jenkins-ci.org/display/JENKINS/JSHint+Checkstyle+Plugin) is
+   deprecated, see [Migration](Migration#migrating-to-139)
  * Allow to abort DSL processing
 * 1.38 (September 09 2015)
  * Replaced the [[Job Reference]], [[View Reference]] and [[Folder Reference]] pages by the

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -12,6 +12,11 @@ Support for versions older than 2.26 of the
 [Parameterized Trigger Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Parameterized+Trigger+Plugin) is
 [[deprecated|Deprecation-Policy]] and will be removed.
 
+### JSHint Checkstyle
+
+Support for the [JSHint Checkstyle Plugin](https://wiki.jenkins-ci.org/display/JENKINS/JSHint+Checkstyle+Plugin) is
+[[deprecated|Deprecation-Policy]] and will be removed. The plugin is no longer available in the Jenkins Update Center.
+
 ## Migrating to 1.38
 
 ### Parameterized Trigger

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1202,9 +1202,12 @@ class PublisherContext extends AbstractExtensibleContext {
      *
      * @since 1.20
      */
+    @Deprecated
     @RequiresPlugin(id = 'jshint-checkstyle')
     void jshint(String pattern,
                 @DslContext(StaticAnalysisContext) Closure staticAnalysisClosure = null) {
+        jobManagement.logDeprecationWarning()
+
         publisherNodes << createDefaultStaticAnalysisNode(
                 'hudson.plugins.jshint.CheckStylePublisher',
                 staticAnalysisClosure,


### PR DESCRIPTION
The plugin is no longer available in the Update Center, see https://github.com/jenkinsci/backend-update-center2/commit/79ca047996ccdb360c864c3866ed25445fbe05b6.