### PR TITLE
correctly document GitContext's clean

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitContext.groovy
@@ -131,7 +131,7 @@ class GitContext extends AbstractContext {
     }
 
     /**
-     * Clean up the workspace before every checkout by deleting all untracked files and directories, including those
+     * Clean up the workspace after every checkout by deleting all untracked files and directories, including those
      * which are specified in {@code .gitignore}. Defaults to {@code false}.
      */
     void clean(boolean clean = true) {


### PR DESCRIPTION
The Git plugin offers two clean checkboxes, one for before and one for after. This option enables the "clean after" behavior, so let's sync the documentation to not be confusing / misleading. Other references appear to be correct.