### PR TITLE
Adds support for buildNeedsWorkspace option in Build Flow Plugin

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -42,6 +42,8 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
  * Changed the DSL syntax for `flexiblePublish`, see [Migration](Migration#migrating-to-142)
  * Check DSL scripts for existence
    ([JENKINS-30541](https://issues.jenkins-ci.org/browse/JENKINS-30541))
+ * Added support for `buildNeedsWorkspace` option for 
+   [Build Flow Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build+Flow+Plugin)
 * 1.41 (December 15 2015)
  * Added support for the [WebLogic Deployer Plugin](https://wiki.jenkins-ci.org/display/JENKINS/WebLogic+Deployer+Plugin)
    ([JENKINS-21880](https://issues.jenkins-ci.org/browse/JENKINS-21880))

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/jobs/BuildFlowJob/buildNeedsWorkspace.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/jobs/BuildFlowJob/buildNeedsWorkspace.groovy
@@ -1,0 +1,4 @@
+buildFlowJob('example-1') {
+    buildFlow('build("job1")')
+    buildNeedsWorkspace()
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/jobs/BuildFlowJob.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/jobs/BuildFlowJob.groovy
@@ -23,6 +23,17 @@ class BuildFlowJob extends Job {
         }
     }
 
+    /**
+     * Sets whether the build flow run needs a workspace. Defaults to {@code true}
+     * @since 1.42
+     */
+    void buildNeedsWorkspace(boolean needsWorkspace = true) {
+        withXmlActions << WithXmlAction.create { Node project ->
+            Node node = methodMissing('buildNeedsWorkspace', needsWorkspace)
+            project / node
+        }
+    }
+
     @Override
     void publishers(@DslContext(BuildFlowPublisherContext) Closure closure) {
         BuildFlowPublisherContext context = new BuildFlowPublisherContext(jobManagement, this)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/jobs/BuildFlowJobSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/jobs/BuildFlowJobSpec.groovy
@@ -24,4 +24,20 @@ class BuildFlowJobSpec extends Specification {
         job.node.dsl.size() == 1
         job.node.dsl[0].value() == 'build Flow Block'
     }
+
+    def 'buildNeedsWorkspace constructs xml'() {
+        when:
+        job.buildNeedsWorkspace()
+
+        then:
+        job.node.buildNeedsWorkspace.size() == 1
+        job.node.buildNeedsWorkspace[0].value() == true
+
+        when:
+        job.buildNeedsWorkspace(false)
+
+        then:
+        job.node.buildNeedsWorkspace.size() == 1
+        job.node.buildNeedsWorkspace[0].value() == false
+    }
 }


### PR DESCRIPTION
Honors existing Jenkins behavior of not adding this option, thereby keeping it false, by default.

use `buildNeedsWorkspace()` to set to true for a build flow job