### PR TITLE
[Jenkins 21880] weblogic deployer plugin support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ project(':job-dsl-core') {
         compile 'xmlunit:xmlunit:1.4' // for runtime use, not just for testing
         compile 'org.jenkins-ci:version-number:1.1'
         compile 'org.jvnet.hudson:xstream:1.4.7-jenkins-1'
+        compile 'commons-lang:commons-lang:2.6' // For WeblogicDeployerPlugin task id generation
     }
 
     codenarcExamples {

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -21,6 +21,7 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
 
 ## Release Notes
 * 1.41 (unreleased)
+ * Added support for the [WebLogic Deployer Plugin](https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin)
  * Added support for the [Mantis Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Mantis+Plugin)
    ([JENKINS-31911](https://issues.jenkins-ci.org/browse/JENKINS-31911))
  * Added support for the [Gatling Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Gatling+Plugin)

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/deployToWeblogic.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/deployToWeblogic.groovy
@@ -1,0 +1,40 @@
+job('example') {
+    publishers {
+        deployToWeblogic {
+            mustExitOnFailure(true)
+            forceStopOnFirstFailure(true)
+
+            // at least one task is required
+            task {
+                // required
+                weblogicEnvironmentTargetedName('dev_environment')
+                // required
+                deploymentName('myApplicationName')
+
+                deploymentTargets('AdminServer')
+
+                // required
+                builtResourceRegexToDeploy('myApp\\.ear')
+                // required
+                baseResourcesGeneratedDirectory('')
+                // required
+                taskName('Deploy myApp to DEV Server')
+
+                jdkName('JDK_7')
+                jdkHome('C:\\Program Files\\Java\\jdk1.7.0_65')
+
+                stageMode(WeblogicDeploymentStageModes.STAGE)
+
+                commandLine('-debug -remote -verbose')
+                commandLine('-name {wl.deployment_name} -targets {wl.targets}')
+                commandLine('-adminurl t3://{wl.host}:{wl.port} -user {wl.login} -password {wl.password}')
+                commandLine('-undeploy -noexit;\n')
+
+                commandLine('-debug -remote -verbose')
+                commandLine('-name {wl.deployment_name} -source {wl.source} -targets {wl.targets}')
+                commandLine('-adminurl t3://{wl.host}:{wl.port} -user {wl.login} -password {wl.password}')
+                commandLine('-deploy -stage -upload;')
+            }
+        }
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -234,6 +234,7 @@ public class DslScriptLoader {
         icz.addImports("javaposse.jobdsl.dsl.helpers.scm.SvnCheckoutStrategy");
         icz.addImports("javaposse.jobdsl.dsl.helpers.scm.SvnDepth");
         icz.addImports("javaposse.jobdsl.dsl.helpers.LocalRepositoryLocation");
+        icz.addImports("javaposse.jobdsl.dsl.helpers.publisher.WeblogicDeployerContext.WeblogicDeploymentStageModes");
         config.addCompilationCustomizers(icz);
 
         config.setOutput(new PrintWriter(jobManagement.getOutputStream())); // This seems to do nothing

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1802,4 +1802,37 @@ class PublisherContext extends AbstractExtensibleContext {
         addStaticAnalysisContext(nodeBuilder, context)
         addStaticAnalysisPattern(nodeBuilder, pattern)
     }
+
+    /**
+     * Configures a Weblogic deployment using the weblogic-deployer-plugin.
+     *
+     * By default the following values are applied. If an instance of a
+     * closure is provided, the values from the closure will take effect.
+     *
+     * @since 1.41
+     */
+    @RequiresPlugin(id = 'weblogic-deployer-plugin', minimumVersion = '2.9.1')
+    void deployToWeblogic(@DslContext(WeblogicDeployerContext) Closure weblogicClosure) {
+
+        WeblogicDeployerContext context = new WeblogicDeployerContext()
+        ContextHelper.executeInContext(weblogicClosure, context)
+
+        NodeBuilder nodeBuilder = NodeBuilder.newInstance()
+        Node weblogicDeployerNode = nodeBuilder.'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin' {
+
+            mustExitOnFailure(context.mustExitOnFailure)
+            forceStopOnFirstFailure(context.forceStopOnFirstFailure)
+            isDeployingOnlyWhenUpdates(context.deployingOnlyWhenUpdates)
+            deployedProjectsDependencies(context.deployedProjectsDependencies)
+
+            selectedDeploymentStrategyIds(context.deploymentPoliciesIdsNodes)
+
+            if (context.taskNodes) {
+                tasks(context.taskNodes)
+            }
+        }
+
+        publisherNodes << weblogicDeployerNode
+    }
+
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerContext.groovy
@@ -1,0 +1,125 @@
+package javaposse.jobdsl.dsl.helpers.publisher
+
+import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.ContextHelper
+import javaposse.jobdsl.dsl.DslContext
+import org.apache.commons.lang.RandomStringUtils
+
+/**
+ * DSL Support for the weblogic-deployment-plugin.
+ */
+class WeblogicDeployerContext implements Context {
+
+    /**
+     * Enumeration of available deployment stage modes.
+     */
+    static enum WeblogicDeploymentStageModes {
+
+        BY_DEFAULT('bydefault'),
+
+        STAGE('stage'),
+
+        NO_STAGE('nostage'),
+
+        EXTERNAL_STAGE('external_stage')
+
+        private final String stringRepresentation
+
+        WeblogicDeploymentStageModes(String stringRepresentation) {
+            this.stringRepresentation = stringRepresentation
+        }
+
+        @Override
+        String toString() {
+            this.stringRepresentation
+        }
+    }
+
+    List<Node> taskNodes = []
+    List<Node> deploymentPoliciesIdsNodes = []
+
+    boolean mustExitOnFailure = false
+    boolean forceStopOnFirstFailure = false
+    boolean deployingOnlyWhenUpdates = false
+    String deployedProjectsDependencies = ''
+
+    /**
+     * Fails the build if the deployment fails. Defaults to {@code false}.
+     */
+    void mustExitOnFailure(boolean mustExitOnFailure = true) {
+        this.mustExitOnFailure = mustExitOnFailure
+    }
+
+    /**
+     * Stop the job on first deployment failure. No other defined deployment task of this job will be executed.
+     * Defaults to {@code false}.
+     */
+    void forceStopOnFirstFailure(boolean forceStopOnFirstFailure = true) {
+        this.forceStopOnFirstFailure = forceStopOnFirstFailure
+    }
+
+    /**
+     * Deploy only if the build was triggered by a parameterized cause AND the SCM detects changes.
+     * Defaults to {@code false}.
+     */
+    void deployingOnlyWhenUpdates(boolean deployingOnlyWhenUpdates = true) {
+        this.deployingOnlyWhenUpdates = deployingOnlyWhenUpdates
+    }
+
+    /**
+     * (experimental plugin feature) Defines a dependency to other deployment jobs.
+     * Defaults to {@code ''}.
+     */
+    void deployedProjectsDependencies(String deployedProjectsDependencies) {
+        this.deployedProjectsDependencies = deployedProjectsDependencies
+    }
+
+    /**
+     * Deploy only when the deployment policy is fulfilled. Defaults to {@code <Empty>}
+     */
+    void deploymentPolicies(@DslContext(WeblogicDeployerPolicyContext) Closure deploymentPoliciesClosure = null) {
+
+        WeblogicDeployerPolicyContext context = new WeblogicDeployerPolicyContext()
+        ContextHelper.executeInContext(deploymentPoliciesClosure, context)
+
+        NodeBuilder nodeBuilder = NodeBuilder.newInstance()
+
+        context.deploymentPolicies.each {
+            policy -> deploymentPoliciesIdsNodes << nodeBuilder.createNode('string', policy)
+        }
+    }
+
+    /**
+     * Configures a Weblogic deployment task using the weblogic-deployer-plugin.
+     *
+     * These are the default values, which are used if they are not overridden by closure.
+     * All other properties must be set via closure for each task definition, as there are no default values.
+     */
+    void task(@DslContext(WeblogicDeployerTaskContext) Closure taskClosure) {
+
+        WeblogicDeployerTaskContext context = new WeblogicDeployerTaskContext()
+        ContextHelper.executeInContext(taskClosure, context)
+
+        NodeBuilder nodeBuilder = NodeBuilder.newInstance()
+        Node tasksNode = nodeBuilder.'org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask' {
+            id(RandomStringUtils.randomAlphanumeric(10))
+            weblogicEnvironmentTargetedName(context.weblogicEnvironmentTargetedName)
+            deploymentName(context.deploymentName)
+            deploymentTargets(context.deploymentTargets)
+            isLibrary(context.isLibrary)
+            builtResourceRegexToDeploy(context.builtResourceRegexToDeploy)
+            baseResourcesGeneratedDirectory(context.baseResourcesGeneratedDirectory)
+            taskName(context.taskName)
+
+            jdk {
+                name(context.jdkName)
+                home(context.jdkHome)
+            }
+            stageMode(context.stageMode.toString())
+            commandLine(context.commandLine)
+            deploymentPlan(context.deploymentPlan)
+        }
+
+        this.taskNodes << tasksNode
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerPolicyContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerPolicyContext.groovy
@@ -1,0 +1,64 @@
+package javaposse.jobdsl.dsl.helpers.publisher
+
+import javaposse.jobdsl.dsl.Context
+
+/**
+ * DSL Support for the weblogic-deployment-plugin's deployment policies subsection.
+ */
+class WeblogicDeployerPolicyContext implements Context {
+
+    /**
+     * Deployment policy.
+     */
+    List<String> deploymentPolicies = []
+
+    /**
+     * Legacy code started this job.  No cause information is available.
+     */
+    void legacyCode() {
+        this.deploymentPolicies.add('hudson.model.Cause\\\\\$LegacyCodeCause')
+    }
+
+    /**
+     * Started by user.
+     */
+    void user() {
+        this.deploymentPolicies.add('hudson.model.Cause\\\\\$UserCause')
+    }
+
+    /**
+     * Started by user.
+     */
+    void userId() {
+        this.deploymentPolicies.add('hudson.model.Cause\\\\\$UserIdCause')
+    }
+
+    /**
+     * Started by remote host.
+     */
+    void remoteHost() {
+        this.deploymentPolicies.add('hudson.model.Cause\\\\\$RemoteCause')
+    }
+
+    /**
+     * Built after other projects are built or whenever a SNAPSHOT dependency is built.
+     */
+    void upstream() {
+        this.deploymentPolicies.add('hudson.model.Cause\\\\\$UpstreamCause')
+    }
+
+    /**
+     * Started by deployment timer.
+     */
+    void deploymentTimer() {
+        this.deploymentPolicies.add('org.jenkinsci.plugins.deploy.weblogic.trigger.DeploymentTrigger' +
+                '\\\\\$DeploymentTriggerCause')
+    }
+
+    /**
+     * Started by an SCM change.
+     */
+    void scmChange() {
+        this.deploymentPolicies.add('hudson.triggers.SCMTrigger\\\\\$SCMTriggerCause')
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerTaskContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WeblogicDeployerTaskContext.groovy
@@ -1,0 +1,123 @@
+package javaposse.jobdsl.dsl.helpers.publisher
+
+import javaposse.jobdsl.dsl.Context
+
+import static javaposse.jobdsl.dsl.helpers.publisher.WeblogicDeployerContext.WeblogicDeploymentStageModes
+
+/**
+ * DSL Support for the weblogic-deployment-plugin's task subsection.
+ */
+class WeblogicDeployerTaskContext implements Context {
+
+    String weblogicEnvironmentTargetedName
+    String deploymentName
+    String deploymentTargets = 'AdminServer'
+    boolean isLibrary = false
+    String builtResourceRegexToDeploy
+    String baseResourcesGeneratedDirectory
+    String taskName
+
+    String jdkName = ''
+    String jdkHome = ''
+
+    WeblogicDeploymentStageModes stageMode = WeblogicDeploymentStageModes.BY_DEFAULT
+    String commandLine = ''
+    String deploymentPlan = ''
+
+    /**
+     * Server environment to deploy to.
+     */
+    void weblogicEnvironmentTargetedName(String weblogicEnvironmentTargetedName) {
+        this.weblogicEnvironmentTargetedName = weblogicEnvironmentTargetedName
+    }
+
+    /**
+     * Name of the deployed Application.
+     */
+    void deploymentName(String deploymentName) {
+        this.deploymentName = deploymentName
+    }
+
+    /**
+     * Targets to deploy to. Comma separated String of targets
+     * (e.g. AdminServer, myManagedServer, myCluster). Defaults to {@code AdminServer}
+     */
+    void deploymentTargets(String deploymentTargets) {
+        this.deploymentTargets = deploymentTargets
+    }
+
+    /**
+     * Type of deployment. Defaults to {@code false}.
+     */
+    void isLibrary(boolean isLibrary = true) {
+        this.isLibrary = isLibrary
+    }
+
+    /**
+     * Regex matching the artifact to deploy.
+     */
+    void builtResourceRegexToDeploy(String builtResourceRegexToDeploy) {
+        this.builtResourceRegexToDeploy = builtResourceRegexToDeploy
+    }
+
+    /**
+     * Base directory where to search for the deployment artifact.
+     * NOTE: Can only be used in FreeStyle projects!
+     */
+    void baseResourcesGeneratedDirectory(String baseResourcesGeneratedDirectory) {
+        this.baseResourcesGeneratedDirectory = baseResourcesGeneratedDirectory
+    }
+
+    /**
+     * Task name to identify deployment task (optional).
+     */
+    void taskName(String taskName) {
+        this.taskName = taskName
+    }
+
+    /**
+     * Name of the JDK to use (optional). If not specified, the default JDK defined in plugin settings will be used.
+     * Defaults to {@code <empty>}.
+     */
+    void jdkName(String jdkName) {
+        this.jdkName = jdkName
+    }
+
+    /**
+     * Path to the JDK home to use.
+     * Defaults to {@code <empty>}.
+     */
+    void jdkHome(String jdkHome) {
+        this.jdkHome = jdkHome
+    }
+
+    /**
+     * Staging method to use.
+     * Defaults to {@code WeblogicDeploymentStageModes.BY_DEFAULT}.
+     */
+    void stageMode(WeblogicDeploymentStageModes stageMode) {
+        this.stageMode = stageMode
+    }
+
+    /**
+     * Defines custom commands to be executed instead of the default ones (undeploy/deploy).
+     * Commands to be executed separated by semicolon. Defaults to {@code ''}.
+     *
+     * Can contain tokens which will be replaced. See plugin website.
+     */
+    void commandLine(String commandLine) {
+        if (this.commandLine.isEmpty()) {
+            this.commandLine += commandLine
+        } else {
+            this.commandLine += ' ' + commandLine
+        }
+    }
+
+    /**
+     * Path to the deployment plan to use. Must be referenced in command line
+     * (See plugin website). Defaults to {@code ''}.
+     */
+    void deploymentPlan(String deploymentPlan) {
+        this.deploymentPlan = deploymentPlan
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -9,6 +9,7 @@ import spock.lang.Specification
 
 import static javaposse.jobdsl.dsl.helpers.publisher.ArchiveXUnitContext.ThresholdMode
 import static javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.Behavior.MarkUnstable
+import static javaposse.jobdsl.dsl.helpers.publisher.WeblogicDeployerContext.WeblogicDeploymentStageModes
 
 class PublisherContextSpec extends Specification {
     JobManagement jobManagement = Mock(JobManagement)
@@ -5316,5 +5317,329 @@ class PublisherContextSpec extends Specification {
 
         where:
         value << [true, false]
+    }
+
+    def 'publish deployment to WebLogic with least args'() {
+        when:
+        context.deployToWeblogic()
+
+        then:
+        context.publisherNodes.size() == 1
+        with(context.publisherNodes[0]) {
+            name() == 'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin'
+            mustExitOnFailure[0].value() == false
+            forceStopOnFirstFailure[0].value() == false
+            isDeployingOnlyWhenUpdates[0].value() == false
+        }
+    }
+
+    def 'publish one deployment to WebLogic with all required args'() {
+        when:
+        context.deployToWeblogic {
+
+            task {
+                weblogicEnvironmentTargetedName('test_environment')
+                deploymentName('myApp')
+                deploymentTargets('ms_one')
+                builtResourceRegexToDeploy('myApp.ear')
+                baseResourcesGeneratedDirectory('')
+                taskName('test_deploy_task')
+
+                jdkName('JDK 7')
+
+                stageMode(WeblogicDeploymentStageModes.BY_DEFAULT)
+            }
+
+        }
+
+        then:
+        context.publisherNodes.size() == 1
+        with(context.publisherNodes[0]) {
+            name() == 'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin'
+            mustExitOnFailure[0].value() == false
+            forceStopOnFirstFailure[0].value() == false
+            isDeployingOnlyWhenUpdates[0].value() == false
+            deployedProjectsDependencies[0].value() == ''
+
+            tasks.size() == 1
+            def task = tasks[0].'org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask'
+            task.size() == 1
+
+            with (task[0]) {
+                id[0].value().size() == 10
+                weblogicEnvironmentTargetedName[0].value() == 'test_environment'
+                deploymentName[0].value() == 'myApp'
+                deploymentTargets[0].value() == 'ms_one'
+                isLibrary[0].value() == false
+                builtResourceRegexToDeploy[0].value() == 'myApp.ear'
+                baseResourcesGeneratedDirectory[0].value() == ''
+                taskName[0].value() == 'test_deploy_task'
+
+                jdk[0].name[0].value() == 'JDK 7'
+                jdk[0].home[0].value() == ''
+
+                stageMode[0].value() == WeblogicDeploymentStageModes.BY_DEFAULT.toString()
+                commandLine[0].value() == ''
+                deploymentPlan[0].value() == ''
+            }
+        }
+    }
+
+    def 'publish one deployment to WebLogic with all args'() {
+        when:
+        context.deployToWeblogic {
+            mustExitOnFailure()
+            forceStopOnFirstFailure()
+            deployingOnlyWhenUpdates()
+            deployedProjectsDependencies('abc,def')
+
+            deploymentPolicies {
+                legacyCode()
+                user()
+                userId()
+                remoteHost()
+                upstream()
+                deploymentTimer()
+                scmChange()
+            }
+
+            task {
+                weblogicEnvironmentTargetedName('test_environment')
+                deploymentName('myApp')
+                deploymentTargets('ms_one')
+                isLibrary()
+                builtResourceRegexToDeploy('myApp.ear')
+                baseResourcesGeneratedDirectory('')
+                taskName('test_deploy_task')
+
+                jdkName('JDK 7')
+                jdkHome('')
+
+                stageMode(WeblogicDeploymentStageModes.BY_DEFAULT)
+                commandLine('')
+                deploymentPlan('')
+            }
+        }
+
+        then:
+        context.publisherNodes.size() == 1
+        with(context.publisherNodes[0]) {
+            name() == 'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin'
+            mustExitOnFailure[0].value() == true
+            forceStopOnFirstFailure[0].value() == true
+            isDeployingOnlyWhenUpdates[0].value() == true
+            deployedProjectsDependencies[0].value() == 'abc,def'
+
+            with(selectedDeploymentStrategyIds[0]) {
+                children().size() == 7
+                string[0].value() == 'hudson.model.Cause\\\\\$LegacyCodeCause'
+                string[1].value() == 'hudson.model.Cause\\\\\$UserCause'
+                string[2].value() == 'hudson.model.Cause\\\\\$UserIdCause'
+                string[3].value() == 'hudson.model.Cause\\\\\$RemoteCause'
+                string[4].value() == 'hudson.model.Cause\\\\\$UpstreamCause'
+                string[5].value() == 'org.jenkinsci.plugins.deploy.weblogic.trigger.DeploymentTrigger' +
+                        '\\\\\$DeploymentTriggerCause'
+                string[6].value() == 'hudson.triggers.SCMTrigger\\\\\$SCMTriggerCause'
+            }
+
+            tasks.size() == 1
+            def task = tasks[0].'org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask'
+            task.size() == 1
+
+            with(task[0]) {
+                id[0].value().size() == 10
+                weblogicEnvironmentTargetedName[0].value() == 'test_environment'
+                deploymentName[0].value() == 'myApp'
+                deploymentTargets[0].value() == 'ms_one'
+                isLibrary[0].value() == true
+                builtResourceRegexToDeploy[0].value() == 'myApp.ear'
+                baseResourcesGeneratedDirectory[0].value() == ''
+                taskName[0].value() == 'test_deploy_task'
+
+                jdk[0].name[0].value() == 'JDK 7'
+                jdk[0].home[0].value() == ''
+
+                stageMode[0].value() == WeblogicDeploymentStageModes.BY_DEFAULT.toString()
+                commandLine[0].value() == ''
+                deploymentPlan[0].value() == ''
+            }
+        }
+    }
+
+    def 'publish one deployment to WebLogic with one commandLine arg'() {
+        when:
+        context.deployToWeblogic {
+
+            task {
+                weblogicEnvironmentTargetedName('test_environment')
+                deploymentName('myApp')
+                deploymentTargets('ms_one')
+                builtResourceRegexToDeploy('myApp.ear')
+                baseResourcesGeneratedDirectory('')
+                taskName('test_deploy_task')
+
+                jdkName('JDK 7')
+
+                stageMode(WeblogicDeploymentStageModes.BY_DEFAULT)
+                commandLine('-debug')
+            }
+        }
+
+        then:
+        def task = context.publisherNodes[0].tasks[0].'org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask'
+
+        task[0].commandLine[0].value() == '-debug'
+    }
+
+    def 'publish one deployment to WebLogic with multiple commandLine args'() {
+        when:
+        context.deployToWeblogic {
+
+            task {
+                weblogicEnvironmentTargetedName('test_environment')
+                deploymentName('myApp')
+                deploymentTargets('ms_one')
+                builtResourceRegexToDeploy('myApp.ear')
+                baseResourcesGeneratedDirectory('')
+                taskName('test_deploy_task')
+
+                jdkName('JDK 7')
+
+                stageMode(WeblogicDeploymentStageModes.BY_DEFAULT)
+                commandLine('-debug')
+                commandLine('-remote')
+                commandLine('-verbose')
+                commandLine('-name {wl.deployment_name}')
+            }
+
+        }
+
+        then:
+        context.publisherNodes.size() == 1
+        with(context.publisherNodes[0]) {
+            name() == 'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin'
+            tasks.size() == 1
+            def task = tasks[0].'org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask'
+            task[0].commandLine[0].value() == '-debug -remote -verbose -name {wl.deployment_name}'
+        }
+    }
+
+    def 'publish to WebLogic without task definition'() {
+        when:
+        context.deployToWeblogic {
+            mustExitOnFailure()
+            forceStopOnFirstFailure()
+            deployingOnlyWhenUpdates()
+            deployedProjectsDependencies('abc,def')
+        }
+
+        then:
+        context.publisherNodes.size() == 1
+        with(context.publisherNodes[0]) {
+            name() == 'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin'
+            mustExitOnFailure[0].value() == true
+            forceStopOnFirstFailure[0].value() == true
+            isDeployingOnlyWhenUpdates[0].value() == true
+            deployedProjectsDependencies[0].value() == 'abc,def'
+
+            tasks.size() == 0
+        }
+    }
+
+    def 'publish two deployment to WebLogic with all args'() {
+        when:
+        context.deployToWeblogic {
+            mustExitOnFailure()
+            forceStopOnFirstFailure()
+            deployingOnlyWhenUpdates()
+            deployedProjectsDependencies('abc,def')
+
+            task {
+                weblogicEnvironmentTargetedName('test_environment')
+                deploymentName('myApp')
+                deploymentTargets('ms_one')
+                isLibrary()
+                builtResourceRegexToDeploy('myApp.ear')
+                baseResourcesGeneratedDirectory('')
+                taskName('test_deploy_task')
+
+                jdkName('JDK 7')
+                jdkHome('')
+
+                stageMode(WeblogicDeploymentStageModes.BY_DEFAULT)
+                commandLine('')
+                deploymentPlan('')
+            }
+
+            task {
+                weblogicEnvironmentTargetedName('test_environment_two')
+                deploymentName('myApp2')
+                deploymentTargets('ms_two')
+                isLibrary()
+                builtResourceRegexToDeploy('myApp2.ear')
+                baseResourcesGeneratedDirectory('')
+                taskName('test_deploy_task_two')
+
+                jdkName('JDK 6')
+                jdkHome('')
+
+                stageMode(WeblogicDeploymentStageModes.BY_DEFAULT)
+                commandLine('')
+                deploymentPlan('')
+            }
+
+        }
+
+        then:
+        context.publisherNodes.size() == 1
+        with(context.publisherNodes[0]) {
+            name() == 'org.jenkinsci.plugins.deploy.weblogic.WeblogicDeploymentPlugin'
+            mustExitOnFailure[0].value() == true
+            forceStopOnFirstFailure[0].value() == true
+            isDeployingOnlyWhenUpdates[0].value() == true
+            deployedProjectsDependencies[0].value() == 'abc,def'
+
+            tasks.size() == 1
+            def task = tasks[0].'org.jenkinsci.plugins.deploy.weblogic.data.DeploymentTask'
+            task.size() == 2
+
+            // first task
+            with(task[0]) {
+                id[0].value().size() == 10
+                weblogicEnvironmentTargetedName[0].value() == 'test_environment'
+                deploymentName[0].value() == 'myApp'
+                deploymentTargets[0].value() == 'ms_one'
+                isLibrary[0].value() == true
+                builtResourceRegexToDeploy[0].value() == 'myApp.ear'
+                baseResourcesGeneratedDirectory[0].value() == ''
+                taskName[0].value() == 'test_deploy_task'
+
+                jdk[0].name[0].value() == 'JDK 7'
+                jdk[0].home[0].value() == ''
+
+                stageMode[0].value() == WeblogicDeploymentStageModes.BY_DEFAULT.toString()
+                commandLine[0].value() == ''
+                deploymentPlan[0].value() == ''
+            }
+
+            // second task
+            with(task[1]) {
+                id[0].value().size() == 10
+                weblogicEnvironmentTargetedName[0].value() == 'test_environment_two'
+                deploymentName[0].value() == 'myApp2'
+                deploymentTargets[0].value() == 'ms_two'
+                isLibrary[0].value() == true
+                builtResourceRegexToDeploy[0].value() == 'myApp2.ear'
+                baseResourcesGeneratedDirectory[0].value() == ''
+                taskName[0].value() == 'test_deploy_task_two'
+
+                jdk[0].name[0].value() == 'JDK 6'
+                jdk[0].home[0].value() == ''
+
+                stageMode[0].value() == WeblogicDeploymentStageModes.BY_DEFAULT.toString()
+                commandLine[0].value() == ''
+                deploymentPlan[0].value() == ''
+            }
+        }
     }
 }


### PR DESCRIPTION
New rebased/updated version of PR https://github.com/jenkinsci/job-dsl-plugin/pull/158 and https://github.com/jenkinsci/job-dsl-plugin/pull/608:

This pull request adds support for the weblogic-deployer-plugin:

```groovy
job('example') {
    publishers {
        deployToWeblogic {
            mustExitOnFailure(true)
            forceStopOnFirstFailure(true)

            // at least one task is required
            task {
                // required
                weblogicEnvironmentTargetedName('dev_environment')
                // required
                deploymentName('myApplicationName')

                deploymentTargets('AdminServer')

                // required
                builtResourceRegexToDeploy('myApp\\.ear')
                // required
                baseResourcesGeneratedDirectory('')
                // required
                taskName('Deploy myApp to DEV Server')

                jdkName('JDK_7')
                jdkHome('C:\\Program Files\\Java\\jdk1.7.0_65')

                stageMode(WeblogicDeploymentStageModes.STAGE)

                commandLine('-debug -remote -verbose')
                commandLine('-name {wl.deployment_name} -targets {wl.targets}')
                commandLine('-adminurl t3://{wl.host}:{wl.port} -user {wl.login} -password {wl.password}')
                commandLine('-undeploy -noexit;\n')

                commandLine('-debug -remote -verbose')
                commandLine('-name {wl.deployment_name} -source {wl.source} -targets {wl.targets}')
                commandLine('-adminurl t3://{wl.host}:{wl.port} -user {wl.login} -password {wl.password}')
                commandLine('-deploy -stage -upload;')
            }
        }
    }
}
```