### PR TITLE
Do not use "rolem" by default.

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/ScmContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/ScmContext.groovy
@@ -300,7 +300,7 @@ class ScmContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'perforce')
     void p4(String viewspec, Closure configure = null) {
-        p4(viewspec, 'rolem', '', configure)
+        p4(viewspec, '', '', configure)
     }
 
     /**


### PR DESCRIPTION
Not specifying user should not result in a random user. If you define the user in the global config, it is preferable that nothing is inserted compared to a random user.