### PR TITLE
Add DSL support for JaCoCo Line Coverage column via 'jacoco' method

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
@@ -154,7 +154,7 @@ class ColumnsContext extends AbstractContext {
      *
      * @since 1.43
      */
-    @RequiresPlugin(id = 'jacoco-column', minimumVersion = '1.0')
+    @RequiresPlugin(id = 'jacoco', minimumVersion = '1.0')
     void jacoco() {
         columnNodes << new Node(null, 'hudson.plugins.jacococoveragecolumn.JaCoCoColumn')
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
@@ -148,4 +148,14 @@ class ColumnsContext extends AbstractContext {
     void progressBar() {
         columnNodes << new Node(null, 'org.jenkins.ci.plugins.progress__bar.ProgressBarColumn')
     }
+
+    /**
+     * Adds a column showing JaCoCo Line Coverage.
+     *
+     * @since 1.43
+     */
+    @RequiresPlugin(id = 'jacoco-column', minimumVersion = '1.0')
+    void jacoco() {
+        columnNodes << new Node(null, 'hudson.plugins.jacococoveragecolumn.JaCoCoColumn')
+    }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
@@ -417,6 +417,20 @@ class ListViewSpec<T extends ListView> extends Specification {
         1 * jobManagement.requireMinimumPluginVersion('custom-job-icon', '0.2')
     }
 
+    def 'jacoco column'() {
+        when:
+        view.columns {
+            jacoco()
+        }
+
+        then:
+        Node root = view.node
+        root.columns.size() == 1
+        root.columns[0].value().size() == 1
+        root.columns[0].value()[0].name() == 'hudson.plugins.jacococoveragecolumn.JaCoCoColumn'
+        1 * jobManagement.requireMinimumPluginVersion('jacoco-column', '1.0')
+    }
+
     protected String getDefaultXml() {
         '''<?xml version='1.0' encoding='UTF-8'?>
 <hudson.model.ListView>

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
@@ -428,7 +428,7 @@ class ListViewSpec<T extends ListView> extends Specification {
         root.columns.size() == 1
         root.columns[0].value().size() == 1
         root.columns[0].value()[0].name() == 'hudson.plugins.jacococoveragecolumn.JaCoCoColumn'
-        1 * jobManagement.requireMinimumPluginVersion('jacoco-column', '1.0')
+        1 * jobManagement.requireMinimumPluginVersion('jacoco', '1.0')
     }
 
     protected String getDefaultXml() {


### PR DESCRIPTION
Passed build.
Ran embedded server and installed JaCoCo 2.0.1 plugin to verify the following Job DSL -
```
listView("TestView") {
  columns {
    status()
    weather()
    name()
    lastSuccess()
    lastFailure()
    lastDuration()
    jacoco()
  }
  jobs {
  }
}
```
Generated a List View that I could then add the above job to and see that the view included the column and the View XML was correct -
```
<?xml version="1.0" encoding="UTF-8"?>
<hudson.model.ListView>
  <name>TestView</name>
  <filterExecutors>false</filterExecutors>
  <filterQueue>false</filterQueue>
  <properties class="hudson.model.View$PropertyList"/>
  <jobNames>
    <comparator class="hudson.util.CaseInsensitiveComparator"/>
    <string>TestDSL</string>
  </jobNames>
  <jobFilters/>
  <columns>
    <hudson.views.StatusColumn/>
    <hudson.views.WeatherColumn/>
    <hudson.views.JobColumn/>
    <hudson.views.LastSuccessColumn/>
    <hudson.views.LastFailureColumn/>
    <hudson.views.LastDurationColumn/>
    <hudson.plugins.jacococoveragecolumn.JaCoCoColumn plugin="jacoco@2.0.1"/>
  </columns>
  <recurse>false</recurse>
</hudson.model.ListView>
```
