### PR TITLE
[FIXED JENKINS-31853] Added scriptOnlyIfFailure and markBuildUnstable options

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -21,6 +21,7 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
 
 ## Release Notes
 * 1.42 (unreleased)
+ * Support for the older versions of the [PostBuildScript Plugin](https://wiki.jenkins-ci.org/display/JENKINS/PostBuildScript+Plugin) is deprecated, see [Migration](Migration#migrating-to-143)
  * Fixed documentation for the [M2 Release Plugin](https://wiki.jenkins-ci.org/display/JENKINS/M2+Release+Plugin)
    ([JENKINS-32135](https://issues.jenkins-ci.org/browse/JENKINS-32135))
  * Added support for the [SeleniumHQ Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Seleniumhq+Plugin)
@@ -273,9 +274,9 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
    ([JENKINS-28458](https://issues.jenkins-ci.org/browse/JENKINS-28458))
  * Fixed [Parameterized Trigger Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Parameterized+Trigger+Plugin) build step
    ([JENKINS-28353](https://issues.jenkins-ci.org/browse/JENKINS-28353))
- * Fixed problem with implementing the extension point 
+ * Fixed problem with implementing the extension point
    ([JENKINS-28408](https://issues.jenkins-ci.org/browse/JENKINS-28408))
- * Provide better error message when trying to move a job into a non-existing folder 
+ * Provide better error message when trying to move a job into a non-existing folder
    ([JENKINS-29100](https://issues.jenkins-ci.org/browse/JENKINS-29100))
  * Fixed problem that caused a changing order of elements not to trigger a job update
    ([JENKINS-29107](https://issues.jenkins-ci.org/browse/JENKINS-29107))

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -1,5 +1,44 @@
 ## Migrating to 1.42
 
+### PostBuildScript Plugin
+
+Support for versions older than 0.17 of the
+[PostBuildScript Plugin](https://wiki.jenkins-ci.org/display/JENKINS/PostBuildScript+Plugin) is
+[[deprecated|Deprecation-Policy]] and will be removed.
+
+The DSL syntax of the `postBuildScripts` context has been changed in order to add new
+methods ([JENKINS-31853](https://issues.jenkins-ci.org/browse/JENKINS-31853)).
+
+DSL prior to 1.42
+```groovy
+job('example') {
+    publishers {
+        postBuildScripts {
+            steps {
+                shell('echo Hello World')
+            }
+            onlyIfBuildSucceeds(false)
+        }
+    }
+}
+```
+
+DSL since 1.42
+```groovy
+job('example') {
+    publishers {
+        postBuildScripts {
+            steps {
+                shell('echo Hello World')
+            }
+            onlyIfBuildSucceeds(false)
+            onlyIfBuildFails(false)
+            markBuildUnstable(false)
+        }
+    }
+}
+```
+
 ### Flexible Publish
 
 The DSL syntax of the `flexiblePublish` context has been changed to fix

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/postBuildScripts.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/postBuildScripts.groovy
@@ -5,6 +5,8 @@ job('example') {
                 shell('echo Hello World')
             }
             onlyIfBuildSucceeds(false)
+            onlyIfBuildFails(false)
+            markBuildUnstable(false)
         }
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PostBuildScriptsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PostBuildScriptsContext.groovy
@@ -1,17 +1,21 @@
 package javaposse.jobdsl.dsl.helpers.publisher
 
-import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.helpers.step.StepContext
+import javaposse.jobdsl.dsl.RequiresPlugin
 
-class PostBuildScriptsContext implements Context {
+class PostBuildScriptsContext extends AbstractContext {
     final StepContext stepContext
     boolean onlyIfBuildSucceeds = true
+    boolean onlyIfBuildFails = false
+    boolean markBuildUnstable = false
 
     PostBuildScriptsContext(JobManagement jobManagement, Item item) {
+        super(jobManagement)
         this.stepContext = new StepContext(jobManagement, item)
     }
 
@@ -27,5 +31,25 @@ class PostBuildScriptsContext implements Context {
      */
     void onlyIfBuildSucceeds(boolean onlyIfBuildSucceeds = true) {
         this.onlyIfBuildSucceeds = onlyIfBuildSucceeds
+    }
+
+    /**
+     * If set, runs the build steps only if the build was failure. Defaults to {@code false}.
+     *
+     * @since 1.42
+     */
+    @RequiresPlugin(id = 'postbuildscript', minimumVersion = '0.17')
+    void onlyIfBuildFails(boolean onlyIfBuildFails = true) {
+        this.onlyIfBuildFails = onlyIfBuildFails
+    }
+
+    /**
+     * If set, marks build unstable instead of failed on script error. Defaults to {@code false}.
+     *
+     * @since 1.42
+     */
+    @RequiresPlugin(id = 'postbuildscript', minimumVersion = '0.17')
+    void markBuildUnstable(boolean markBuildUnstable = true) {
+        this.markBuildUnstable = markBuildUnstable
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1382,12 +1382,18 @@ class PublisherContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'postbuildscript')
     void postBuildScripts(@DslContext(PostBuildScriptsContext) Closure closure) {
+        jobManagement.logPluginDeprecationWarning('postbuildscript', '0.17')
+
         PostBuildScriptsContext context = new PostBuildScriptsContext(jobManagement, item)
         ContextHelper.executeInContext(closure, context)
 
         publisherNodes << new NodeBuilder().'org.jenkinsci.plugins.postbuildscript.PostBuildScript' {
             buildSteps(context.stepContext.stepNodes)
             scriptOnlyIfSuccess(context.onlyIfBuildSucceeds)
+            if (!jobManagement.getPluginVersion('postbuildscript')?.isOlderThan(new VersionNumber('0.17'))) {
+                scriptOnlyIfFailure(context.onlyIfBuildFails)
+                markBuildUnstable(context.markBuildUnstable)
+            }
         }
     }
 


### PR DESCRIPTION
In addtion to that, it forces a minimum version since latest release was early 2015 and previous one was in 2013, so I believe we can force people to use the latest one instead.