### PR TITLE
Fix problem with running the DSL in multiple threads

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
@@ -24,11 +24,11 @@ import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 @ThreadInterrupt
 abstract class JobParent extends Script implements DslFactory {
     JobManagement jm
-    Set<Item> referencedJobs = new LinkedHashSet<>()
-    Set<View> referencedViews = new LinkedHashSet<>()
-    Set<ConfigFile> referencedConfigFiles = new LinkedHashSet<>()
-    Set<UserContent> referencedUserContents = new LinkedHashSet<>()
-    List<String> queueToBuild = []
+    Set<Item> referencedJobs = new LinkedHashSet<>().asSynchronized()
+    Set<View> referencedViews = new LinkedHashSet<>().asSynchronized()
+    Set<ConfigFile> referencedConfigFiles = new LinkedHashSet<>().asSynchronized()
+    Set<UserContent> referencedUserContents = new LinkedHashSet<>().asSynchronized()
+    List<String> queueToBuild = [].asSynchronized()
 
     /**
      * @since 1.30


### PR DESCRIPTION
We use GPars eachParallel() to split up generation of jobs
into multiple threads. This significantly reduced our
run time from 25min to 5min.

Unfortunately, it leads to a race condition, which causes
random jobs to be lost (and deleted) on each run.

Ultimately, it all boils down to this non thread-safe statement
in JobParent.processItem():
  referencedJobs << job

Making the 5 collections asSynchronized() fixed the problem for us.