### PR TITLE
Fix Jenkins Artifactory URL

### DIFF
--- a/docs/IDE-Support.md
+++ b/docs/IDE-Support.md
@@ -39,7 +39,7 @@ installation.
     repositories {
         mavenCentral()
         maven {
-            url 'http://repo.jenkins-ci.org/releases/'
+            url 'https://jenkins-ci.artifactoryonline.com/jenkinsci/releases/'
         }
     }
 


### PR DESCRIPTION
Although the previous URL works, it redirects to https with a bad certificate. I've updated the URL to the correct one.