### PR TITLE
Allow thresholds to be empty

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/ArchiveXUnitThresholdContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/ArchiveXUnitThresholdContext.groovy
@@ -3,16 +3,16 @@ package javaposse.jobdsl.dsl.helpers.publisher
 import javaposse.jobdsl.dsl.Context
 
 class ArchiveXUnitThresholdContext implements Context {
-    int unstable = 0
-    int unstableNew = 0
-    int failure = 0
-    int failureNew = 0
+    Integer unstable = 0
+    Integer unstableNew = 0
+    Integer failure = 0
+    Integer failureNew = 0
 
     /**
      * Sets the build to unstable if the number or percentage of test failures or skiped tests exceeds the threshold.
      * Defaults to 0.
      */
-    void unstable(int unstable) {
+    void unstable(Integer unstable) {
         this.unstable = unstable
     }
 
@@ -20,7 +20,7 @@ class ArchiveXUnitThresholdContext implements Context {
      * Sets the build to unstable if the number or percentage of new test failures or skiped tests exceeds the
      * threshold. Defaults to 0.
      */
-    void unstableNew(int unstableNew) {
+    void unstableNew(Integer unstableNew) {
         this.unstableNew = unstableNew
     }
 
@@ -28,7 +28,7 @@ class ArchiveXUnitThresholdContext implements Context {
      * Fails the build if the number or percentage of test failures or skiped tests exceeds the threshold.
      * Defaults to 0.
      */
-    void failure(int failure) {
+    void failure(Integer failure) {
         this.failure = failure
     }
 
@@ -36,7 +36,7 @@ class ArchiveXUnitThresholdContext implements Context {
      * Fails the build if the number or percentage of test failures or skiped tests exceeds the threshold.
      * Defaults to 0.
      */
-    void failureNew(int failureNew) {
+    void failureNew(Integer failureNew) {
         this.failureNew = failureNew
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -183,16 +183,24 @@ class PublisherContext extends AbstractExtensibleContext {
             }
             thresholds {
                 'org.jenkinsci.plugins.xunit.threshold.FailedThreshold' {
-                    unstableThreshold xUnitContext.failedThresholdsContext.unstable
-                    unstableNewThreshold xUnitContext.failedThresholdsContext.unstableNew
-                    failureThreshold xUnitContext.failedThresholdsContext.failure
-                    failureNewThreshold xUnitContext.failedThresholdsContext.failureNew
+                    unstableThreshold xUnitContext.failedThresholdsContext.unstable == null ? ''
+                            : xUnitContext.failedThresholdsContext.unstable
+                    unstableNewThreshold xUnitContext.failedThresholdsContext.unstableNew == null ? ''
+                            : xUnitContext.failedThresholdsContext.unstableNew
+                    failureThreshold xUnitContext.failedThresholdsContext.failure == null ? ''
+                            : xUnitContext.failedThresholdsContext.failure
+                    failureNewThreshold xUnitContext.failedThresholdsContext.failureNew == null ? ''
+                            : xUnitContext.failedThresholdsContext.failureNew
                 }
                 'org.jenkinsci.plugins.xunit.threshold.SkippedThreshold' {
-                    unstableThreshold xUnitContext.skippedThresholdsContext.unstable
-                    unstableNewThreshold xUnitContext.skippedThresholdsContext.unstableNew
-                    failureThreshold xUnitContext.skippedThresholdsContext.failure
-                    failureNewThreshold xUnitContext.skippedThresholdsContext.failureNew
+                    unstableThreshold xUnitContext.skippedThresholdsContext.unstable == null ? ''
+                            : xUnitContext.skippedThresholdsContext.unstable
+                    unstableNewThreshold xUnitContext.skippedThresholdsContext.unstableNew == null ? ''
+                            : xUnitContext.skippedThresholdsContext.unstableNew
+                    failureThreshold xUnitContext.skippedThresholdsContext.failure == null ? ''
+                            : xUnitContext.skippedThresholdsContext.failure
+                    failureNewThreshold xUnitContext.skippedThresholdsContext.failureNew == null ? ''
+                            : xUnitContext.skippedThresholdsContext.failureNew
                 }
             }
             thresholdMode xUnitContext.thresholdMode.xmlValue


### PR DESCRIPTION
The default values for the thresholds are empty strings in the GUI and not zeros. Zeros have a different meaning, they enforce having 0 failed tests, while an empty string means "do not check this threshold".