### PR TITLE
Add statusUrl support in the pull request builder

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext/pullRequest.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext/pullRequest.groovy
@@ -24,6 +24,7 @@ job('example') {
                 commitStatus {
                     context('deploy to staging site')
                     startedStatus('deploying to staging site...')
+                    statusUrl('http://mystatussite.com/prs')
                     completedStatus('SUCCESS', 'All is well')
                     completedStatus('FAILURE', 'Something went wrong. Investigate!')
                 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GitHubPullRequestBuilderCommitStatusContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GitHubPullRequestBuilderCommitStatusContext.groovy
@@ -9,6 +9,7 @@ class GitHubPullRequestBuilderCommitStatusContext implements Context {
     String context
     String triggeredStatus
     String startedStatus
+    String statusUrl
     List<Node> completedStatus = []
 
     /**
@@ -30,6 +31,15 @@ class GitHubPullRequestBuilderCommitStatusContext implements Context {
      */
     void startedStatus(String startedStatus) {
         this.startedStatus = startedStatus
+    }
+    
+    /**
+     * Use a custom url instead of the job default.
+     *
+     * @since 1.31
+     */
+    void statusUrl(String statusUrl) {
+        this.statusUrl = statusUrl
     }
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GitHubPullRequestBuilderExtensionContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GitHubPullRequestBuilderExtensionContext.groovy
@@ -18,6 +18,7 @@ class GitHubPullRequestBuilderExtensionContext implements Context {
             commitStatusContext(context.context ?: '')
             triggeredStatus(context.triggeredStatus ?: '')
             startedStatus(context.startedStatus ?: '')
+            statusUrl(context.statusUrl ?: '')
             completedStatus(context.completedStatus)
         }
     }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
@@ -444,6 +444,7 @@ class TriggerContextSpec extends Specification {
                     delegate.context('Deploy to staging site')
                     triggeredStatus('deploy triggered')
                     startedStatus('deploy started')
+                    statusUrl('http://mysite.com')
                     completedStatus('SUCCESS', 'All is well')
                     completedStatus('FAILURE', 'Something has gone wrong')
                 }
@@ -470,10 +471,11 @@ class TriggerContextSpec extends Specification {
                 children().size() == 1
                 with(children()[0]) {
                     name() == 'org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus'
-                    children().size() == 4
+                    children().size() == 5
                     commitStatusContext[0].value() == 'Deploy to staging site'
                     triggeredStatus[0].value() == 'deploy triggered'
                     startedStatus[0].value() == 'deploy started'
+                    statusUrl[0].value() == 'http://mysite.com'
                     with(completedStatus[0]) {
                         children().size() == 2
                         with(children()[0]) {


### PR DESCRIPTION
This is needed right now because a change in the ghprb will not print the default status URL if no statusUrl node is present in the config.