### PR TITLE
[JENKINS-33967] Enhanced git with submodule timeout

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitExtensionContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitExtensionContext.groovy
@@ -79,6 +79,11 @@ class GitExtensionContext extends AbstractContext {
             if (jobManagement.isMinimumPluginVersionInstalled('git', '2.4.1')) {
                 reference(context.reference ?: '')
             }
+            if (jobManagement.isMinimumPluginVersionInstalled('git', '2.2.8')) {
+                if (context.timeout != null) {
+                    timeout(context.timeout)
+                }
+            }
         }
     }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitSubmoduleOptionsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitSubmoduleOptionsContext.groovy
@@ -9,6 +9,7 @@ class GitSubmoduleOptionsContext extends AbstractContext {
     boolean recursive
     boolean tracking
     String reference
+    Integer timeout
 
     protected GitSubmoduleOptionsContext(JobManagement jobManagement) {
         super(jobManagement)
@@ -43,5 +44,14 @@ class GitSubmoduleOptionsContext extends AbstractContext {
     @RequiresPlugin(id = 'git', minimumVersion = '2.4.1')
     void reference(String reference) {
         this.reference = reference
+    }
+
+    /**
+     * Specify a timeout (in minutes) for submodules operations.
+     * @since 1.46
+     */
+    @RequiresPlugin(id = 'git', minimumVersion = '2.2.8')
+    void timeout(Integer timeout) {
+        this.timeout = timeout
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
@@ -1554,6 +1554,9 @@ class ScmContextSpec extends Specification {
     }
 
     def 'call git scm with full submodule options'() {
+        setup:
+        mockJobManagement.isMinimumPluginVersionInstalled('git', '2.2.8') >> true
+
         when:
         context.git {
             remote {
@@ -1564,6 +1567,7 @@ class ScmContextSpec extends Specification {
                     disable()
                     recursive()
                     tracking()
+                    timeout(40)
                 }
             }
         }
@@ -1574,10 +1578,11 @@ class ScmContextSpec extends Specification {
             extensions.size() == 1
             extensions[0].children().size() == 1
             with(extensions[0].'hudson.plugins.git.extensions.impl.SubmoduleOption'[0]) {
-                children().size() == 3
+                children().size() == 4
                 disableSubmodules[0].value() == true
                 recursiveSubmodules[0].value() == true
                 trackingSubmodules[0].value() == true
+                timeout[0].value() == 40
             }
         }
         1 * mockJobManagement.requireMinimumPluginVersion('git', '2.2.6')


### PR DESCRIPTION
- [JENKINS-33967](https://issues.jenkins-ci.org/browse/JENKINS-33967)

```groovy
job('example-1') {
    scm {
        git {
            remote {
                name('remoteB')
                url('git@server:account/repo1.git')
            }
            extensions {
                submoduleOptions {
                     timeout(40)
                }
            }
        }
    }
}

```