### PR TITLE
Fixing typo in systemGroovyScriptFile example

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/step/StepContext/systemGroovyScriptFile.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/step/StepContext/systemGroovyScriptFile.groovy
@@ -1,6 +1,6 @@
 job('example') {
     steps {
-        systemGroovyCommand('disconnect-slave.groovy') {
+        systemGroovyScriptFile('disconnect-slave.groovy') {
             binding('computerName', 'ubuntu-04')
         }
     }


### PR DESCRIPTION
`systemGroovyScriptFile.groovy` example file instead used `systemGroovyCommand`.