### PR TITLE
contentType error in API Viewer for email-ext

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/extendedEmail.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/extendedEmail.groovy
@@ -5,7 +5,7 @@ job('example') {
             trigger(triggerName: 'StillUnstable', subject: 'Subject', body: 'Body', recipientList: 'RecipientList',
                     sendToDevelopers: true, sendToRequester: true, includeCulprits: true, sendToRecipientList: false)
             configure { node ->
-                node / contentType << 'html'
+                node / contentType << 'text/html'
             }
         }
     }


### PR DESCRIPTION
In the API viewer for extendedEmail it lists a configure step that sets
contentType to ‘html’.  This causes emails to fail with an error about
“expected / found ;”.    If I manually select the HTML content type
with the email-ext plugin, it puts
<contentType>text/html</contentType>.  This change prepends “text/“