### PR TITLE
Make publishJabber treat target as group if it contains "@conference."

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -388,7 +388,7 @@ class PublisherContext extends AbstractExtensibleContext {
         publisherNodes << new NodeBuilder().'hudson.plugins.jabber.im.transport.JabberPublisher' {
             delegate.targets {
                 targets.split().each { target ->
-                    boolean isGroup = target.startsWith('*')
+                    boolean isGroup = target.startsWith('*') || target.contains('@conference.')
                     if (isGroup) {
                         String targetClean = target[1..-1]
                         'hudson.plugins.im.GroupChatIMMessageTarget' {


### PR DESCRIPTION
The Jenkins plugin annotates the Targets text box as follows:

    "Whitespace separated list of accounts to send notifications to
    (like 'peter@myjabberserver.org') -- for group chats, prepend a '*'
    (e.g.  '*commitroom@conference.myjabberserver.org') -- note that
    JIDs that contain '@conference.' are automatically recognized as
    group chats (no need to prepend '*')"

This patch makes `publishJabber` behave as documented above.