### PR TITLE
document multi-line triggers

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
@@ -94,7 +94,7 @@ class TriggerContext extends AbstractExtensibleContext {
 
     /**
      * Triggers the job based on regular intervals.
-     * 
+     *
      * To configure a multi-line entry, use a single trigger string with entries separated by \n.
      */
     void cron(String cronString) {
@@ -107,7 +107,7 @@ class TriggerContext extends AbstractExtensibleContext {
 
     /**
      * Polls source control for changes at regular intervals.
-     * 
+     *
      * To configure a multi-line entry, use a single trigger string with entries separated by \n.
      */
     void scm(String cronString, @DslContext(ScmTriggerContext) Closure scmTriggerClosure = null) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
@@ -94,6 +94,8 @@ class TriggerContext extends AbstractExtensibleContext {
 
     /**
      * Triggers the job based on regular intervals.
+     * 
+     * To configure a multi-line entry, use a single trigger string with entries separated by \n.
      */
     void cron(String cronString) {
         Preconditions.checkNotNull(cronString, 'cronString must be specified')
@@ -105,6 +107,8 @@ class TriggerContext extends AbstractExtensibleContext {
 
     /**
      * Polls source control for changes at regular intervals.
+     * 
+     * To configure a multi-line entry, use a single trigger string with entries separated by \n.
      */
     void scm(String cronString, @DslContext(ScmTriggerContext) Closure scmTriggerClosure = null) {
         Preconditions.checkNotNull(cronString, 'cronString must be specified')


### PR DESCRIPTION
I attempted to improve the documentation for using multi-line cron/scm entries. My initial intuition for this was to use multiple cron()'s, but only one showed up. I'm happy to adjust this language as desired and add it other places so others can discover this; I don't think it should require specific language/parsing knowledge to know how to separate lines. Or, perhaps the solution is that multiple cron()s and scm()s should be allowed. Just throwing one documentation solution out there :)