### PR TITLE
Add non stored password parameter

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -21,7 +21,7 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
 
 ## Release Notes
 * 1.44 (unreleased)
- * Added nonStoredPasswordParameter provided by the 
+ * Added nonStoredPasswordParam provided by the 
    [Mask Passwords Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Mask+Passwords+Plugin)
  * Added support for the [Mattermost Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Mattermost+Plugin)
    ([JENKINS-32764](https://issues.jenkins-ci.org/browse/JENKINS-32764))

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -21,6 +21,8 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
 
 ## Release Notes
 * 1.44 (unreleased)
+ * Added nonStoredPasswordParameter provided by the 
+   [Mask Passwords Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Mask+Passwords+Plugin)
  * Added support for the [Mattermost Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Mattermost+Plugin)
    ([JENKINS-32764](https://issues.jenkins-ci.org/browse/JENKINS-32764))
  * Added support for the [P4 Plugin](https://wiki.jenkins-ci.org/display/JENKINS/P4+Plugin)

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/BuildParametersContext/nonStoredPasswordParam.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/BuildParametersContext/nonStoredPasswordParam.groovy
@@ -1,0 +1,5 @@
+job('example') {
+    parameters {
+        nonStoredPasswordParam('myParameterName', 'my description')
+    }
+}

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/BuildParametersContext/nonStoredPasswordParameter.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/BuildParametersContext/nonStoredPasswordParameter.groovy
@@ -1,0 +1,5 @@
+job('example') {
+    parameters {
+        nonStoredPasswordParameter('myParameterName', 'my description')
+    }
+}

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/BuildParametersContext/nonStoredPasswordParameter.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/BuildParametersContext/nonStoredPasswordParameter.groovy
@@ -1,5 +1,0 @@
-job('example') {
-    parameters {
-        nonStoredPasswordParameter('myParameterName', 'my description')
-    }
-}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -373,6 +373,22 @@ class BuildParametersContext extends AbstractExtensibleContext {
                 }
     }
 
+    /**
+     * Defines a parameter that allows you to take in a users password.
+     *
+     * @since 1.44
+     */
+    @RequiresPlugin(id = 'mask-passwords', minimumVersion = '2.6')
+    void nonStoredPasswordParameter(String parameterName, String description = null) {
+        checkParameterName(parameterName)
+
+        buildParameterNodes[parameterName] = new NodeBuilder().
+                'com.michelin.cio.hudson.plugins.passwordparam.PasswordParameterDefinition' {
+                    name(parameterName)
+                    delegate.description(description ?: '')
+                }
+    }
+
     private checkParameterName(String name) {
         checkNotNullOrEmpty(name, 'parameterName cannot be null')
         checkArgument(!buildParameterNodes.containsKey(name), "parameter ${name} already defined")

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -379,7 +379,7 @@ class BuildParametersContext extends AbstractExtensibleContext {
      * @since 1.44
      */
     @RequiresPlugin(id = 'mask-passwords', minimumVersion = '2.6')
-    void nonStoredPasswordParameter(String parameterName, String description = null) {
+    void nonStoredPasswordParam(String parameterName, String description = null) {
         checkParameterName(parameterName)
 
         buildParameterNodes[parameterName] = new NodeBuilder().

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -1475,7 +1475,7 @@ class BuildParametersContextSpec extends Specification {
 
     def 'base nonStoredPasswordParameter usage'() {
         when:
-        context.nonStoredPasswordParameter('myParameterName', 'my parameter description')
+        context.nonStoredPasswordParam('myParameterName', 'my parameter description')
 
         then:
         context.buildParameterNodes != null
@@ -1489,7 +1489,7 @@ class BuildParametersContextSpec extends Specification {
 
     def 'simplified nonStoredPasswordParameter usage'() {
         when:
-        context.nonStoredPasswordParameter('myParameterName')
+        context.nonStoredPasswordParam('myParameterName')
 
         then:
         context.buildParameterNodes != null
@@ -1503,7 +1503,7 @@ class BuildParametersContextSpec extends Specification {
 
     def 'nonStoredPasswordParameter name argument cant be null'() {
         when:
-        context.nonStoredPasswordParameter(null)
+        context.nonStoredPasswordParam(null)
 
         then:
         thrown(DslScriptException)
@@ -1511,7 +1511,7 @@ class BuildParametersContextSpec extends Specification {
 
     def 'nonStoredPasswordParameter name argument cant be empty'() {
         when:
-        context.nonStoredPasswordParameter('')
+        context.nonStoredPasswordParam('')
 
         then:
         thrown(DslScriptException)
@@ -1520,7 +1520,7 @@ class BuildParametersContextSpec extends Specification {
     def 'nonStoredPasswordParameter already defined'() {
         when:
         context.booleanParam('one')
-        context.nonStoredPasswordParameter('one')
+        context.nonStoredPasswordParam('one')
 
         then:
         thrown(DslScriptException)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -1472,4 +1472,57 @@ class BuildParametersContextSpec extends Specification {
         then:
         thrown(DslScriptException)
     }
+
+    def 'base nonStoredPasswordParameter usage'() {
+        when:
+        context.nonStoredPasswordParameter('myParameterName', 'my parameter description')
+
+        then:
+        context.buildParameterNodes != null
+        context.buildParameterNodes.size() == 1
+        context.buildParameterNodes['myParameterName'].children().size() == 2
+        context.buildParameterNodes['myParameterName'].name() ==
+                'com.michelin.cio.hudson.plugins.passwordparam.PasswordParameterDefinition'
+        context.buildParameterNodes['myParameterName'].name.text() == 'myParameterName'
+        context.buildParameterNodes['myParameterName'].description.text() == 'my parameter description'
+    }
+
+    def 'simplified nonStoredPasswordParameter usage'() {
+        when:
+        context.nonStoredPasswordParameter('myParameterName')
+
+        then:
+        context.buildParameterNodes != null
+        context.buildParameterNodes.size() == 1
+        context.buildParameterNodes['myParameterName'].children().size() == 2
+        context.buildParameterNodes['myParameterName'].name() ==
+                'com.michelin.cio.hudson.plugins.passwordparam.PasswordParameterDefinition'
+        context.buildParameterNodes['myParameterName'].name.text() == 'myParameterName'
+        context.buildParameterNodes['myParameterName'].description.text() == ''
+    }
+
+    def 'nonStoredPasswordParameter name argument cant be null'() {
+        when:
+        context.nonStoredPasswordParameter(null)
+
+        then:
+        thrown(DslScriptException)
+    }
+
+    def 'nonStoredPasswordParameter name argument cant be empty'() {
+        when:
+        context.nonStoredPasswordParameter('')
+
+        then:
+        thrown(DslScriptException)
+    }
+
+    def 'nonStoredPasswordParameter already defined'() {
+        when:
+        context.booleanParam('one')
+        context.nonStoredPasswordParameter('one')
+
+        then:
+        thrown(DslScriptException)
+    }
 }


### PR DESCRIPTION
Added the nonStoredPassword parameter included with the mask-passwords plugin. This allows a job to take in a password as user input. The password is not persisted between builds and there is no default so password security shouldn't be a concern.