### PR TITLE
[JENKINS-34534] support for gitlab-plugin 1.2.0

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -90,6 +90,8 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
    ([JENKINS-30323](https://issues.jenkins-ci.org/browse/JENKINS-30323))
  * Enhanced support for the [JIRA Plugin](https://wiki.jenkins-ci.org/display/JENKINS/JIRA+Plugin)
    ([#834](https://github.com/jenkinsci/job-dsl-plugin/pull/834))
+ * Enhanced support for the [Gitlab Plugin](https://wiki.jenkins-ci.org/display/JENKINS/GitLab+Plugin)
+   ([JENKINS-34534](https://issues.jenkins-ci.org/browse/JENKINS-34534))
  * Removed anything that has been deprecated in 1.40, see [Migration](Migration#migrating-to-140)
  * Changed the behavior of the `currentJobParameters` method in the `phaseJob` context, see
    [Migration](Migration#migrating-to-146)

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext/gitlabPush.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext/gitlabPush.groovy
@@ -10,7 +10,7 @@ job('example') {
             addVoteOnMergeRequest(false)
             useCiFeatures(false)
             acceptMergeRequestOnSuccess()
-            allowAllBranches(false)
+            branchFilterType('all')
             includeBranches('include1,include2')
             excludeBranches('exclude1,exclude2')
         }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GitLabTriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GitLabTriggerContext.groovy
@@ -6,10 +6,13 @@ import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
 class GitLabTriggerContext implements Context {
     private static final Set<String> VALID_EXECUTION_STATUSES = ['never', 'source', 'both']
+    private static final Set<String> VALID_BRANCH_FILTER_TYPES = ['all', 'nameBasedFilter', 'regexBasedFilter']
 
     String includeBranches = ''
     String excludeBranches = ''
+    String targetBranchRegex = ''
     String rebuildOpenMergeRequest = 'never'
+    String branchFilterType = 'all'
     boolean buildOnMergeRequestEvents = true
     boolean buildOnPushEvents = true
     boolean enableCiSkip = true
@@ -32,6 +35,15 @@ class GitLabTriggerContext implements Context {
      */
     void excludeBranches(String excludeBranches) {
         this.excludeBranches = excludeBranches
+    }
+
+    /**
+     * The target branch regex allows to limit the execution of this job to
+     * certain branches. Any branch matching the specified pattern triggers the
+     * job.
+     */
+    void targetBranchRegex(String targetBranchRegex) {
+        this.targetBranchRegex = targetBranchRegex
     }
 
     /**
@@ -93,8 +105,22 @@ class GitLabTriggerContext implements Context {
     /**
      * If set, ignores filtered branches. Defaults to {@code false}.
      */
+    @Deprecated
     void allowAllBranches(boolean allowAllBranches = true) {
         this.allowAllBranches = allowAllBranches
+    }
+
+    /**
+     * Sets branch filter type. Defaults to {@code 'all'}.
+     *
+     * Possible values are {@code 'all'}, {@code 'nameBasedFilter'}, {@code 'regexBasedFilter'}.
+     */
+    void branchFilterType(String branchFilterType) {
+        checkArgument(
+            VALID_BRANCH_FILTER_TYPES.contains(branchFilterType),
+            "branchFilter type must be one of ${VALID_BRANCH_FILTER_TYPES.join(', ')}"
+        )
+        this.branchFilterType = branchFilterType
     }
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
@@ -204,6 +204,8 @@ class TriggerContext extends ItemTriggerContext {
      */
     @RequiresPlugin(id = 'gitlab-plugin', minimumVersion = '1.1.28')
     void gitlabPush(@DslContext(GitLabTriggerContext) Closure closure) {
+        jobManagement.logPluginDeprecationWarning('gitlab-plugin', '1.2.0')
+
         GitLabTriggerContext context = new GitLabTriggerContext()
         ContextHelper.executeInContext(closure, context)
 
@@ -217,10 +219,15 @@ class TriggerContext extends ItemTriggerContext {
             addNoteOnMergeRequest(context.addNoteOnMergeRequest)
             addCiMessage(context.useCiFeatures)
             addVoteOnMergeRequest(context.addVoteOnMergeRequest)
-            allowAllBranches(context.allowAllBranches)
             includeBranchesSpec(context.includeBranches ?: '')
             excludeBranchesSpec(context.excludeBranches ?: '')
             acceptMergeRequestOnSuccess(context.acceptMergeRequestOnSuccess)
+            if (jobManagement.isMinimumPluginVersionInstalled('gitlab-plugin', '1.2.0')) {
+                branchFilterType(context.branchFilterType)
+                targetBranchRegex(context.targetBranchRegex ?: '')
+            } else {
+                allowAllBranches(context.allowAllBranches)
+            }
         }
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
@@ -376,9 +376,88 @@ class TriggerContextSpec extends Specification {
             acceptMergeRequestOnSuccess[0].value() == false
         }
         1 * mockJobManagement.requireMinimumPluginVersion('gitlab-plugin', '1.1.28')
+        1 * mockJobManagement.logPluginDeprecationWarning('gitlab-plugin', '1.2.0')
+    }
+
+    def 'call gitlabPush trigger with no options, plugin version 1.2.x'() {
+        setup:
+        mockJobManagement.isMinimumPluginVersionInstalled('gitlab-plugin', '1.2.0') >> true
+
+        when:
+        context.gitlabPush {
+        }
+
+        then:
+        with(context.triggerNodes[0]) {
+            name() == 'com.dabsquared.gitlabjenkins.GitLabPushTrigger'
+            children().size() == 14
+            spec[0].value().empty
+            triggerOnPush[0].value() == true
+            triggerOnMergeRequest[0].value() == true
+            triggerOpenMergeRequestOnPush[0].value() == 'never'
+            ciSkip[0].value() == true
+            setBuildDescription[0].value() == true
+            addNoteOnMergeRequest[0].value() == true
+            addCiMessage[0].value() == false
+            addVoteOnMergeRequest[0].value() == true
+            branchFilterType[0].value() == 'all'
+            includeBranchesSpec[0].value().empty
+            excludeBranchesSpec[0].value().empty
+            targetBranchRegex[0].value().empty
+            acceptMergeRequestOnSuccess[0].value() == false
+        }
+        1 * mockJobManagement.requireMinimumPluginVersion('gitlab-plugin', '1.1.28')
+        1 * mockJobManagement.logPluginDeprecationWarning('gitlab-plugin', '1.2.0')
     }
 
     def 'call gitlabPush trigger with all options'() {
+        setup:
+        mockJobManagement.isMinimumPluginVersionInstalled('gitlab-plugin', '1.2.0') >> true
+
+        when:
+        context.gitlabPush {
+            buildOnMergeRequestEvents(value)
+            buildOnPushEvents(value)
+            enableCiSkip(value)
+            setBuildDescription(value)
+            addNoteOnMergeRequest(value)
+            rebuildOpenMergeRequest('both')
+            addVoteOnMergeRequest(value)
+            useCiFeatures(value)
+            acceptMergeRequestOnSuccess(value)
+            branchFilterType('all')
+            includeBranches('include1,include2')
+            excludeBranches('exclude1,exclude2')
+            targetBranchRegex('(.*debug.*|.*release.*)')
+        }
+
+        then:
+        with(context.triggerNodes[0]) {
+            name() == 'com.dabsquared.gitlabjenkins.GitLabPushTrigger'
+            children().size() == 14
+            spec[0].value().empty
+            triggerOnPush[0].value() == value
+            triggerOnMergeRequest[0].value() == value
+            triggerOpenMergeRequestOnPush[0].value() == 'both'
+            ciSkip[0].value() == value
+            setBuildDescription[0].value() == value
+            addNoteOnMergeRequest[0].value() == value
+            addCiMessage[0].value() == value
+            addVoteOnMergeRequest[0].value() == value
+            branchFilterType[0].value() == 'all'
+            includeBranchesSpec[0].value() == 'include1,include2'
+            excludeBranchesSpec[0].value() == 'exclude1,exclude2'
+            targetBranchRegex[0].value() == '(.*debug.*|.*release.*)'
+            acceptMergeRequestOnSuccess[0].value() == value
+        }
+        1 * mockJobManagement.requireMinimumPluginVersion('gitlab-plugin', '1.1.28')
+        1 * mockJobManagement.logPluginDeprecationWarning('gitlab-plugin', '1.2.0')
+
+        where:
+        value << [true, false]
+    }
+
+    def 'call gitlabPush trigger with all options, plugin version older than 1.2.0'() {
         when:
         context.gitlabPush {
             buildOnMergeRequestEvents(value)
@@ -414,6 +493,7 @@ class TriggerContextSpec extends Specification {
             acceptMergeRequestOnSuccess[0].value() == value
         }
         1 * mockJobManagement.requireMinimumPluginVersion('gitlab-plugin', '1.1.28')
+        1 * mockJobManagement.logPluginDeprecationWarning('gitlab-plugin', '1.2.0')
 
         where:
         value << [true, false]


### PR DESCRIPTION
- `allowAllBraches` paramater was replaced by `branchFilterType`
- new parameter `targetBranchRegex`
- new property `gitlabConnection` which sets the gitlab connection a job
  should use