### PR TITLE
Jenkins 31264 gradle use workspace as home

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -86,6 +86,7 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
  * Removed implicit star import of `javaposse.jobdsl.dsl.ConfigFileType` in scripts, see
    [Migration](Migration#migrating-to-139)
  * Removed anything that has been deprecated in 1.31, see [Migration](Migration#migrating-to-131)
+ * Added support for the useWorkspaceAsHome property of the [Gradle Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Gradle+Plugin)
 * 1.38 (September 09 2015)
  * Replaced the [[Job Reference]], [[View Reference]] and [[Folder Reference]] pages by the
    [API Viewer](https://jenkinsci.github.io/job-dsl-plugin/)

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -42,6 +42,7 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
  * Added workaround for [GROOVY-6263](https://issues.apache.org/jira/browse/GROOVY-6263) to `WorkspaceCleanupContext`
  * Added support for the [SSH Plugin](https://wiki.jenkins-ci.org/display/JENKINS/SSH+plugin)
    ([JENKINS-30957](https://issues.jenkins-ci.org/browse/JENKINS-30957))
+ * Added support for the `useWorkspaceAsHome` property of the [Gradle Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Gradle+Plugin)  
 * 1.39 (October 05 2015)
  * Increased the minimum supported Jenkins version to 1.596
  * Added support for the [ZenTimestamp Plugin](https://wiki.jenkins-ci.org/display/JENKINS/ZenTimestamp+Plugin)
@@ -86,7 +87,6 @@ Have a look at the [Jenkins Job DSL Gradle example](https://github.com/sheehan/j
  * Removed implicit star import of `javaposse.jobdsl.dsl.ConfigFileType` in scripts, see
    [Migration](Migration#migrating-to-139)
  * Removed anything that has been deprecated in 1.31, see [Migration](Migration#migrating-to-131)
- * Added support for the useWorkspaceAsHome property of the [Gradle Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Gradle+Plugin)
 * 1.38 (September 09 2015)
  * Replaced the [[Job Reference]], [[View Reference]] and [[Folder Reference]] pages by the
    [API Viewer](https://jenkinsci.github.io/job-dsl-plugin/)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/GradleContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/GradleContext.groovy
@@ -11,6 +11,7 @@ class GradleContext implements Context {
     String buildFile = ''
     boolean fromRootBuildScriptDir = true
     boolean makeExecutable
+    boolean useWorkspaceAsHome = false
     String gradleName = '(Default)'
     Closure configureBlock
 
@@ -75,6 +76,13 @@ class GradleContext implements Context {
      */
     void makeExecutable(boolean makeExecutable = true) {
         this.makeExecutable = makeExecutable
+    }
+
+    /**
+     * Sets the useWorkspaceAsHome flag. Defaults to {@code false}.
+     */
+    void useWorkspaceAsHome(boolean useWorkspaceAsHome = false) {
+        this.useWorkspaceAsHome  = useWorkspaceAsHome
     }
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/GradleContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/GradleContext.groovy
@@ -11,7 +11,7 @@ class GradleContext implements Context {
     String buildFile = ''
     boolean fromRootBuildScriptDir = true
     boolean makeExecutable
-    boolean useWorkspaceAsHome = false
+    boolean useWorkspaceAsHome
     String gradleName = '(Default)'
     Closure configureBlock
 
@@ -81,7 +81,7 @@ class GradleContext implements Context {
     /**
      * Sets the useWorkspaceAsHome flag. Defaults to {@code false}.
      */
-    void useWorkspaceAsHome(boolean useWorkspaceAsHome = false) {
+    void useWorkspaceAsHome(boolean useWorkspaceAsHome = true) {
         this.useWorkspaceAsHome  = useWorkspaceAsHome
     }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -115,6 +115,7 @@ class StepContext extends AbstractExtensibleContext {
             useWrapper gradleContext.useWrapper
             makeExecutable gradleContext.makeExecutable
             fromRootBuildScriptDir gradleContext.fromRootBuildScriptDir
+            useWorkspaceAsHome gradleContext.useWorkspaceAsHome
         }
 
         if (gradleContext.configureBlock) {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
@@ -165,6 +165,7 @@ class StepContextSpec extends Specification {
             gradleName[0].value() == '(Default)'
             fromRootBuildScriptDir[0].value() == true
             makeExecutable[0].value() == false
+            useWorkspaceAsHome[0].value() == false
         }
         (1.._) * jobManagement.requirePlugin('gradle')
 
@@ -184,6 +185,7 @@ class StepContextSpec extends Specification {
             gradleName[0].value() == '(Default)'
             fromRootBuildScriptDir[0].value() == true
             makeExecutable[0].value() == false
+            useWorkspaceAsHome[0].value() == false
         }
         (1.._) * jobManagement.requirePlugin('gradle')
     }
@@ -202,6 +204,7 @@ class StepContextSpec extends Specification {
             gradleName 'gn'
             fromRootBuildScriptDir true
             makeExecutable true
+            useWorkspaceAsHome true
         }
 
         then:
@@ -216,6 +219,7 @@ class StepContextSpec extends Specification {
             gradleName[0].value() == 'gn'
             fromRootBuildScriptDir[0].value() == true
             makeExecutable[0].value() == true
+            useWorkspaceAsHome[0].value() == true
         }
         1 * jobManagement.requirePlugin('gradle')
     }


### PR DESCRIPTION
Fix for JENKINS-31264.  Hopefully we can get this in 1.40 so I can remove my custom workaround in our seed job.