### PR TITLE
[FIXED JENKINS-33782] Add support for git-chooser-alternative to the scm helper's StrategyContext

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -63,6 +63,7 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
    ([#747](https://github.com/jenkinsci/job-dsl-plugin/pull/747))
  * Deprecated a method for the [EnvInject Plugin](https://wiki.jenkins-ci.org/display/JENKINS/EnvInject+Plugin), see
    [Migration](Migration#migrating-to-145)
+ * Add support for the [Git Chooser Alternative Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Git+Chooser+Alternative+Plugin) plugin. ([JENKINS-33782](https://issues.jenkins-ci.org/browse/JENKINS-33782) + [jenkinsci/job-dsl-plugin#801](https://github.com/jenkinsci/job-dsl-plugin/pull/801))
 * 1.44 (March 11 2016)
  * Added support for the [Mattermost Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Mattermost+Plugin)
    ([JENKINS-32764](https://issues.jenkins-ci.org/browse/JENKINS-32764))

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/ScmContext/git.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/ScmContext/git.groovy
@@ -59,3 +59,21 @@ job('example-4') {
         }
     }
 }
+
+// checkout repo at a specific branch using the alternative build choosing strategy.
+job('example-1') {
+    scm {
+        git {
+            branches('branch-that-may-not-exist', 'master')
+            remote {
+                github('account/repo', 'ssh')
+            }
+            extensions {
+                choosingStrategy {
+                    // Default to "master" if "branch-that-may-not-exist" does not exist.
+                    alternative()
+                }
+            }
+        }
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/StrategyContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/StrategyContext.groovy
@@ -41,4 +41,16 @@ class StrategyContext extends AbstractContext {
             ancestorCommitSha1(commit)
         }
     }
+
+    /**
+     * Selects branches in priority order based on which branch exists.
+     *
+     * @since 1.45
+     */
+    @RequiresPlugin(id = 'git-chooser-alternative', minimumVersion = '1.1')
+    void alternative() {
+        buildChooser = NodeBuilder.newInstance().buildChooser(
+            class: 'org.jenkinsci.plugins.git.chooser.alternative.AlternativeBuildChooser'
+        )
+    }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
@@ -1217,6 +1217,32 @@ class ScmContextSpec extends Specification {
         1 * mockJobManagement.requireMinimumPluginVersion('git', '2.3.1')
     }
 
+    def 'call git scm with alternative build chooser extension'() {
+        when:
+        context.git {
+            remote {
+                url('https://github.com/jenkinsci/job-dsl-plugin.git')
+            }
+            extensions {
+                choosingStrategy {
+                    alternative()
+                }
+            }
+        }
+
+        then:
+        context.scmNodes[0] != null
+        context.scmNodes[0].extensions.size() == 1
+        context.scmNodes[0].extensions[0].'hudson.plugins.git.extensions.impl.BuildChooserSetting'.size() == 1
+        with(context.scmNodes[0].extensions[0].'hudson.plugins.git.extensions.impl.BuildChooserSetting'[0]) {
+            children().size() == 1
+            buildChooser[0].attribute('class') ==
+                    'org.jenkinsci.plugins.git.chooser.alternative.AlternativeBuildChooser'
+        }
+        1 * mockJobManagement.requireMinimumPluginVersion('git', '2.2.6')
+        1 * mockJobManagement.requireMinimumPluginVersion('git-chooser-alternative', '1.1')
+    }
+
     def 'call git scm with gerrit trigger build chooser extension'() {
         when:
         context.git {


### PR DESCRIPTION
See also [JENKINS-33782](https://issues.jenkins-ci.org/browse/JENKINS-33782).

- [x] Add an `alternative` function to `StrategyContext`.
- [x] Update release notes
- [x] Add an example to `scm_context.groovy`
- [x] Add a spec for the new `alternative` function