### PR TITLE
Don't set CurrentBuildParameters when currentJobParameters is called …

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/PhaseJobContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/PhaseJobContext.groovy
@@ -32,7 +32,9 @@ class PhaseJobContext extends AbstractContext {
      */
     void currentJobParameters(boolean currentJobParameters = true) {
         this.currentJobParameters = currentJobParameters
-        paramTrigger.currentBuild()
+        if (currentJobParameters) {
+            paramTrigger.currentBuild()
+        }
     }
 
     /**


### PR DESCRIPTION
…with false

Found an issue where if you call currentJobParameters(false) in a PhaseJob, it still calls DownstreamTriggerParameterContext.currentBuild(), which still makes the job pass in its current parameters.