### PR TITLE
[JIRA 32069] S3 bucket AWS regions must match com.amazonaws.

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/s3.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext/s3.groovy
@@ -1,7 +1,7 @@
 job('example') {
     publishers {
         s3('myProfile') {
-            entry('foo', 'bar', 'eu-west-1') {
+            entry('foo', 'bar', 'EU_WEST_1') {
                 storageClass('REDUCED_REDUNDANCY')
                 noUploadOnFailure()
                 uploadFromSlave()

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/S3BucketPublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/S3BucketPublisherContext.groovy
@@ -10,9 +10,22 @@ import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 
 class S3BucketPublisherContext extends AbstractContext {
+    /**
+     * This has to match com.amazonaws.regions.Regions enum:
+     * http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/regions/Regions.html
+     */
     private static final List<String> REGIONS = [
-            'us-gov-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'eu-west-1', 'eu-central-1', 'ap-southeast-1',
-            'ap-southeast-2', 'ap-northeast-1', 'sa-east-1', 'cn-north-1'
+        'AP_NORTHEAST_1',
+        'AP_SOUTHEAST_1',
+        'AP_SOUTHEAST_2',
+        'CN_NORTH_1',
+        'EU_CENTRAL_1',
+        'EU_WEST_1',
+        'GovCloud',
+        'SA_EAST_1',
+        'US_EAST_1',
+        'US_WEST_1',
+        'US_WEST_2'
     ]
 
     List<Node> entries = []

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -3203,12 +3203,12 @@ class PublisherContextSpec extends Specification {
 
         where:
         source | bucket | region
-        null   | 'test' | 'eu-west-1'
-        ''     | 'test' | 'eu-west-1'
-        'test' | null   | 'eu-west-1'
-        'test' | ''     | 'eu-west-1'
-        null   | null   | 'eu-west-1'
-        ''     | ''     | 'eu-west-1'
+        null   | 'test' | 'EU_WEST_1'
+        ''     | 'test' | 'EU_WEST_1'
+        'test' | null   | 'EU_WEST_1'
+        'test' | ''     | 'EU_WEST_1'
+        null   | null   | 'EU_WEST_1'
+        ''     | ''     | 'EU_WEST_1'
         'test' | 'test' | ''
         'test' | 'test' | null
     }
@@ -3216,7 +3216,7 @@ class PublisherContextSpec extends Specification {
     def 'call s3 with invalid storage class'(String storageClass) {
         when:
         context.s3('test') {
-            entry('foo', 'bar', 'eu-west-1') {
+            entry('foo', 'bar', 'EU_WEST_1') {
                 delegate.storageClass(storageClass)
             }
         }
@@ -3234,7 +3234,7 @@ class PublisherContextSpec extends Specification {
 
         when:
         context.s3('profile') {
-            entry('foo', 'bar', 'us-east-1')
+            entry('foo', 'bar', 'US_EAST_1')
             metadata('key', 'value')
         }
 
@@ -3251,7 +3251,7 @@ class PublisherContextSpec extends Specification {
                 sourceFile[0].value() == 'foo'
                 bucket[0].value() == 'bar'
                 storageClass[0].value() == 'STANDARD'
-                selectedRegion[0].value() == 'us-east-1'
+                selectedRegion[0].value() == 'US_EAST_1'
                 noUploadOnFailure[0].value() == false
                 uploadFromSlave[0].value() == false
                 managedArtifacts[0].value() == false
@@ -3275,8 +3275,8 @@ class PublisherContextSpec extends Specification {
 
         when:
         context.s3('profile') {
-            entry('foo', 'bar', 'eu-west-1')
-            entry('bar', 'baz', 'us-east-1') {
+            entry('foo', 'bar', 'EU_WEST_1')
+            entry('bar', 'baz', 'US_EAST_1') {
                 storageClass('REDUCED_REDUNDANCY')
                 noUploadOnFailure(true)
                 uploadFromSlave(true)
@@ -3300,7 +3300,7 @@ class PublisherContextSpec extends Specification {
                 sourceFile[0].value() == 'foo'
                 bucket[0].value() == 'bar'
                 storageClass[0].value() == 'STANDARD'
-                selectedRegion[0].value() == 'eu-west-1'
+                selectedRegion[0].value() == 'EU_WEST_1'
                 noUploadOnFailure[0].value() == false
                 uploadFromSlave[0].value() == false
                 managedArtifacts[0].value() == false
@@ -3312,7 +3312,7 @@ class PublisherContextSpec extends Specification {
                 sourceFile[0].value() == 'bar'
                 bucket[0].value() == 'baz'
                 storageClass[0].value() == 'REDUCED_REDUNDANCY'
-                selectedRegion[0].value() == 'us-east-1'
+                selectedRegion[0].value() == 'US_EAST_1'
                 noUploadOnFailure[0].value() == true
                 uploadFromSlave[0].value() == true
                 managedArtifacts[0].value() == true


### PR DESCRIPTION
In S3BucketPublisherContext, the REGIONS list does not match
com.amazonaws.regions.Regions, and this causes an error when attempting
to use the S3 plugin:

```
java.lang.IllegalArgumentException: No enum constant com.amazonaws.regions.Regions.us-east-1
    at hudson.plugins.s3.S3Profile.upload(S3Profile.java:140)
    at hudson.plugins.s3.S3BucketPublisher.perform(S3BucketPublisher.java:174)
    at hudson.tasks.BuildStepMonitor$2.perform(BuildStepMonitor.java:32)
    at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:782)
    at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:723)
    at hudson.model.Build$BuildExecution.post2(Build.java:185)
    at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:668)
    at hudson.model.Run.execute(Run.java:1763)
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
    at hudson.model.ResourceController.execute(ResourceController.java:98)
    at hudson.model.Executor.run(Executor.java:410)
Build step 'Publish artifacts to S3 Bucket' changed build result to UNSTABLE
```

Pull request simply renames strings to match their enum counterpart.