### PR TITLE
Fix for unspecified health in Warnings plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1985,8 +1985,8 @@ class PublisherContext extends AbstractExtensibleContext {
     @SuppressWarnings('NoDef')
     private static addStaticAnalysisContext(def nodeBuilder, StaticAnalysisContext context) {
         nodeBuilder.with {
-            healthy(context.healthy)
-            unHealthy(context.unHealthy)
+            healthy(context.healthy ?: '')
+            unHealthy(context.unHealthy ?: '')
             thresholdLimit(context.thresholdLimit)
             defaultEncoding(context.defaultEncoding)
             canRunOnFailed(context.canRunOnFailed)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/StaticAnalysisPublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/StaticAnalysisPublisherContextSpec.groovy
@@ -23,8 +23,8 @@ class StaticAnalysisPublisherContextSpec extends Specification {
         def pmdNode = context.publisherNodes[0]
         assertValues(pmdNode, [], extraNodes,
                 pattern: 'somewhere',
-                healthy: null,
-                unHealthy: null,
+                healthy: '',
+                unHealthy: '',
                 thresholdLimit: 'low',
                 defaultEncoding: '',
                 canRunOnFailed: false,
@@ -59,8 +59,8 @@ class StaticAnalysisPublisherContextSpec extends Specification {
         context.publisherNodes.size() == 1
         def warningsNode = context.publisherNodes[0]
         assertValues(warningsNode, ['consoleParsers'], [:],
-                healthy: null,
-                unHealthy: null,
+                healthy: '',
+                unHealthy: '',
                 thresholdLimit: 'low',
                 defaultEncoding: '',
                 canRunOnFailed: false,
@@ -214,8 +214,8 @@ class StaticAnalysisPublisherContextSpec extends Specification {
         def analysisCollectorNode = context.publisherNodes[0]
         assertValues(
                 analysisCollectorNode,
-                healthy: null,
-                unHealthy: null,
+                healthy: '',
+                unHealthy: '',
                 thresholdLimit: 'low',
                 defaultEncoding: '',
                 canRunOnFailed: false,

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/StaticAnalysisPublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/StaticAnalysisPublisherContextSpec.groovy
@@ -307,8 +307,8 @@ class StaticAnalysisPublisherContextSpec extends Specification {
             low[0].value().empty
             ignoreCase[0].value() == false
             excludePattern[0].value().empty
-            healthy[0].value() == null
-            unHealthy[0].value() == null
+            healthy[0].value() == ''
+            unHealthy[0].value() == ''
             thresholdLimit[0].value() == 'low'
             defaultEncoding[0].value().empty
             thresholds[0].value().empty
@@ -338,8 +338,8 @@ class StaticAnalysisPublisherContextSpec extends Specification {
             low[0].value().empty
             ignoreCase[0].value() == false
             excludePattern[0].value().empty
-            healthy[0].value() == null
-            unHealthy[0].value() == null
+            healthy[0].value() == ''
+            unHealthy[0].value() == ''
             thresholdLimit[0].value() == 'low'
             defaultEncoding[0].value().empty
             thresholds[0].value().empty
@@ -372,8 +372,8 @@ class StaticAnalysisPublisherContextSpec extends Specification {
             low[0].value() == 'three'
             ignoreCase[0].value() == true
             excludePattern[0].value() == 'bar'
-            healthy[0].value() == null
-            unHealthy[0].value() == null
+            healthy[0].value() == ''
+            unHealthy[0].value() == ''
             thresholdLimit[0].value() == 'low'
             defaultEncoding[0].value().empty
             thresholds[0].value().empty


### PR DESCRIPTION
"healthy" and "unHealthy" default to empty strings as values in the GUI and null gets written to xml as a string "null", which leads to errors in runtime.