### PR TITLE
When ghprb version is new enough, emit configVersion 3

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/PullRequestBuilderContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/PullRequestBuilderContext.groovy
@@ -1,5 +1,7 @@
 package javaposse.jobdsl.dsl.helpers.triggers
 
+import hudson.util.VersionNumber
+
 import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
@@ -94,8 +96,12 @@ class PullRequestBuilderContext extends AbstractContext {
      * This string is exactly matched against the comment
      */
     void triggerPhrase(String triggerPhrase) {
-        // Quote the phrase
-        this.triggerPhrase = "\\Q${triggerPhrase}\\E"
+        // Quote the phrase if plugin version is new enough
+        if (this.jobManagement.getPluginVersion('ghprb')?.isOlderThan(new VersionNumber('1.27'))) {
+            this.triggerPhrase = triggerPhrase
+        } else {
+            this.triggerPhrase = "\\Q${triggerPhrase}\\E"
+        }
     }
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/PullRequestBuilderContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/PullRequestBuilderContext.groovy
@@ -91,8 +91,19 @@ class PullRequestBuilderContext extends AbstractContext {
 
     /**
      * When filled, commenting this phrase in the pull request will trigger a build.
+     * This string is exactly matched against the comment
      */
     void triggerPhrase(String triggerPhrase) {
+        // Quote the phrase
+        this.triggerPhrase = "\\Q${triggerPhrase}\\E"
+    }
+
+    /**
+     * When filled, commenting this phrase in the pull request will trigger a build.
+     * This string is matched using regex against the comment
+     */
+    @RequiresPlugin(id = 'ghprb', minimumVersion = '1.27')
+    void regexTriggerPhrase(String triggerPhrase) {
         this.triggerPhrase = triggerPhrase
     }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
@@ -165,6 +165,13 @@ class TriggerContext extends AbstractExtensibleContext {
             if (!jobManagement.getPluginVersion('ghprb')?.isOlderThan(new VersionNumber('1.26'))) {
                 extensions(pullRequestBuilderContext.extensionContext.extensionNodes)
             }
+            // If ghprb is version 1.29, we can use regex in the trigger phrase.  If the configVersion is
+            // less than 3, then the phrase would be quoted automatically.
+            // To avoid issues with users depending on the quoted version, regexTriggerPhrase
+            // is used to indicate an unquoted triggerPhrase, while triggerPhrase is automatically quoted.
+            if (!jobManagement.getPluginVersion('ghprb')?.isOlderThan(new VersionNumber('1.27'))) {
+                configVersion '3'
+            }
         }
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
@@ -331,6 +331,8 @@ class TriggerContextSpec extends Specification {
 
         when:
         context.pullRequest {
+            // Trigger phrase should be unquoted.
+            triggerPhrase('unquoted trigger phrase')
         }
 
         then:
@@ -344,7 +346,7 @@ class TriggerContextSpec extends Specification {
             autoCloseFailedPullRequests[0].value() == false
             cron[0].value() == 'H/5 * * * *'
             spec[0].value() == 'H/5 * * * *'
-            triggerPhrase[0].value() == ''
+            triggerPhrase[0].value() == 'unquoted trigger phrase'
             adminlist[0].value() == ''
             whitelist[0].value() == ''
             orgslist[0].value() == ''

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
@@ -307,6 +307,35 @@ class TriggerContextSpec extends Specification {
         then:
         with(context.triggerNodes[0]) {
             name() == 'org.jenkinsci.plugins.ghprb.GhprbTrigger'
+            children().size() == 14
+            onlyTriggerPhrase[0].value() == false
+            useGitHubHooks[0].value() == false
+            allowMembersOfWhitelistedOrgsAsAdmin[0].value() == false
+            permitAll[0].value() == false
+            autoCloseFailedPullRequests[0].value() == false
+            cron[0].value() == 'H/5 * * * *'
+            spec[0].value() == 'H/5 * * * *'
+            triggerPhrase[0].value() == ''
+            adminlist[0].value() == ''
+            whitelist[0].value() == ''
+            orgslist[0].value() == ''
+            commentFilePath[0].value() == ''
+            configVersion[0].value() == '3'
+        }
+        1 * mockJobManagement.requirePlugin('ghprb')
+    }
+
+    def 'call pull request trigger with plugin version 1.26'() {
+        setup:
+        mockJobManagement.getPluginVersion('ghprb') >> new VersionNumber('1.26')
+
+        when:
+        context.pullRequest {
+        }
+
+        then:
+        with(context.triggerNodes[0]) {
+            name() == 'org.jenkinsci.plugins.ghprb.GhprbTrigger'
             children().size() == 13
             onlyTriggerPhrase[0].value() == false
             useGitHubHooks[0].value() == false
@@ -390,7 +419,7 @@ class TriggerContextSpec extends Specification {
         then:
         with(context.triggerNodes[0]) {
             name() == 'org.jenkinsci.plugins.ghprb.GhprbTrigger'
-            children().size() == 13
+            children().size() == 14
             adminlist[0].value() == 'test1\ntest2'
             whitelist[0].value() == 'test1\ntest2'
             orgslist[0].value() == 'test1\ntest2'
@@ -417,19 +446,61 @@ class TriggerContextSpec extends Specification {
         then:
         with(context.triggerNodes[0]) {
             name() == 'org.jenkinsci.plugins.ghprb.GhprbTrigger'
-            children().size() == 13
+            children().size() == 14
             adminlist[0].value() == 'test'
             whitelist[0].value() == 'test'
             orgslist[0].value() == 'test'
             cron[0].value() == '*/5 * * * *'
             spec[0].value() == '*/5 * * * *'
-            triggerPhrase[0].value() == 'ok to test'
+            // Using trigger phrase on new plugin versions will quote the trigger phrase
+            triggerPhrase[0].value() == '\\Qok to test\\E'
             onlyTriggerPhrase[0].value() == true
             useGitHubHooks[0].value() == true
             allowMembersOfWhitelistedOrgsAsAdmin[0].value() == true
             permitAll[0].value() == true
             autoCloseFailedPullRequests[0].value() == true
             commentFilePath[0].value() == 'myCommentFile'
+            configVersion[0].value() == '3'
+        }
+        1 * mockJobManagement.requirePlugin('ghprb')
+        1 * mockJobManagement.requireMinimumPluginVersion('ghprb', '1.14')
+        1 * mockJobManagement.requireMinimumPluginVersion('ghprb', '1.15-0')
+    }
+
+    def 'call pull request trigger with regex trigger phrase'() {
+        when:
+        context.pullRequest {
+            admins(['test'])
+            userWhitelist(['test'])
+            orgWhitelist(['test'])
+            cron('*/5 * * * *')
+            regexTriggerPhrase('.*ok to test.*')
+            onlyTriggerPhrase(true)
+            useGitHubHooks(true)
+            allowMembersOfWhitelistedOrgsAsAdmin(true)
+            permitAll(true)
+            autoCloseFailedPullRequests(true)
+            commentFilePath('myCommentFile')
+        }
+
+        then:
+        with(context.triggerNodes[0]) {
+            name() == 'org.jenkinsci.plugins.ghprb.GhprbTrigger'
+            children().size() == 14
+            adminlist[0].value() == 'test'
+            whitelist[0].value() == 'test'
+            orgslist[0].value() == 'test'
+            cron[0].value() == '*/5 * * * *'
+            spec[0].value() == '*/5 * * * *'
+            // Using trigger phrase on new plugin versions will quote the trigger phrase
+            triggerPhrase[0].value() == '.*ok to test.*'
+            onlyTriggerPhrase[0].value() == true
+            useGitHubHooks[0].value() == true
+            allowMembersOfWhitelistedOrgsAsAdmin[0].value() == true
+            permitAll[0].value() == true
+            autoCloseFailedPullRequests[0].value() == true
+            commentFilePath[0].value() == 'myCommentFile'
+            configVersion[0].value() == '3'
         }
         1 * mockJobManagement.requirePlugin('ghprb')
         1 * mockJobManagement.requireMinimumPluginVersion('ghprb', '1.14')
@@ -454,7 +525,7 @@ class TriggerContextSpec extends Specification {
         then:
         with(context.triggerNodes[0]) {
             name() == 'org.jenkinsci.plugins.ghprb.GhprbTrigger'
-            children().size() == 13
+            children().size() == 14
             adminlist[0].value() == ''
             whitelist[0].value() == ''
             orgslist[0].value() == ''


### PR DESCRIPTION
Earlier versions of the ghprb did not have regex matching for trigger phrases.  When this was introduced, the config upgrade process quoted the trigger phrase strings.  Because the DSL does not emit configVersion 3, a regex trigger phrase will get quoted when it doesn't need to even to.