### PR TITLE
Add support for extracting related JIRA environment variables

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/step/StepContext/extractJiraEnvironmentVariables.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/step/StepContext/extractJiraEnvironmentVariables.groovy
@@ -1,0 +1,5 @@
+job('example') {
+    steps {
+        extractJiraEnvironmentVariables()
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -1135,6 +1135,19 @@ class StepContext extends AbstractExtensibleContext {
     }
 
     /**
+     * Extracts JIRA information for the build to environment variables.
+     *
+     * {@code JIRA_ISSUES} - A comma separated list of issues referenced in the version control system changelog
+     * {@code JIRA_URL} - Primary URL for the JIRA server
+     *
+     * @since 1.46
+    */
+    @RequiresPlugin(id = 'jira', minimumVersion = '2.2')
+    void extractJiraEnvironmentVariables() {
+        stepNodes << new NodeBuilder().'hudson.plugins.jira.JiraEnvironmentVariableBuilder'()
+    }
+
+    /**
      * Invokes a CMake build script.
      *
      * @since 1.45

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
@@ -3637,6 +3637,17 @@ class StepContextSpec extends Specification {
         'key1' | 'key2' | 'key3' | 'key1'      | 'key2'       | 'key3'
     }
 
+    def 'call extractJiraEnvironmentVariables method'() {
+        when:
+        context.extractJiraEnvironmentVariables()
+
+        then:
+        context.stepNodes != null
+        context.stepNodes.size() == 1
+        context.stepNodes[0].name() == 'hudson.plugins.jira.JiraEnvironmentVariableBuilder'
+        1 * jobManagement.requireMinimumPluginVersion('jira', '2.2')
+    }
+
     def 'call cmake methods with no options'() {
         when:
         context.cmake {


### PR DESCRIPTION
The JIRA plugin support was missing this feature implemented in version 2.2 of the plugin.