### PR TITLE
Use correct JaCoCo plugin versioning

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/JacocoContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/JacocoContext.groovy
@@ -150,7 +150,7 @@ class JacocoContext extends AbstractContext {
     /**
      * If set, changes the build status according to the thresholds. Defaults to {@code false}.
      */
-    @RequiresPlugin(id = 'jacoco', minimumVersion = '10.0.13')
+    @RequiresPlugin(id = 'jacoco', minimumVersion = '1.0.13')
     void changeBuildStatus(boolean change = true) {
         this.changeBuildStatus = change
     }


### PR DESCRIPTION
Seems to be a typo -- there is no 10.0.13, only 1.0.13: https://wiki.jenkins-ci.org/display/JENKINS/JaCoCo+Plugin