### PR TITLE
[JENKINS-31544] Added Build failure analyzer plugin support

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/properties/PropertiesContext/buildFailureAnalyzer.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/properties/PropertiesContext/buildFailureAnalyzer.groovy
@@ -1,11 +1,11 @@
 job('example1') {
     properties {
-        scannerJobProperty()
+        buildFailureAnalyzer()
     }
 }
 
 job('example2') {
     properties {
-        scannerJobProperty(false)
+        buildFailureAnalyzer(false)
     }
 }

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/properties/PropertiesContext/scannerJobProperty.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/properties/PropertiesContext/scannerJobProperty.groovy
@@ -1,0 +1,11 @@
+job('example1') {
+    properties {
+        scannerJobProperty()
+    }
+}
+
+job('example2') {
+    properties {
+        scannerJobProperty(false)
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/properties/PropertiesContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/properties/PropertiesContext.groovy
@@ -102,4 +102,16 @@ class PropertiesContext extends AbstractExtensibleContext {
             delegate.projectUrl(projectUrl ?: '')
         }
     }
+
+    /**
+     * Configures the Build Failure Analyzer.
+     *
+     * @since 1.41
+     */
+    @RequiresPlugin(id = 'build-failure-analyzer', minimumVersion = '1.13')
+    void scannerJobProperty(Boolean doNotScan = false) {
+        propertiesNodes << new NodeBuilder().'com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty' {
+            delegate.doNotScan(doNotScan)
+        }
+    }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/properties/PropertiesContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/properties/PropertiesContext.groovy
@@ -109,9 +109,9 @@ class PropertiesContext extends AbstractExtensibleContext {
      * @since 1.41
      */
     @RequiresPlugin(id = 'build-failure-analyzer', minimumVersion = '1.13')
-    void scannerJobProperty(Boolean doNotScan = false) {
+    void buildFailureAnalyzer(boolean scan = true) {
         propertiesNodes << new NodeBuilder().'com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty' {
-            delegate.doNotScan(doNotScan)
+            delegate.doNotScan(!scan)
         }
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/properties/PropertiesContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/properties/PropertiesContextSpec.groovy
@@ -155,4 +155,34 @@ class PropertiesContextSpec extends Specification {
         ''                                            || ''
         null                                          || ''
     }
+
+    def 'scannerJobProperty'() {
+        when:
+        context.scannerJobProperty()
+
+        then:
+        with(context.propertiesNodes[0]) {
+            name() == 'com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty'
+            children().size() == 1
+            doNotScan[0].value() == false
+        }
+    }
+
+    def 'scannerJobProperty with value'() {
+        when:
+        context.scannerJobProperty(value)
+
+        then:
+        with(context.propertiesNodes[0]) {
+            name() == 'com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty'
+            children().size() == 1
+            doNotScan[0].value() == expected
+        }
+
+        where:
+        value || expected
+        true  || true
+        false || false
+        null  || null
+    }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/properties/PropertiesContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/properties/PropertiesContextSpec.groovy
@@ -156,9 +156,9 @@ class PropertiesContextSpec extends Specification {
         null                                          || ''
     }
 
-    def 'scannerJobProperty'() {
+    def 'buildFailureAnalyzer'() {
         when:
-        context.scannerJobProperty()
+        context.buildFailureAnalyzer()
 
         then:
         with(context.propertiesNodes[0]) {
@@ -168,9 +168,9 @@ class PropertiesContextSpec extends Specification {
         }
     }
 
-    def 'scannerJobProperty with value'() {
+    def 'buildFailureAnalyzer with value'() {
         when:
-        context.scannerJobProperty(value)
+        context.buildFailureAnalyzer(value)
 
         then:
         with(context.propertiesNodes[0]) {
@@ -181,8 +181,7 @@ class PropertiesContextSpec extends Specification {
 
         where:
         value || expected
-        true  || true
-        false || false
-        null  || null
+        true  || false
+        false || true
     }
 }


### PR DESCRIPTION
Added [Build Failure Analyzer](https://wiki.jenkins-ci.org/display/JENKINS/Build+Failure+Analyzer) plugin support
- https://issues.jenkins-ci.org/browse/JENKINS-31544