### PR TITLE
Shell step with closure

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/step/StepContext/shell.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/step/StepContext/shell.groovy
@@ -2,5 +2,9 @@ job('example') {
     steps {
         shell('echo Hello World!')
         shell(readFileFromWorkspace('build.sh'))
+        shell {
+            block('MESSAGE="Hello, World!"')
+            block('echo $MESSAGE')
+        }
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/ShellScriptContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/ShellScriptContext.groovy
@@ -1,0 +1,25 @@
+package javaposse.jobdsl.dsl.helpers.step
+
+import javaposse.jobdsl.dsl.Context
+
+class ShellScriptContext implements Context {
+    List<String> blocks = []
+
+    /**
+     * Adds a block to the shell script.
+     *
+     * @param block block to add
+     */
+    void block(String block) {
+        blocks << block
+    }
+
+    /**
+     * Adds blocks to the shell script.
+     *
+     * @param blocks blocks to add
+     */
+    void block(List<String> blocks) {
+        this.blocks.addAll(blocks)
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -61,6 +61,15 @@ class StepContext extends AbstractExtensibleContext {
     }
 
     /**
+     * Runs a shell script.
+     */
+    void shell(Closure closure) {
+        ShellScriptContext context = new ShellScriptContext()
+        ContextHelper.executeInContext(closure, context)
+        shell(context.blocks.join('\n'))
+    }
+
+    /**
      * Runs a remote shell script.
      *
      * @since 1.40

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
@@ -27,6 +27,21 @@ class StepContextSpec extends Specification {
         shellStep.command[0].value() == 'echo "Hello"'
     }
 
+    def 'call shell method with closure'() {
+        when:
+        context.shell {
+            block('echo "A"')
+            block(['echo "B"', 'echo "C"'])
+        }
+
+        then:
+        context.stepNodes != null
+        context.stepNodes.size() == 1
+        def shellStep = context.stepNodes[0]
+        shellStep.name() == 'hudson.tasks.Shell'
+        shellStep.command[0].value() == 'echo "A"\necho "B"\necho "C"'
+    }
+
     def 'call remoteShell method with minimal options'() {
         when:
         context.remoteShell('root@example.com:22') {


### PR DESCRIPTION
Added a shell step with closure. It's very useful for construction of the scripts from several blocks when the blocks need to be inside one script. This allows, for example, extracting the common setup/teardown of scripts into a separate method.