### PR TITLE
[JENKINS-32135] Fixed documentation for the M2 Release Plugin

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -21,6 +21,7 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
 
 ## Release Notes
 * 1.42 (unreleased)
+ * Fixed documentation for the [M2 Release Plugin](https://wiki.jenkins-ci.org/display/JENKINS/M2+Release+Plugin) ([JENKINS-32135](https://issues.jenkins-ci.org/browse/JENKINS-32135))
  * Added support for the [Ruby Metrics Plugin](https://wiki.jenkins-ci.org/display/JENKINS/RubyMetrics+plugin)
    ([JENKINS-31830](https://issues.jenkins-ci.org/browse/JENKINS-31830))
  * Added support for the [DOS Trigger Plugin](https://wiki.jenkins-ci.org/display/JENKINS/DOS+Trigger)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/MavenWrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/MavenWrapperContext.groovy
@@ -4,6 +4,7 @@ import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.RequiresPlugin
 
 class MavenWrapperContext extends WrapperContext {
     MavenWrapperContext(JobManagement jobManagement, Item item) {
@@ -16,6 +17,7 @@ class MavenWrapperContext extends WrapperContext {
      *
      * @since 1.25
      */
+    @RequiresPlugin(id = 'm2release')
     void mavenRelease(@DslContext(MavenReleaseContext) Closure releaseClosure = null) {
         MavenReleaseContext context = new MavenReleaseContext()
         ContextHelper.executeInContext(releaseClosure, context)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/MavenWrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/MavenWrapperContextSpec.groovy
@@ -26,6 +26,8 @@ class MavenWrapperContextSpec extends Specification {
         m2releaseNode.selectAppendHudsonUsername[0].value() == false
         m2releaseNode.selectScmCredentials[0].value() == false
         m2releaseNode.numberOfReleaseBuildsToKeep[0].value() == 1
+
+        1 * mockJobManagement.requirePlugin('m2release')
     }
 
     def 'configure m2release plugin with all args'() {
@@ -55,5 +57,7 @@ class MavenWrapperContextSpec extends Specification {
         m2releaseNode.selectAppendHudsonUsername[0].value() == true
         m2releaseNode.selectScmCredentials[0].value() == true
         m2releaseNode.numberOfReleaseBuildsToKeep[0].value() == 10
+
+        1 * mockJobManagement.requirePlugin('m2release')
     }
 }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-32135

Plugin url is not part of the docs: https://jenkinsci.github.io/job-dsl-plugin/#method/javaposse.jobdsl.dsl.helpers.wrapper.MavenWrapperContext.mavenRelease