### PR TITLE
[JENKINS-33482] fix: 'Create tag for each build' is activated by default for oneliner

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/ScmContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/ScmContext.groovy
@@ -180,9 +180,6 @@ class ScmContext extends AbstractExtensibleContext {
             if (configure) {
                 delegate.configure(configure)
             }
-            extensions {
-                perBuildTag()
-            }
         }
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslSampleSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslSampleSpec.groovy
@@ -165,7 +165,7 @@ class DslSampleSpec extends Specification {
         <remotePoll>false</remotePoll>
         <ignoreNotifyCommit>false</ignoreNotifyCommit>
         <gitTool>Default</gitTool>
-        <skipTag>false</skipTag>
+        <skipTag>true</skipTag>
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <url>git://github.com/JavaPosseRoundup/job-dsl-plugin.git</url>
@@ -319,9 +319,6 @@ mavenJob('PROJ-maven-with-template') {
                 <name>**</name>
             </hudson.plugins.git.BranchSpec>
         </branches>
-        <extensions>
-            <hudson.plugins.git.extensions.impl.PerBuildTag/>
-        </extensions>
     </scm>
 </maven2-moduleset>
 '''
@@ -364,7 +361,7 @@ mavenJob('PROJ-maven-with-template') {
         <remotePoll>false</remotePoll>
         <ignoreNotifyCommit>false</ignoreNotifyCommit>
         <gitTool>Default</gitTool>
-        <skipTag>false</skipTag>
+        <skipTag>true</skipTag>
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <url>git://github.com/JavaPosseRoundup/job-dsl-plugin.git</url>

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
@@ -1176,8 +1176,12 @@ class ScmContextSpec extends Specification {
 
         then:
         context.scmNodes[0] != null
-        context.scmNodes[0].userRemoteConfigs[0].'hudson.plugins.git.UserRemoteConfig'[0].url[0].value() == GIT_REPO_URL
-        context.scmNodes[0].branches[0].'hudson.plugins.git.BranchSpec'[0].name[0].value() == '**'
+        with(context.scmNodes[0]) {
+            userRemoteConfigs[0].'hudson.plugins.git.UserRemoteConfig'[0].url[0].value() == GIT_REPO_URL
+            branches[0].'hudson.plugins.git.BranchSpec'[0].name[0].value() == '**'
+            createTag.size() == 0
+            extensions.size() == 0
+        }
         (1.._) * mockJobManagement.requireMinimumPluginVersion('git', '2.2.6')
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/jobs/WorkflowJobSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/jobs/WorkflowJobSpec.groovy
@@ -66,7 +66,7 @@ class WorkflowJobSpec extends Specification {
             attribute('class') == 'org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition'
             children().size() == 2
             scm[0].attribute('class') == 'hudson.plugins.git.GitSCM'
-            scm[0].children().size() == 15
+            scm[0].children().size() == 14
             scriptPath[0].value() == 'JenkinsFile'
         }
         1 * jobManagement.requireMinimumPluginVersion('workflow-cps', '1.2')
@@ -88,7 +88,7 @@ class WorkflowJobSpec extends Specification {
             attribute('class') == 'org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition'
             children().size() == 2
             scm[0].attribute('class') == 'hudson.plugins.git.GitSCM'
-            scm[0].children().size() == 15
+            scm[0].children().size() == 14
             scriptPath[0].value() == '.jenkins/Jenkinsfile'
         }
         1 * jobManagement.requireMinimumPluginVersion('workflow-cps', '1.2')


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-33482