### PR TITLE
[JENKINS-33093] Support new feature of upcoming Gradle Plugin 1.25

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/GradleContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/GradleContext.groovy
@@ -14,6 +14,7 @@ class GradleContext extends AbstractContext {
     boolean fromRootBuildScriptDir = true
     boolean makeExecutable
     boolean useWorkspaceAsHome
+    boolean passAsProperties
     String gradleName = '(Default)'
     Closure configureBlock
 
@@ -82,6 +83,13 @@ class GradleContext extends AbstractContext {
      */
     void makeExecutable(boolean makeExecutable = true) {
         this.makeExecutable = makeExecutable
+    }
+
+    /**
+     * Passes job parameters as Gradle properties. Defaults to {@code false}.
+     */
+    void passAsProperties(boolean passAsProperties = false) {
+        this.passAsProperties = passAsProperties
     }
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -140,6 +140,9 @@ class StepContext extends AbstractExtensibleContext {
             if (jobManagement.isMinimumPluginVersionInstalled('gradle', '1.23')) {
                 useWorkspaceAsHome gradleContext.useWorkspaceAsHome
             }
+            if (jobManagement.isMinimumPluginVersionInstalled('gradle', '1.25')) {
+                passAsProperties gradleContext.passAsProperties
+            }
         }
 
         if (gradleContext.configureBlock) {


### PR DESCRIPTION
Gradle Plugin up to version 1.24 passes job parameters as system properties (-D). The new Gradle Plugin 1.25 (yet to be released) will offer an option to pass job parameters as Gradle Properties (-P).
The new feature is version agnostic and will only kick in for versions >= 1.25. For compatibility reasons, the default is to use the old behaviour (system properties).
The PR for the Gradle Plugin feature itself is https://github.com/jenkinsci/gradle-plugin/pull/27