### PR TITLE
[JENKINS-32391] Basic implementation of Perforce P4 plugin support.

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -21,6 +21,8 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
 
 ## Release Notes
 * 1.43 (unreleased)
+ * Added support for the [P4 Plugin](https://wiki.jenkins-ci.org/display/JENKINS/P4+Plugin)
+   ([JENKINS-32391](https://issues.jenkins-ci.org/browse/JENKINS-32391))
  * Added support for the [Clover PHP Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Clover+PHP+Plugin)
    ([JENKINS-31557](https://issues.jenkins-ci.org/browse/JENKINS-31557))
  * Allow `BuildParametersContext` to be extended

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/ScmContext/perforcep4.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/ScmContext/perforcep4.groovy
@@ -1,7 +1,7 @@
 job('example-1') {
     scm {
         perforcep4('p4_credentials') {
-            manual('ws_name', '//depot/Tools/build //ws_name/build')
+            manual('ws_name', '//depot/Tools/build/... //ws_name/build/...')
         }
     }
 }
@@ -9,7 +9,7 @@ job('example-1') {
 job('example-2') {
     scm {
         perforcep4('p4_credentials') {
-            manual('ws_name', '//depot/Tools/build //ws_name/build')
+            manual('ws_name', '//depot/Tools/build/... //ws_name/build/...')
             configure { node ->
                 node / workspace / spec / clobber('true')
             }

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/ScmContext/perforcep4.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/ScmContext/perforcep4.groovy
@@ -1,0 +1,18 @@
+job('example-1') {
+    scm {
+        perforcep4('p4_credentials') {
+            manual('ws_name', '//depot/Tools/build //ws_name/build')
+        }
+    }
+}
+
+job('example-2') {
+    scm {
+        perforcep4('p4_credentials') {
+            manual('ws_name', '//depot/Tools/build //ws_name/build')
+            configure { node ->
+                node / workspace / spec / clobber('true')
+            }
+        }
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/P4Context.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/P4Context.groovy
@@ -1,0 +1,49 @@
+package javaposse.jobdsl.dsl.helpers.scm
+
+import javaposse.jobdsl.dsl.AbstractContext
+import javaposse.jobdsl.dsl.JobManagement
+
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNull
+
+class P4Context extends AbstractContext {
+
+    Node workspaceConfig
+    Closure withXmlClosure
+
+    P4Context(JobManagement jobManagement) {
+        super(jobManagement)
+    }
+
+    /**
+     * Set up a manual workspace with workspace name and viewspec.
+     */
+    void manual(String workspaceName, String viewspec) {
+        checkNotNull(workspaceName, 'workspaceName must not be null')
+        checkNotNull(viewspec, 'viewspec must not be null')
+
+        workspaceConfig = new NodeBuilder().workspace(class: 'org.jenkinsci.plugins.p4.workspace.ManualWorkspaceImpl') {
+            charset 'none'
+            pinHost 'false'
+            name workspaceName
+            spec {
+                allwrite 'false'
+                clobber 'false'
+                compress 'false'
+                locked 'false'
+                modtime 'false'
+                rmdir 'false'
+                streamName ''
+                line 'LOCAL'
+                view viewspec
+            }
+        }
+    }
+
+    /**
+     * Allows direct manipulation of the generated XML. The {@code scm} node is passed into the configure block.
+     *
+     */
+    void configure(Closure withXmlClosure) {
+        this.withXmlClosure = withXmlClosure
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
@@ -1994,9 +1994,13 @@ class ScmContextSpec extends Specification {
     }
 
     def 'call perforcep4 with manual workspace'() {
+        setup:
+        def viewspec = '//depot/Tools/build/... //ws/build/...\n' +
+            '//depot/webapplications/helloworld/... //ws/helloworld/...'
+
         when:
         context.perforcep4('p4-user-creds') {
-            manual('ws', '//depot/Tools/build/...\n//ws/webapplications/helloworld/...')
+            manual('ws', viewspec)
         }
 
         then:
@@ -2020,7 +2024,7 @@ class ScmContextSpec extends Specification {
                     rmdir[0].value() == 'false'
                     streamName[0].value() == ''
                     line[0].value() == 'LOCAL'
-                    view[0].value() == '//depot/Tools/build/...\n//ws/webapplications/helloworld/...'
+                    view[0].value() == viewspec
                 }
             }
             with(populate[0]) {
@@ -2038,9 +2042,13 @@ class ScmContextSpec extends Specification {
     }
 
     def 'call perforcep4 with manual workspace and configure'() {
+        setup:
+        def viewspec = '//depot/Tools/build/... //ws/build/...\n' +
+            '//depot/webapplications/helloworld/... //ws/helloworld/...'
+
         when:
         context.perforcep4('p4-user-creds') {
-            manual('ws', '//depot/Tools/build/...\n//ws/webapplications/helloworld/...')
+            manual('ws', viewspec)
             configure { node ->
                 node / workspace / spec / clobber('true')
             }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
@@ -1993,6 +1993,73 @@ class ScmContextSpec extends Specification {
         (1.._) * mockJobManagement.requirePlugin('perforce')
     }
 
+    def 'call perforcep4 with manual workspace'() {
+        when:
+        context.perforcep4('p4-user-creds') {
+            manual('ws', '//depot/Tools/build/...\n//ws/webapplications/helloworld/...')
+        }
+
+        then:
+        context.scmNodes[0] != null
+        with(context.scmNodes[0]) {
+            attributes()['class'] == 'org.jenkinsci.plugins.p4.PerforceScm'
+            credential[0].value() == 'p4-user-creds'
+            workspace.size() == 1
+            with(workspace[0]) {
+                attributes()['class'] == 'org.jenkinsci.plugins.p4.workspace.ManualWorkspaceImpl'
+                charset[0].value() == 'none'
+                pinHost[0].value() == 'false'
+                name[0].value() == 'ws'
+                spec.size() == 1
+                with(spec[0]) {
+                    allwrite[0].value() == 'false'
+                    clobber[0].value() == 'false'
+                    compress[0].value() == 'false'
+                    locked[0].value() == 'false'
+                    modtime[0].value() == 'false'
+                    rmdir[0].value() == 'false'
+                    streamName[0].value() == ''
+                    line[0].value() == 'LOCAL'
+                    view[0].value() == '//depot/Tools/build/...\n//ws/webapplications/helloworld/...'
+                }
+            }
+            with(populate[0]) {
+                attributes()['class'] == 'org.jenkinsci.plugins.p4.populate.AutoCleanImpl'
+                have[0].value() == 'true'
+                force[0].value() == 'false'
+                modtime[0].value() == 'false'
+                quiet[0].value() == 'true'
+                pin[0].value() == ''
+                replace[0].value() == 'true'
+                delete[0].value() == 'true'
+            }
+        }
+        1 * mockJobManagement.requireMinimumPluginVersion('p4', '1.3.5')
+    }
+
+    def 'call perforcep4 with manual workspace and configure'() {
+        when:
+        context.perforcep4('p4-user-creds') {
+            manual('ws', '//depot/Tools/build/...\n//ws/webapplications/helloworld/...')
+            configure { node ->
+                node / workspace / spec / clobber('true')
+            }
+        }
+
+        then:
+        context.scmNodes[0] != null
+        with(context.scmNodes[0]) {
+            workspace.size() == 1
+            with(workspace[0]) {
+                spec.size() == 1
+                with(spec[0]) {
+                    clobber[0].value() == 'true'
+                }
+            }
+        }
+        1 * mockJobManagement.requireMinimumPluginVersion('p4', '1.3.5')
+    }
+
     def 'call cloneWorkspace'(parentJob, criteria) {
         when:
         context.cloneWorkspace(parentJob, criteria)


### PR DESCRIPTION
This is a basic implementation of support for Perforce Software's "p4 plugin". This uses credentials instead of username and password which are used by the older "perforce plugin".

Compared the to syntax I suggested in JENKINS-32391 I decided to call the DSL command "perforcep4" rather than "perforce". This leaves the possibility of renaming the older "p4" support to "perforce" and this to p4 if that is desired (so that the commands match the plugin names).

Also I decided to implement the "Manual" workspace within a context instead of as one method. This leaves room for further "workspace behaviours" to be implemented ("Spec File", "Static", "Streams", "Template").