### PR TITLE
Fix use of Categories with WorkspaceCleanupContext

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/WorkspaceCleanupContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/common/WorkspaceCleanupContext.groovy
@@ -40,7 +40,7 @@ abstract class WorkspaceCleanupContext implements Context {
         this.deleteCommand = deleteCommand
     }
 
-    private void addPattern(String type, String pattern) {
+    protected void addPattern(String type, String pattern) {
         patternNodes << new NodeBuilder().'hudson.plugins.ws__cleanup.Pattern' {
             delegate.pattern(pattern)
             delegate.type(type)


### PR DESCRIPTION
Prefer `protected` so that Categories will work properly with `PreBuildCleanupContext`.

This issue can be reproduced by this simple job script which will throw an exception. The script does not throw an exeption when not using Categories:

```groovy
class Bar { }

use (Bar) {
    freeStyleJob('deb-promote') {
        wrappers {
            preBuildCleanup {
                excludePattern 'deb/'
            }
        }
    }
}
```

Exception:
```
Caused by: groovy.lang.MissingMethodException: No signature of method: javaposse.jobdsl.dsl.helpers.wrapper.PreBuildCleanupContext.addPattern() is applicable for argument types: (java.lang.String, java.lang.String) values: [EXCLUDE, deb/
```

For reference, see https://issues.apache.org/jira/browse/GROOVY-6263