### PR TITLE
fix verifying valid script name

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -56,9 +56,10 @@ public class DslScriptLoader {
                         script = InvokerHelper.createScript(cls, binding);
                     } else {
                         String scriptLocation = scriptRequest.getLocation();
+                        File scriptFile = new File(scriptLocation);
 
                         jobManagement.getOutputStream().printf("Processing DSL script %s\n", scriptLocation);
-                        if (!isValidScriptName(scriptLocation)) {
+                        if (!isValidScriptName(scriptFile.getName())) {
                             jobManagement.logDeprecationWarning(
                                     "script names may only contain letters, digits and underscores, but may not start with a digit; support for arbitrary names",
                                     scriptLocation,

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslScriptLoader.java
@@ -55,15 +55,17 @@ public class DslScriptLoader {
                         Class cls = engine.getGroovyClassLoader().parseClass(scriptRequest.getBody(), "script");
                         script = InvokerHelper.createScript(cls, binding);
                     } else {
-                        jobManagement.getOutputStream().printf("Processing DSL script %s\n", scriptRequest.getLocation());
-                        if (!isValidScriptName(scriptRequest.getLocation())) {
+                        String scriptLocation = scriptRequest.getLocation();
+
+                        jobManagement.getOutputStream().printf("Processing DSL script %s\n", scriptLocation);
+                        if (!isValidScriptName(scriptLocation)) {
                             jobManagement.logDeprecationWarning(
                                     "script names may only contain letters, digits and underscores, but may not start with a digit; support for arbitrary names",
-                                    scriptRequest.getLocation(),
+                                    scriptLocation,
                                     -1
                             );
                         }
-                        script = engine.createScript(scriptRequest.getLocation(), binding);
+                        script = engine.createScript(scriptLocation, binding);
                     }
                     assert script instanceof JobParent;
 


### PR DESCRIPTION
Since 1.42, when processing DSLs with the standalone jar, I got warnings:

$ java -jar job-dsl-core-1.42-standalone-jar path/to/my/script.groovy
[...]
Warning: (path/to/my/script.groovy) script names may only contain letters, digits and underscores, but may not start with a digit; support for arbitrary names is deprecated
[...]

This fixes this, by checking only the filename, not the full path.