### PR TITLE
Passing in rich objects to Generated* to facilitate simpler end-user testing

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -149,7 +149,7 @@ public class DslScriptLoader {
                 }
                 jp.getJm().createOrUpdateConfig(item, ignoreExisting);
                 String templateName = item instanceof Job ? ((Job) item).getTemplateName() : null;
-                generatedJobs.add(new GeneratedJob(templateName, item.getName()));
+                generatedJobs.add(new GeneratedJob(templateName, item));
             }
         }
         return generatedJobs;
@@ -161,7 +161,7 @@ public class DslScriptLoader {
             String xml = view.getXml();
             LOGGER.log(Level.FINE, String.format("Saving view %s as %s", view.getName(), xml));
             jp.getJm().createOrUpdateView(view.getName(), xml, ignoreExisting);
-            GeneratedView gv = new GeneratedView(view.getName());
+            GeneratedView gv = new GeneratedView(view);
             generatedViews.add(gv);
         }
         return generatedViews;
@@ -172,7 +172,7 @@ public class DslScriptLoader {
         for (ConfigFile configFile : jp.getReferencedConfigFiles()) {
             LOGGER.log(Level.FINE, String.format("Saving config file %s", configFile.getName()));
             String id = jp.getJm().createOrUpdateConfigFile(configFile, ignoreExisting);
-            generatedConfigFiles.add(new GeneratedConfigFile(id, configFile.getName()));
+            generatedConfigFiles.add(new GeneratedConfigFile(id, configFile));
         }
         return generatedConfigFiles;
     }
@@ -182,7 +182,7 @@ public class DslScriptLoader {
         for (UserContent userContent : jp.getReferencedUserContents()) {
             LOGGER.log(Level.FINE, String.format("Saving user content %s", userContent.getPath()));
             jp.getJm().createOrUpdateUserContent(userContent, ignoreExisting);
-            generatedUserContents.add(new GeneratedUserContent(userContent.getPath()));
+            generatedUserContents.add(new GeneratedUserContent(userContent));
         }
         return generatedUserContents;
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedConfigFile.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedConfigFile.groovy
@@ -3,7 +3,21 @@ package javaposse.jobdsl.dsl
 class GeneratedConfigFile {
     final String id
     final String name
+    final ConfigFile configFile
 
+    GeneratedConfigFile(String id, ConfigFile configFile) {
+        if (! id) {
+            throw new IllegalArgumentException('id cannot be null')
+        }
+        if (! configFile) {
+            throw new IllegalArgumentException('configFile cannot be null')
+        }
+        this.id = id
+        this.name = configFile.name
+        this.configFile = configFile
+    }
+
+    @Deprecated
     GeneratedConfigFile(String id, String name) {
         if (id == null || name == null) {
             throw new IllegalArgumentException()

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedJob.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedJob.groovy
@@ -3,7 +3,18 @@ package javaposse.jobdsl.dsl
 class GeneratedJob {
     final String templateName
     final String jobName
+    final Item item
 
+    GeneratedJob(String templateName, Item item) {
+        if (! item) {
+            throw new IllegalArgumentException('item cannot be null')
+        }
+        this.templateName = templateName
+        this.jobName = item.name
+        this.item = item
+    }
+
+    @Deprecated
     GeneratedJob(String templateName, String jobName) {
         if (jobName == null) {
             throw new IllegalArgumentException()

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedUserContent.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedUserContent.groovy
@@ -2,7 +2,17 @@ package javaposse.jobdsl.dsl
 
 class GeneratedUserContent {
     final String path
+    final UserContent userContent
 
+    GeneratedUserContent(UserContent userContent) {
+        if (! userContent) {
+            throw new IllegalArgumentException('userContent cannot be null')
+        }
+        this.path = userContent.path
+        this.userContent = userContent
+    }
+
+    @Deprecated
     GeneratedUserContent(String path) {
         if (path == null) {
             throw new IllegalArgumentException()

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedView.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedView.groovy
@@ -2,7 +2,17 @@ package javaposse.jobdsl.dsl
 
 class GeneratedView {
     final String name
+    final View view
 
+    GeneratedView(View view) {
+        if (! view) {
+            throw new IllegalArgumentException('view cannot be null')
+        }
+        this.name = view.name
+        this.view = view
+    }
+
+    @Deprecated
     GeneratedView(String name) {
         if (name == null) {
             throw new IllegalArgumentException()

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/GeneratedConfigFileSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/GeneratedConfigFileSpec.groovy
@@ -3,7 +3,7 @@ package javaposse.jobdsl.dsl
 import spock.lang.Specification
 
 class GeneratedConfigFileSpec extends Specification {
-    def 'id is null'() {
+    def 'id is null (deprecated)'() {
         when:
         new GeneratedConfigFile(null, 'foo')
 
@@ -11,9 +11,26 @@ class GeneratedConfigFileSpec extends Specification {
         thrown(IllegalArgumentException)
     }
 
+    def 'name is null (deprecated)'() {
+        when:
+        new GeneratedConfigFile('235421345', (String) null)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'id is null'() {
+        when:
+        def foo = new ConfigFile(ConfigFileType.Custom, new MemoryJobManagement()).with { name = 'foo'; it }
+        new GeneratedConfigFile(null, foo)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
     def 'name is null'() {
         when:
-        new GeneratedConfigFile('235421345', null)
+        new GeneratedConfigFile('235421345', (ConfigFile) null)
 
         then:
         thrown(IllegalArgumentException)
@@ -21,7 +38,8 @@ class GeneratedConfigFileSpec extends Specification {
 
     def 'get name and id'() {
         when:
-        GeneratedConfigFile configFile = new GeneratedConfigFile('235421345', 'foo')
+        def foo = new ConfigFile(ConfigFileType.Custom, new MemoryJobManagement()).with { name = 'foo'; it }
+        GeneratedConfigFile configFile = new GeneratedConfigFile('235421345', foo)
 
         then:
         configFile.id == '235421345'
@@ -30,9 +48,12 @@ class GeneratedConfigFileSpec extends Specification {
 
     def 'only id is relevant for hashCode and equals'() {
         when:
-        GeneratedConfigFile configFile1 = new GeneratedConfigFile('235421345', 'foo')
-        GeneratedConfigFile configFile2 = new GeneratedConfigFile('235421345', 'new name')
-        GeneratedConfigFile configFile3 = new GeneratedConfigFile('235421346', 'other')
+        def foo = new ConfigFile(ConfigFileType.Custom, new MemoryJobManagement()).with { name = 'foo'; it }
+        def newName = new ConfigFile(ConfigFileType.Custom, new MemoryJobManagement()).with { name = 'new name'; it }
+        def other = new ConfigFile(ConfigFileType.Custom, new MemoryJobManagement()).with { name = 'other'; it }
+        GeneratedConfigFile configFile1 = new GeneratedConfigFile('235421345', foo)
+        GeneratedConfigFile configFile2 = new GeneratedConfigFile('235421345', newName)
+        GeneratedConfigFile configFile3 = new GeneratedConfigFile('235421346', other)
 
         then:
         configFile1.hashCode() == configFile2.hashCode()
@@ -43,7 +64,8 @@ class GeneratedConfigFileSpec extends Specification {
 
     def 'test toString'() {
         when:
-        GeneratedConfigFile configFile = new GeneratedConfigFile('235421345', 'foo')
+        def foo = new ConfigFile(ConfigFileType.Custom, new MemoryJobManagement()).with { name = 'foo'; it }
+        GeneratedConfigFile configFile = new GeneratedConfigFile('235421345', foo)
 
         then:
         configFile.toString() == "GeneratedConfigFile{name='foo', id='235421345'}"

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/GeneratedJobSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/GeneratedJobSpec.groovy
@@ -1,11 +1,13 @@
 package javaposse.jobdsl.dsl
 
+import javaposse.jobdsl.dsl.jobs.FreeStyleJob
 import spock.lang.Specification
 
 class GeneratedJobSpec extends Specification {
     def 'toString without template'() {
         when:
-        GeneratedJob generatedJob = new GeneratedJob(null, 'test')
+        def test = new FreeStyleJob(new MemoryJobManagement()).with { name = 'test'; it }
+        GeneratedJob generatedJob = new GeneratedJob(null, test)
 
         then:
         generatedJob.toString() == "GeneratedJob{name='test'}"
@@ -13,7 +15,8 @@ class GeneratedJobSpec extends Specification {
 
     def 'toString with template'() {
         when:
-        GeneratedJob generatedJob = new GeneratedJob('foo', 'test')
+        def test = new FreeStyleJob(new MemoryJobManagement()).with { name = 'test'; it }
+        GeneratedJob generatedJob = new GeneratedJob('foo', test)
 
         then:
         generatedJob.toString() == "GeneratedJob{name='test', template='foo'}"

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/GeneratedViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/GeneratedViewSpec.groovy
@@ -5,7 +5,8 @@ import spock.lang.Specification
 class GeneratedViewSpec extends Specification {
     def 'name'() {
         when:
-        GeneratedView view = new GeneratedView('test')
+        def test = new TestView(new MemoryJobManagement()) {}.with { name = 'test'; it }
+        GeneratedView view = new GeneratedView(test)
 
         then:
         view.name == 'test'
@@ -21,27 +22,32 @@ class GeneratedViewSpec extends Specification {
 
     def 'test equals'() {
         when:
-        GeneratedView view = new GeneratedView('test')
+        def test = new TestView(new MemoryJobManagement()) {}.with { name = 'test'; it }
+        def foo = new TestView(new MemoryJobManagement()) {}.with { name = 'foo'; it }
+        GeneratedView view = new GeneratedView(test)
 
         then:
         view.equals(view)
-        view.equals(new GeneratedView('test'))
-        !view.equals(new GeneratedView('foo'))
+        view.equals(new GeneratedView(test))
+        !view.equals(new GeneratedView(foo))
         !view.equals('test')
     }
 
     def 'test hashCode'() {
         when:
-        GeneratedView view = new GeneratedView('test')
+        def test = new TestView(new MemoryJobManagement()) {}.with { name = 'test'; it }
+        def other = new TestView(new MemoryJobManagement()) {}.with { name = 'other'; it }
+        GeneratedView view = new GeneratedView(test)
 
         then:
-        view.hashCode() == new GeneratedView('test').hashCode()
-        view.hashCode() != new GeneratedView('other').hashCode()
+        view.hashCode() == new GeneratedView(test).hashCode()
+        view.hashCode() != new GeneratedView(other).hashCode()
     }
 
     def 'test toString'() {
         when:
-        GeneratedView view = new GeneratedView('test')
+        def test = new TestView(new MemoryJobManagement()) {}.with { name = 'test'; it }
+        GeneratedView view = new GeneratedView(test)
 
         then:
         view.toString() == "GeneratedView{name='test'}"


### PR DESCRIPTION
Prior to 1.39, we had code which used the generated output to validate which jobs were created and if they had changed. The 76f8c6c (1.40) broke that. There was no convenient way we could find to get at the XML, so this PR adds the item/view/configFile/userContent into its corresponding Generated____ object. I have maintained backwards compatibility, and deprecated the previous constructors, and updated all specs.

If there's a "better" way to get at the information I'm trying to get, I'm all ears.