### PR TITLE
handle node with null attributes

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/NodeEnhancement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/NodeEnhancement.groovy
@@ -101,7 +101,8 @@ class NodeEnhancement {
         if (newValue instanceof List) {
             newValue = cloneNodeList((List) newValue)
         }
-        new Node(null, node.name(), new HashMap(node.attributes()), newValue)
+        Map attributes = node.attributes() ? new HashMap(node.attributes()) : [:]
+        new Node(null, node.name(), attributes, newValue)
     }
 
     /**

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/NodeEnhancementSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/NodeEnhancementSpec.groovy
@@ -104,6 +104,19 @@ class NodeEnhancementSpec extends Specification {
         result == root.test[0]
     }
 
+    def 'div handles node with null attributes'() {
+        setup:
+        Node node = new Node(null, 'test', null)
+
+        when:
+        execute {
+            it / node
+        }
+
+        then:
+        root.test.size() == 1
+    }
+
     private Node execute(Closure closure) {
         closure.delegate = new MissingPropertyToStringDelegate(root)
 


### PR DESCRIPTION
Recent changes to NodeEnhancement are throwing an exception when encountering a Node with null attributes.

In my case, that was coming from here: https://github.com/jenkinsci/job-dsl-plugin/blob/fd173066cb95849c7b7402060131dba18a00150b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy#L247