### PR TITLE
Jenkins 28986 - Improve support for Extended Email Plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/EmailTriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/EmailTriggerContext.groovy
@@ -11,6 +11,7 @@ class EmailTriggerContext implements Context {
     boolean triggerSendToRequester
     boolean triggerIncludeCulprits
     boolean triggerSendToRecipientList
+    boolean triggerAttachBuildLog
     String triggerReplyTo
 
     /**
@@ -18,12 +19,13 @@ class EmailTriggerContext implements Context {
      *
      * By default, {@code recipientList} is an empty list, {@code subject} is $PROJECT_DEFAULT_SUBJECT,
      * {@code body} is $PROJECT_DEFAULT_CONTENT, {@code sendToDevelopers} is false, {@code sendToRequester} is false,
-     * {@code includeCulprits} is false, {@code sendToRecipientList} is true,
+     * {@code includeCulprits} is false, {@code sendToRecipientList} is true, {@code attachBuildLog} is false,
      * and {@code replyTo} is $PROJECT_DEFAULT_REPLYTO
      */
     EmailTriggerContext(String shortName, String recipientList = null, String subject = null, String body = null,
                         Boolean sendToDevelopers = null, Boolean sendToRequester = null,
-                        Boolean includeCulprits = null, Boolean sendToRecipientList = null, String replyTo = null) {
+                        Boolean includeCulprits = null, Boolean sendToRecipientList = null,
+                        Boolean attachBuildLog = null, String replyTo = null) {
         triggerShortName = shortName
         triggerRecipientList = recipientList ?: ''
         triggerSubject = subject ?: '$PROJECT_DEFAULT_SUBJECT'
@@ -32,6 +34,7 @@ class EmailTriggerContext implements Context {
         triggerSendToRequester = sendToRequester == null ? false : sendToRequester
         triggerIncludeCulprits = includeCulprits == null ? false : includeCulprits
         triggerSendToRecipientList = sendToRecipientList == null ? true : sendToRecipientList
+        triggerAttachBuildLog = attachBuildLog == null ? false : attachBuildLog
         triggerReplyTo = replyTo ?: '$PROJECT_DEFAULT_REPLYTO'
     }
 
@@ -91,6 +94,13 @@ class EmailTriggerContext implements Context {
      */
     void sendToRecipientList(boolean sendToRecipientList = true) {
         triggerSendToRecipientList = sendToRecipientList
+    }
+
+    /**
+     * Specifies whether or not to attach the build log to the email.
+     */
+    void attachBuildLog(boolean attachBuildLog = true) {
+        triggerAttachBuildLog = attachBuildLog
     }
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/EmailTriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/EmailTriggerContext.groovy
@@ -1,0 +1,111 @@
+package javaposse.jobdsl.dsl.helpers.publisher
+
+import javaposse.jobdsl.dsl.Context
+
+class EmailTriggerContext implements Context {
+    String triggerShortName
+    String triggerRecipientList
+    String triggerSubject
+    String triggerBody
+    boolean triggerSendToDevelopers
+    boolean triggerSendToRequester
+    boolean triggerIncludeCulprits
+    boolean triggerSendToRecipientList
+    String triggerReplyTo
+
+    /**
+     * Creates the email trigger context.
+     *
+     * By default, {@code recipientList} is an empty list, {@code subject} is $PROJECT_DEFAULT_SUBJECT,
+     * {@code body} is $PROJECT_DEFAULT_CONTENT, {@code sendToDevelopers} is false, {@code sendToRequester} is false,
+     * {@code includeCulprits} is false, {@code sendToRecipientList} is true,
+     * and {@code replyTo} is $PROJECT_DEFAULT_REPLYTO
+     */
+    EmailTriggerContext(String shortName, String recipientList = null, String subject = null, String body = null,
+                        Boolean sendToDevelopers = null, Boolean sendToRequester = null,
+                        Boolean includeCulprits = null, Boolean sendToRecipientList = null, String replyTo = null) {
+        triggerShortName = shortName
+        triggerRecipientList = recipientList ?: ''
+        triggerSubject = subject ?: '$PROJECT_DEFAULT_SUBJECT'
+        triggerBody = body ?: '$PROJECT_DEFAULT_CONTENT'
+        triggerSendToDevelopers = sendToDevelopers == null ? false : sendToDevelopers
+        triggerSendToRequester = sendToRequester == null ? false : sendToRequester
+        triggerIncludeCulprits = includeCulprits == null ? false : includeCulprits
+        triggerSendToRecipientList = sendToRecipientList == null ? true : sendToRecipientList
+        triggerReplyTo = replyTo ?: '$PROJECT_DEFAULT_REPLYTO'
+    }
+
+    /**
+     * Specifies the recipient list for the email.
+     *
+     * The {@code recipients} parameter must be a comma-separated list of recipients.
+     */
+    void recipientList(String recipients) {
+        triggerRecipientList = recipients
+    }
+
+    /**
+     * Specifies the recipient list for the email.
+     */
+    void recipientList(List<String> recipients) {
+        recipientList(recipients.join(','))
+    }
+
+    /**
+     * Specifies the subject for the email.
+     */
+    void subject(String subject) {
+        triggerSubject = subject
+    }
+
+    /**
+     * Specifies the body for the email.
+     */
+    void body(String body) {
+        triggerBody = body
+    }
+
+    /**
+     * Specifies whether or not the email should be sent to developers.
+     */
+    void sendToDevelopers(boolean sendToDevelopers = true) {
+        triggerSendToDevelopers = sendToDevelopers
+    }
+
+    /**
+     * Specifies whether or not the email should be sent to requester.
+     */
+    void sendToRequester(boolean sendToRequester = true) {
+        triggerSendToRequester = sendToRequester
+    }
+
+    /**
+     * Specifies whether or not the email should be sent to culprits.
+     */
+    void includeCulprits(boolean includeCulprits = true) {
+        triggerIncludeCulprits = includeCulprits
+    }
+
+    /**
+     * Specifies whether or not the email should be sent to recipient list.
+     */
+    void sendToRecipientList(boolean sendToRecipientList = true) {
+        triggerSendToRecipientList = sendToRecipientList
+    }
+
+    /**
+     * Specifies the To list for the email.
+     *
+     * The {@code replyToList} parameter must be a comma-separated list of recipients.
+     */
+    void replyTo(String replyToList) {
+        triggerReplyTo = replyToList
+    }
+
+    /**
+     * Specifies the To list for the email.
+     */
+    void replyTo(List<String> replyToList) {
+        replyTo(replyToList.join(','))
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -93,7 +93,7 @@ class PublisherContext extends AbstractExtensibleContext {
                             includeCulprits trigger.triggerIncludeCulprits as String
                             sendToRecipientList trigger.triggerSendToRecipientList as String
                             attachmentsPattern ''
-                            attachBuildLog false
+                            attachBuildLog trigger.triggerAttachBuildLog as String
                             compressBuildLog false
                             replyTo trigger.triggerReplyTo
                             contentType 'project'

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -111,6 +111,7 @@ class PublisherContextSpec extends Specification {
                 sendToDevelopers()
                 includeCulprits()
                 sendToRequester()
+                attachBuildLog()
             }
             trigger('Fixed') {
                 subject('Build status: fixed')
@@ -147,7 +148,7 @@ class PublisherContextSpec extends Specification {
         emailFailure.includeCulprits[0].value() as String == 'true'
         emailFailure.sendToRecipientList[0].value() as String == 'true'
         emailFailure.attachmentsPattern[0].value() == ''
-        emailFailure.attachBuildLog[0].value() as String == 'false'
+        emailFailure.attachBuildLog[0].value() as String == 'true'
         emailFailure.compressBuildLog[0].value() as String == 'false'
         emailFailure.replyTo[0].value() == '$PROJECT_DEFAULT_REPLYTO'
         emailFailure.contentType[0].value() == 'project'

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -95,6 +95,79 @@ class PublisherContextSpec extends Specification {
         emailDefault.sendToRequester[0].value() == 'true'
     }
 
+    def 'call extended email with structured triggers'() {
+        when:
+        def recipients = ['a@example.com', 'b@example.com']
+        context.extendedEmail {
+            recipientList(recipients)
+            defaultSubject('Build status: failed')
+            defaultContent('The build is broken')
+            attachBuildLog()
+            replyTo(recipients)
+
+            trigger('Failure') {
+                subject('$PROJECT_DEFAULT_SUBJECT')
+                body('$PROJECT_DEFAULT_CONTENT')
+                sendToDevelopers()
+                includeCulprits()
+                sendToRequester()
+            }
+            trigger('Fixed') {
+                subject('Build status: fixed')
+                body('The build has been fixed')
+                recipientList(recipients)
+                replyTo(recipients)
+                sendToDevelopers()
+                sendToRequester()
+            }
+        }
+
+        then:
+        Node emailPublisher = context.publisherNodes[0]
+        emailPublisher.recipientList[0].value() == 'a@example.com,b@example.com'
+        emailPublisher.contentType[0].value() == 'default'
+        emailPublisher.defaultSubject[0].value() == 'Build status: failed'
+        emailPublisher.defaultContent[0].value() == 'The build is broken'
+        emailPublisher.attachmentsPattern[0].value() == ''
+        emailPublisher.presendScript[0].value() == '$DEFAULT_PRESEND_SCRIPT'
+        emailPublisher.attachBuildLog[0].value() as String == 'true'
+        emailPublisher.compressBuildLog[0].value() as String == 'false'
+        emailPublisher.replyTo[0].value() == 'a@example.com,b@example.com'
+        emailPublisher.saveOutput[0].value() as String == 'false'
+
+        Node triggers = emailPublisher.configuredTriggers[0]
+        triggers.children().size() == 2
+        triggers.children()[0].name() == 'hudson.plugins.emailext.plugins.trigger.FailureTrigger'
+        Node emailFailure = triggers.children()[0].email[0]
+        emailFailure.recipientList[0].value() == ''
+        emailFailure.subject[0].value() == '$PROJECT_DEFAULT_SUBJECT'
+        emailFailure.body[0].value() == '$PROJECT_DEFAULT_CONTENT'
+        emailFailure.sendToDevelopers[0].value() as String == 'true'
+        emailFailure.sendToRequester[0].value() as String == 'true'
+        emailFailure.includeCulprits[0].value() as String == 'true'
+        emailFailure.sendToRecipientList[0].value() as String == 'true'
+        emailFailure.attachmentsPattern[0].value() == ''
+        emailFailure.attachBuildLog[0].value() as String == 'false'
+        emailFailure.compressBuildLog[0].value() as String == 'false'
+        emailFailure.replyTo[0].value() == '$PROJECT_DEFAULT_REPLYTO'
+        emailFailure.contentType[0].value() == 'project'
+
+        triggers.children()[0].name() == 'hudson.plugins.emailext.plugins.trigger.FailureTrigger'
+        Node emailFixed = triggers.children()[1].email[0]
+        emailFixed.recipientList[0].value() == 'a@example.com,b@example.com'
+        emailFixed.subject[0].value() == 'Build status: fixed'
+        emailFixed.body[0].value() == 'The build has been fixed'
+        emailFixed.sendToDevelopers[0].value() as String == 'true'
+        emailFixed.sendToRequester[0].value() as String == 'true'
+        emailFixed.includeCulprits[0].value() as String == 'false'
+        emailFixed.sendToRecipientList[0].value() as String == 'true'
+        emailFixed.attachmentsPattern[0].value() == ''
+        emailFixed.attachBuildLog[0].value() as String == 'false'
+        emailFixed.compressBuildLog[0].value() as String == 'false'
+        emailFixed.replyTo[0].value() == 'a@example.com,b@example.com'
+        emailFixed.contentType[0].value() == 'project'
+    }
+
     def 'call standard mailer method'() {
         when:
         context.mailer('recipient')


### PR DESCRIPTION
I've seen that there are some other Extended Email improvements in the pull requests, but anyway here's what we're using at Criteo (we rebased our patches on top of 1.42). Please tell me what to do to get this accepted, if possible backwards-compatibility-wise.