### PR TITLE
[JENKINS-31174] Improved logging

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -2,6 +2,7 @@ package javaposse.jobdsl.dsl;
 
 import groovy.lang.Binding;
 import groovy.lang.GroovyClassLoader;
+import groovy.lang.GroovyRuntimeException;
 import groovy.lang.Script;
 import groovy.util.GroovyScriptEngine;
 import groovy.util.ResourceException;
@@ -71,15 +72,11 @@ public class DslScriptLoader {
 
                     binding.setVariable("jobFactory", jp);
 
-                    try {
-                        script.run();
-                    } catch (DslScriptException e) {
-                        throw e;
-                    } catch (RuntimeException e) {
-                        throw new DslScriptException(e.getMessage(), e);
-                    }
+                    script.run();
                 } catch (CompilationFailedException e) {
                     throw new DslException(e.getMessage(), e);
+                } catch (GroovyRuntimeException e) {
+                    throw new DslScriptException(e.getMessage(), e);
                 } catch (ResourceException e) {
                     throw new IOException("Unable to run script", e);
                 } catch (ScriptException e) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
@@ -268,5 +268,6 @@ interface JobManagement {
      *         node or {@code null} if no extension has been found
      * @since 1.33
      */
-    Node callExtension(String name, Item item, Class<? extends ExtensibleContext> contextType, Object... args)
+    Node callExtension(String name, Item item, Class<? extends ExtensibleContext> contextType,
+                       Object... args) throws Throwable
 }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
@@ -21,6 +21,7 @@ import hudson.model.View;
 import hudson.model.ViewGroup;
 import hudson.tasks.Builder;
 import javaposse.jobdsl.dsl.DslException;
+import javaposse.jobdsl.dsl.DslScriptException;
 import javaposse.jobdsl.dsl.DslScriptLoader;
 import javaposse.jobdsl.dsl.GeneratedConfigFile;
 import javaposse.jobdsl.dsl.GeneratedItems;
@@ -239,7 +240,10 @@ public class ExecuteDslScripts extends Builder {
             } finally {
                 generator.close();
             }
-        } catch (DslException e) {
+        } catch (RuntimeException e) {
+            if (!(e instanceof DslException)) {
+                e.printStackTrace(listener.getLogger());
+            }
             LOGGER.log(Level.FINE, String.format("Exception while processing DSL scripts: %s", e.getMessage()), e);
             throw new AbortException(e.getMessage());
         }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -55,6 +55,7 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -403,7 +404,7 @@ public final class JenkinsJobManagement extends AbstractJobManagement {
 
     @Override
     public Node callExtension(String name, javaposse.jobdsl.dsl.Item item,
-                              Class<? extends ExtensibleContext> contextType, Object... args) {
+                              Class<? extends ExtensibleContext> contextType, Object... args) throws Throwable {
         Set<ExtensionPointMethod> candidates = ExtensionPointHelper.findExtensionPoints(name, contextType, args);
         if (candidates.isEmpty()) {
             LOGGER.fine(
@@ -422,8 +423,8 @@ public final class JenkinsJobManagement extends AbstractJobManagement {
         try {
             Object result = Iterables.getOnlyElement(candidates).call(getSession(item), args);
             return result == null ? NO_VALUE : new XmlParser().parseText(Items.XSTREAM2.toXML(result));
-        } catch (Exception e) {
-            throw new RuntimeException("Error calling extension", e);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
         }
     }
 


### PR DESCRIPTION
* unwrap InvocationTargetExceptions when calling extensions to hide the fact that extensions are called through reflection
* log stack traces for all exceptions but DslScriptExceptions so that users can debug their scripts without looking in Jenkins logs
* only wrap GroovyRuntimeException in DslScriptException so that users can debug their scripts without looking in Jenkins logs but problems like simple syntax errors do not cause stack traces