### PR TITLE
Add GitHub branch source support

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/workflow/BranchSourcesContext/github.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/workflow/BranchSourcesContext/github.groovy
@@ -1,0 +1,9 @@
+multibranchWorkflowJob('example') {
+    branchSources {
+        github {
+            scanCredentialsId('github-ci')
+            repoOwner('OwnerName')
+            repository('job-dsl-plugin')
+        }
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/BranchSourcesContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/BranchSourcesContext.groovy
@@ -28,4 +28,28 @@ class BranchSourcesContext implements Context {
             }
         }
     }
+    /**
+     * Adds a GitHub branch source. Can be called multiple times to add more branch sources.
+     */
+    void github(@DslContext(GitHubBranchSourceContext) Closure branchSourceClosure) {
+        GitHubBranchSourceContext context = new GitHubBranchSourceContext()
+        ContextHelper.executeInContext(branchSourceClosure, context)
+
+        branchSourceNodes << new NodeBuilder().'jenkins.branch.BranchSource' {
+            source(class: 'org.jenkinsci.plugins.github_branch_source.GitHubSCMSource') {
+                id(UUID.randomUUID())
+                apiUri(context.apiUri ?: '')
+                scanCredentialsId(context.scanCredentialsId ?: '')
+                checkoutCredentialsId(context.checkoutCredentialsId ?: '')
+                repoOwner(context.repoOwner ?: '')
+                repository(context.repository ?: '')
+                includes(context.includes ?: '')
+                excludes(context.excludes ?: '')
+                ignoreOnPushNotifications(context.ignoreOnPushNotifications)
+            }
+            strategy(class: 'jenkins.branch.DefaultBranchPropertyStrategy') {
+                properties(class: 'empty-list')
+            }
+        }
+    }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/GitHubBranchSourceContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/GitHubBranchSourceContext.groovy
@@ -1,0 +1,70 @@
+package javaposse.jobdsl.dsl.helpers.workflow
+
+import javaposse.jobdsl.dsl.Context
+
+class GitHubBranchSourceContext implements Context {
+    String apiUri = 'https://api.github.com'
+    String scanCredentialsId
+    String checkoutCredentialsId = 'SAME'
+    String repoOwner
+    String repository
+    String includes = '*'
+    String excludes
+    boolean ignoreOnPushNotifications
+
+    /**
+     * Sets the GitHub api Uri
+     */
+    void apiUri(String apiUri) {
+        this.apiUri = apiUri
+    }
+
+    /**
+     * Sets scan credentials for authentication with Github.
+     */
+    void scanCredentialsId(String scanCredentialsId) {
+        this.scanCredentialsId = scanCredentialsId
+    }
+
+    /**
+     * Sets checkout credentials for authentication with Github (defaults to scan credentials).
+     */
+    void checkoutCredentialsId(String checkoutCredentialsId) {
+        this.checkoutCredentialsId = checkoutCredentialsId
+    }
+
+    /**
+     * Sets name of the GitHub Organization or GitHub User Account.
+     */
+    void repoOwner(String repoOwner) {
+        this.repoOwner = repoOwner
+    }
+
+    /**
+     * Sets name of the GitHub repository.
+     */
+    void repository(String repository) {
+        this.repository = repository
+    }
+
+    /**
+     * Sets a pattern for branches to include.
+     */
+    void includes(String includes) {
+        this.includes = includes
+    }
+
+    /**
+     * Sets a pattern for branches to exclude.
+     */
+    void excludes(String excludes) {
+        this.excludes = excludes
+    }
+
+    /**
+     * If set, ignores push notifications. Defaults to {@code false}.
+     */
+    void ignoreOnPushNotifications(boolean ignoreOnPushNotifications = true) {
+        this.ignoreOnPushNotifications = ignoreOnPushNotifications
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/workflow/BranchSourcesContextsSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/workflow/BranchSourcesContextsSpec.groovy
@@ -64,4 +64,73 @@ class BranchSourcesContextsSpec extends Specification {
             }
         }
     }
+
+    def 'github with minimal options'() {
+        when:
+        context.github {}
+
+        then:
+        context.branchSourceNodes.size() == 1
+        with(context.branchSourceNodes[0]) {
+            name() == 'jenkins.branch.BranchSource'
+            children().size() == 2
+            with(source[0]) {
+                children().size() == 9
+                id[0].value() instanceof UUID
+                apiUri[0].value() == 'https://api.github.com'
+                scanCredentialsId[0].value().empty
+                checkoutCredentialsId[0].value() == 'SAME'
+                repoOwner[0].value().empty
+                repository[0].value().empty
+                includes[0].value() == '*'
+                excludes[0].value().empty
+                ignoreOnPushNotifications[0].value() == false
+            }
+            with(strategy[0]) {
+                children().size() == 1
+                attribute('class') == 'jenkins.branch.DefaultBranchPropertyStrategy'
+                properties[0].value().empty
+                properties[0].attribute('class') == 'empty-list'
+            }
+        }
+    }
+
+    def 'github with all options'() {
+        when:
+        context.github {
+            apiUri('https://custom.url')
+            scanCredentialsId('scanCreds')
+            checkoutCredentialsId('checkoutCreds')
+            repoOwner('ownerName')
+            repository('repoName')
+            includes('lorem')
+            excludes('ipsum')
+            ignoreOnPushNotifications()
+        }
+
+        then:
+        context.branchSourceNodes.size() == 1
+        with(context.branchSourceNodes[0]) {
+            name() == 'jenkins.branch.BranchSource'
+            children().size() == 2
+            with(source[0]) {
+                children().size() == 9
+                id[0].value() instanceof UUID
+                apiUri[0].value() == 'https://custom.url'
+                scanCredentialsId[0].value() == 'scanCreds'
+                checkoutCredentialsId[0].value() == 'checkoutCreds'
+                repoOwner[0].value() == 'ownerName'
+                repository[0].value() == 'repoName'
+                includes[0].value() == 'lorem'
+                excludes[0].value() == 'ipsum'
+                ignoreOnPushNotifications[0].value() == true
+            }
+            with(strategy[0]) {
+                children().size() == 1
+                attribute('class') == 'jenkins.branch.DefaultBranchPropertyStrategy'
+                properties[0].value().empty
+                properties[0].attribute('class') == 'empty-list'
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adds support for the github-branch-source plugin to the Jenkins DSL for multibranch workflow (now called Pipeline) jobs (https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+GitHub+Branch+Source+Plugin)