### PR TITLE
[JENKINS-33968] Enhanced git with submodule reference repo

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitExtensionContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitExtensionContext.groovy
@@ -69,13 +69,16 @@ class GitExtensionContext extends AbstractContext {
      * Specifies behaviors for handling sub-modules.
      */
     void submoduleOptions(@DslContext(GitSubmoduleOptionsContext) Closure closure) {
-        GitSubmoduleOptionsContext context = new GitSubmoduleOptionsContext()
+        GitSubmoduleOptionsContext context = new GitSubmoduleOptionsContext(jobManagement)
         executeInContext(closure, context)
 
         extensions << NodeBuilder.newInstance().'hudson.plugins.git.extensions.impl.SubmoduleOption' {
             disableSubmodules(context.disable)
             recursiveSubmodules(context.recursive)
             trackingSubmodules(context.tracking)
+            if (jobManagement.isMinimumPluginVersionInstalled('git', '2.4.1')) {
+                reference(context.reference)
+            }
         }
     }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitSubmoduleOptionsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitSubmoduleOptionsContext.groovy
@@ -1,11 +1,18 @@
 package javaposse.jobdsl.dsl.helpers.scm
 
-import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.AbstractContext
+import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.RequiresPlugin
 
-class GitSubmoduleOptionsContext implements Context {
+class GitSubmoduleOptionsContext extends AbstractContext {
     boolean disable
     boolean recursive
     boolean tracking
+    String reference
+
+    protected GitSubmoduleOptionsContext(JobManagement jobManagement) {
+        super(jobManagement)
+    }
 
     /**
      * Disables submodules processing. Defaults to {@code false}.
@@ -26,5 +33,14 @@ class GitSubmoduleOptionsContext implements Context {
      */
     void tracking(boolean tracking = true) {
         this.tracking = tracking
+    }
+
+    /**
+     * Specify a folder containing a repository that will be used by Git as a reference during clone operations.
+     * @since 1.45
+     */
+    @RequiresPlugin(id = 'git', minimumVersion = '2.4.1')
+    void reference(String reference) {
+        this.reference = reference
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
@@ -1554,6 +1554,9 @@ class ScmContextSpec extends Specification {
     }
 
     def 'call git scm with full submodule options'() {
+        setup:
+        mockJobManagement.isMinimumPluginVersionInstalled('git', '2.4.1') >> true
+
         when:
         context.git {
             remote {
@@ -1564,6 +1567,7 @@ class ScmContextSpec extends Specification {
                     disable()
                     recursive()
                     tracking()
+                    reference('/foo')
                 }
             }
         }
@@ -1574,10 +1578,11 @@ class ScmContextSpec extends Specification {
             extensions.size() == 1
             extensions[0].children().size() == 1
             with(extensions[0].'hudson.plugins.git.extensions.impl.SubmoduleOption'[0]) {
-                children().size() == 3
+                children().size() == 4
                 disableSubmodules[0].value() == true
                 recursiveSubmodules[0].value() == true
                 trackingSubmodules[0].value() == true
+                reference[0].value() == '/foo'
             }
         }
         1 * mockJobManagement.requireMinimumPluginVersion('git', '2.2.6')


### PR DESCRIPTION
- [JENKINS-33968](https://issues.jenkins-ci.org/browse/JENKINS-33968)

```groovy
job('example-1') {
    scm {
        git {
            remote {
                name('remoteB')
                url('git@server:account/repo1.git')
            }
            extensions {
                submoduleOptions {
                     reference('/foo/bar')
                }
            }
        }
    }
}

```