### PR TITLE
JENKINS-32285 Making BuildParametersContext extensible

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
@@ -497,7 +497,7 @@ abstract class Job extends Item {
      * @since 1.15
      */
     void parameters(@DslContext(BuildParametersContext) Closure closure) {
-        BuildParametersContext context = new BuildParametersContext(jobManagement)
+        BuildParametersContext context = new BuildParametersContext(jobManagement, this)
         ContextHelper.executeInContext(closure, context)
 
         withXmlActions << WithXmlAction.create { Node project ->

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -1,9 +1,10 @@
 package javaposse.jobdsl.dsl.helpers
 
 import hudson.util.VersionNumber
-import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
+import javaposse.jobdsl.dsl.DslScriptException
+import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.RequiresPlugin
 import javaposse.jobdsl.dsl.helpers.parameter.AbstractActiveChoiceContext
@@ -18,11 +19,30 @@ import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 import static javaposse.jobdsl.dsl.Preconditions.checkNotNull
 import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 
-class BuildParametersContext extends AbstractContext {
+class BuildParametersContext extends AbstractExtensibleContext {
     Map<String, Node> buildParameterNodes = [:]
 
-    BuildParametersContext(JobManagement jobManagement) {
-        super(jobManagement)
+    BuildParametersContext(JobManagement jobManagement, Item item) {
+        super(jobManagement, item)
+    }
+
+    /**
+     * We expect any paramater definition node to have a <code>name</code> field containing
+     * the name of the parameter so we can add it in the map of nodes.
+     * @param node Parameter definition node
+     */
+    @Override
+    protected void addExtensionNode(Node node) {
+        String name = null
+        Object nameFields = node.get('name')
+        if (nameFields instanceof NodeList && nameFields.size() > 0) {
+            name = nameFields[0].text()
+        }
+        if (name) {
+            buildParameterNodes[name] = node
+        } else {
+            throw new DslScriptException("Can only add nodes with a 'name' field.")
+        }
     }
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/ReleaseContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/ReleaseContext.groovy
@@ -96,7 +96,7 @@ class ReleaseContext extends AbstractContext {
      * Add parameters for the release.
      */
     void parameters(@DslContext(BuildParametersContext) Closure parametersClosure) {
-        BuildParametersContext parametersContext = new BuildParametersContext(jobManagement)
+        BuildParametersContext parametersContext = new BuildParametersContext(jobManagement, this.item)
         ContextHelper.executeInContext(parametersClosure, parametersContext)
         params.addAll(parametersContext.buildParameterNodes.values())
     }


### PR DESCRIPTION
Hi,

This is a pull request for [JENKINS-32285](https://issues.jenkins-ci.org/browse/JENKINS-32285), allowing the possibility for other plugins to contribute to the `parameters` section, by making the `BuildParametersContext` extensible.

Best regards,
Damien.