### PR TITLE
[JENKINS-31818] Added support for vSphereDeployFromTemplate step

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/step/StepContext/vSphereDeployFromTemplate.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/step/StepContext/vSphereDeployFromTemplate.groovy
@@ -1,0 +1,5 @@
+job('example') {
+    steps {
+        vSphereDeployFromTemplate('vsphere.acme.org', 'template', 'clone', 'cluster')
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -813,6 +813,26 @@ class StepContext extends AbstractExtensibleContext {
         }
     }
 
+    /**
+     * This build step will create a VM from the specified template.
+     *
+     * @since 1.41
+     */
+    @RequiresPlugin(id = 'vsphere-cloud')
+    void vSphereDeployFromTemplate(String server, String template, String clone, String cluster) {
+        Preconditions.checkNotNullOrEmpty(template, 'template must be specified')
+        Preconditions.checkNotNullOrEmpty(clone, 'clone must be specified')
+        Preconditions.checkNotNullOrEmpty(cluster, 'cluster must be specified')
+        vSphereBuildStep(server, 'Deploy') {
+            delegate.template(template)
+            delegate.clone(clone)
+            delegate.cluster(cluster)
+            linkedClone(false)
+            resourcePool('')
+            datastore('')
+        }
+    }
+
     private vSphereBuildStep(String server, String builder, Closure configuration) {
         Integer hash = jobManagement.getVSphereCloudHash(server)
         Preconditions.checkNotNull(hash, "vSphere server ${server} does not exist")

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
@@ -3038,6 +3038,34 @@ class StepContextSpec extends Specification {
         1 * jobManagement.requirePlugin('vsphere-cloud')
     }
 
+    def 'vSphere deploy from template'() {
+        setup:
+        jobManagement.getVSphereCloudHash('vsphere.acme.org') >> 4711
+
+        when:
+        context.vSphereDeployFromTemplate('vsphere.acme.org', 'template', 'clone', 'cluster')
+
+        then:
+        context.stepNodes.size() == 1
+        with(context.stepNodes[0]) {
+            name() == 'org.jenkinsci.plugins.vsphere.VSphereBuildStepContainer'
+            children().size() == 3
+            with(buildStep[0]) {
+                attribute('class') == 'org.jenkinsci.plugins.vsphere.builders.Deploy'
+                children().size() == 6
+                template[0].value() == 'template'
+                clone[0].value() == 'clone'
+                cluster[0].value() == 'cluster'
+                datastore[0].value().empty
+                resourcePool[0].value().empty
+                linkedClone[0].value() == false
+            }
+            serverName[0].value() == 'vsphere.acme.org'
+            serverHash[0].value() == 4711
+        }
+        1 * jobManagement.requirePlugin('vsphere-cloud')
+    }
+
     def 'vSphere server not found'() {
         when:
         context.vSpherePowerOff('vsphere.acme.org', 'foo')


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-31818

Although there are 3 different non mandatory fields:
- linkedClone(false)
- resourcePool('')
- datastore('')

How do I manage those attribute? Should I create a DSL Context for Vsphere? If so, does it make one per build step?

Any suggestions?

Cheers
