### PR TITLE
Updated git repo for tutorial and triggers to new H/ format instead of */

### DIFF
--- a/docs/Tutorial---Using-the-Jenkins-Job-DSL.md
+++ b/docs/Tutorial---Using-the-Jenkins-Job-DSL.md
@@ -34,10 +34,10 @@ Now that we have created our empty Seed Job we need to configure it. We're going
 ```
 job('DSL-Tutorial-1-Test') {
     scm {
-        git('git://github.com/jgritman/aws-sdk-test.git')
+        git('git://github.com/quidryan/aws-sdk-test.git')
     }
     triggers {
-        scm('*/15 * * * *')
+        scm('H/15 * * * *')
     }
     steps {
         maven('-e clean test')


### PR DESCRIPTION
Updated the git repo to pull from quidryan in the first tutorial which works for all of the demo projects for job-dsl-plugin and updated the Jenkins SCM triggers timer to H/15 from */15 to follow Jenkins best practices.