### PR TITLE
Support NEW_FAILURE_AND_FIXED instant messaging strategy

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/IrcContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/IrcContext.groovy
@@ -9,7 +9,7 @@ import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 class IrcContext implements Context {
     List<IrcPublisherChannel> channels = []
 
-    List<String> strategies = ['ALL', 'ANY_FAILURE', 'FAILURE_AND_FIXED', 'STATECHANGE_ONLY']
+    List<String> strategies = ['ALL', 'ANY_FAILURE', 'FAILURE_AND_FIXED', 'NEW_FAILURE_AND_FIXED', 'STATECHANGE_ONLY']
 
     List<String> notificationMessages = ['Default', 'SummaryOnly', 'BuildParameters', 'PrintFailingTests']
 
@@ -65,7 +65,7 @@ class IrcContext implements Context {
 
     /**
      * Specifies when to send notifications. Must be one of {@code 'ALL'}, {@code 'FAILURE_AND_FIXED'},
-     * {@code 'ANY_FAILURE'} or {@code 'STATECHANGE_ONLY'}.
+     * {@code 'ANY_FAILURE'}, {@code 'NEW_FAILURE_AND_FIXED'} or {@code 'STATECHANGE_ONLY'}.
      */
     void strategy(String strategy) {
         checkArgument(strategies.contains(strategy), "Possible values: ${strategies.join(',')}")

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/JabberContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/JabberContext.groovy
@@ -6,7 +6,7 @@ import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class JabberContext implements Context {
     private static final Set<String> VALID_STRATEGY_NAMES = [
-            'ALL', 'FAILURE_AND_FIXED', 'ANY_FAILURE', 'STATECHANGE_ONLY'
+            'ALL', 'FAILURE_AND_FIXED', 'ANY_FAILURE', 'STATECHANGE_ONLY', 'NEW_FAILURE_AND_FIXED'
     ]
     private static final Set<String> VALID_CHANNEL_NOTIFICATION_NAMES = [
             'Default', 'SummaryOnly', 'BuildParameters', 'PrintFailingTests'
@@ -22,7 +22,7 @@ class JabberContext implements Context {
 
     /**
      * Specifies when to send notifications. Must be one of {@code 'ALL'} (default), {@code 'FAILURE_AND_FIXED'},
-     * {@code 'ANY_FAILURE'} or {@code 'STATECHANGE_ONLY'}.
+     * {@code 'ANY_FAILURE'}, {@code 'NEW_FAILURE_AND_FIXED'} or {@code 'STATECHANGE_ONLY'}.
      */
     void strategyName(String strategyName) {
         checkArgument(


### PR DESCRIPTION
instant-messaging-plugin supports NEW_FAILURE_AND_FIXED since 2013,
so enabling usage of it in DSL for Jabber and IRC plugins.