### PR TITLE
Adding pipelineJob/multibranchPipelineJob methods.

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/DslFactory/multibranchPipelineJob.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/DslFactory/multibranchPipelineJob.groovy
@@ -1,0 +1,14 @@
+multibranchPipelineJob('example') {
+    branchSources {
+        git {
+            remote('https://github.com/jenkinsci/job-dsl-plugin.git')
+            credentialsId('github-ci')
+            includes('JENKINS-*')
+        }
+    }
+    orphanedItemStrategy {
+        discardOldItems {
+            numToKeep(20)
+        }
+    }
+}

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/DslFactory/pipelineJob.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/DslFactory/pipelineJob.groovy
@@ -1,0 +1,8 @@
+pipelineJob('example') {
+    definition {
+        cps {
+            script(readFileFromWorkspace('project-a-workflow.groovy'))
+            sandbox()
+        }
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
@@ -144,7 +144,8 @@ interface DslFactory extends ViewFactory {
     WorkflowJob workflowJob(String name, @DslContext(WorkflowJob) Closure closure)
 
     /**
-     * Create or updates a pipeline job - alias for #workflowJob(java.lang.String).
+     * Create or updates a pipeline job.
+     * Alias for #workflowJob(java.lang.String).
      *
      * @since 1.47
      * @see #workflowJob(java.lang.String, groovy.lang.Closure)
@@ -153,7 +154,8 @@ interface DslFactory extends ViewFactory {
     WorkflowJob pipelineJob(String name)
 
     /**
-     * Create or updates a workflow job - alias for #workflowJob(java.lang.String, groovy.lang.Closure)
+     * Create or updates a workflow job.
+     * Alias for #workflowJob(java.lang.String, groovy.lang.Closure)
      *
      * @since 1.47
      */
@@ -178,7 +180,8 @@ interface DslFactory extends ViewFactory {
     MultibranchWorkflowJob multibranchWorkflowJob(String name, @DslContext(MultibranchWorkflowJob) Closure closure)
 
     /**
-     * Create or updates a multibranch pipeline job - alias for #multibranchWorkflowJob(java.lang.String).
+     * Create or updates a multibranch pipeline job.
+     * Alias for #multibranchWorkflowJob(java.lang.String).
      *
      * @since 1.47
      * @see #multibranchWorkflowJob(java.lang.String, groovy.lang.Closure)
@@ -187,7 +190,8 @@ interface DslFactory extends ViewFactory {
     MultibranchWorkflowJob multibranchPipelineJob(String name)
 
     /**
-     * Creates or updates a multibranch pipeline job - alias for #multibranchWorkflowJob(java.lang.String, groovy.lang.Closure).
+     * Creates or updates a multibranch pipeline job.
+     * Alias for #multibranchWorkflowJob(java.lang.String, groovy.lang.Closure).
      *
      * @since 1.47
      */

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
@@ -144,6 +144,23 @@ interface DslFactory extends ViewFactory {
     WorkflowJob workflowJob(String name, @DslContext(WorkflowJob) Closure closure)
 
     /**
+     * Create or updates a pipeline job - alias for #workflowJob(java.lang.String).
+     *
+     * @since 1.47
+     * @see #workflowJob(java.lang.String, groovy.lang.Closure)
+     */
+    @RequiresPlugin(id = 'workflow-aggregator')
+    WorkflowJob pipelineJob(String name)
+
+    /**
+     * Create or updates a workflow job - alias for #workflowJob(java.lang.String, groovy.lang.Closure)
+     *
+     * @since 1.47
+     */
+    @RequiresPlugin(id = 'workflow-aggregator')
+    WorkflowJob pipelineJob(String name, @DslContext(WorkflowJob) Closure closure)
+
+    /**
      * Create or updates a multibranch workflow job.
      *
      * @since 1.42
@@ -159,6 +176,23 @@ interface DslFactory extends ViewFactory {
      */
     @RequiresPlugin(id = 'workflow-multibranch', minimumVersion = '1.12')
     MultibranchWorkflowJob multibranchWorkflowJob(String name, @DslContext(MultibranchWorkflowJob) Closure closure)
+
+    /**
+     * Create or updates a multibranch pipeline job - alias for #multibranchWorkflowJob(java.lang.String).
+     *
+     * @since 1.47
+     * @see #multibranchWorkflowJob(java.lang.String, groovy.lang.Closure)
+     */
+    @RequiresPlugin(id = 'workflow-multibranch', minimumVersion = '1.12')
+    MultibranchWorkflowJob multibranchPipelineJob(String name)
+
+    /**
+     * Creates or updates a multibranch pipeline job - alias for #multibranchWorkflowJob(java.lang.String, groovy.lang.Closure).
+     *
+     * @since 1.47
+     */
+    @RequiresPlugin(id = 'workflow-multibranch', minimumVersion = '1.12')
+    MultibranchWorkflowJob multibranchPipelineJob(String name, @DslContext(MultibranchWorkflowJob) Closure closure)
 
     /**
      * Creates or updates a folder.

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
@@ -130,8 +130,10 @@ interface DslFactory extends ViewFactory {
      * Create or updates a workflow job.
      *
      * @since 1.30
+     * @deprecated as of 1.47. Use #pipelineJob(java.lang.String, groovy.lang.Closure) instead.
      * @see #workflowJob(java.lang.String, groovy.lang.Closure)
      */
+    @Deprecated
     @RequiresPlugin(id = 'workflow-aggregator')
     WorkflowJob workflowJob(String name)
 
@@ -139,7 +141,9 @@ interface DslFactory extends ViewFactory {
      * Create or updates a workflow job.
      *
      * @since 1.31
+     * @deprecated as of 1.47. Use #pipelineJob(java.lang.String, groovy.lang.Closure) instead.
      */
+    @Deprecated
     @RequiresPlugin(id = 'workflow-aggregator')
     WorkflowJob workflowJob(String name, @DslContext(WorkflowJob) Closure closure)
 
@@ -166,8 +170,10 @@ interface DslFactory extends ViewFactory {
      * Create or updates a multibranch workflow job.
      *
      * @since 1.42
+     * @deprecated as of 1.47. Use #multibranchPipelineJob(java.lang.String, groovy.lang.Closure) instead.
      * @see #multibranchWorkflowJob(java.lang.String, groovy.lang.Closure)
      */
+    @Deprecated
     @RequiresPlugin(id = 'workflow-multibranch', minimumVersion = '1.12')
     MultibranchWorkflowJob multibranchWorkflowJob(String name)
 
@@ -175,7 +181,9 @@ interface DslFactory extends ViewFactory {
      * Creates or updates a multibranch workflow job.
      *
      * @since 1.42
+     * @deprecated as of 1.47. Use #multibranchPipelineJob(java.lang.String, groovy.lang.Closure) instead.
      */
+    @Deprecated
     @RequiresPlugin(id = 'workflow-multibranch', minimumVersion = '1.12')
     MultibranchWorkflowJob multibranchWorkflowJob(String name, @DslContext(MultibranchWorkflowJob) Closure closure)
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
@@ -88,7 +88,9 @@ abstract class JobParent extends Script implements DslFactory {
 
     /**
      * @since 1.30
+     * @deprecated as of 1.47. Use #pipelineJob(java.lang.String, groovy.lang.Closure) instead.
      */
+    @Deprecated
     @Override
     WorkflowJob workflowJob(String name, @DslContext(WorkflowJob) Closure closure = null) {
         processItem(name, WorkflowJob, closure)
@@ -104,6 +106,7 @@ abstract class JobParent extends Script implements DslFactory {
 
     /**
      * @since 1.42
+     * @deprecated as of 1.47. Use #multibranchPipelineJob(java.lang.String, groovy.lang.Closure) instead.
      */
     @Override
     MultibranchWorkflowJob multibranchWorkflowJob(String name,

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
@@ -95,10 +95,27 @@ abstract class JobParent extends Script implements DslFactory {
     }
 
     /**
+     * @since 1.47
+     */
+    @Override
+    WorkflowJob pipelineJob(String name, @DslContext(WorkflowJob) Closure closure = null) {
+        processItem(name, WorkflowJob, closure)
+    }
+
+    /**
      * @since 1.42
      */
     @Override
     MultibranchWorkflowJob multibranchWorkflowJob(String name,
+                                                  @DslContext(MultibranchWorkflowJob) Closure closure = null) {
+        processItem(name, MultibranchWorkflowJob, closure)
+    }
+
+    /**
+     * @since 1.47
+     */
+    @Override
+    MultibranchWorkflowJob multibranchPipelineJob(String name,
                                                   @DslContext(MultibranchWorkflowJob) Closure closure = null) {
         processItem(name, MultibranchWorkflowJob, closure)
     }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobParentSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobParentSpec.groovy
@@ -527,9 +527,31 @@ class JobParentSpec extends Specification {
         1 * jobManagement.requirePlugin('workflow-aggregator')
     }
 
+    def 'pipeline'() {
+        when:
+        WorkflowJob job = parent.pipelineJob('test') {
+        }
+
+        then:
+        job.name == 'test'
+        parent.referencedJobs.contains(job)
+        1 * jobManagement.requirePlugin('workflow-aggregator')
+    }
+
     def 'multibranchWorkflowJob'() {
         when:
         MultibranchWorkflowJob job = parent.multibranchWorkflowJob('test') {
+        }
+
+        then:
+        job.name == 'test'
+        parent.referencedJobs.contains(job)
+        1 * jobManagement.requireMinimumPluginVersion('workflow-multibranch', '1.12')
+    }
+
+    def 'multibranchPipelineJob'() {
+        when:
+        MultibranchWorkflowJob job = parent.multibranchPipelineJob('test') {
         }
 
         then:


### PR DESCRIPTION
I've noticed some confusion on the part of users when they don't see
"pipelineJob" available in Job DSL, just "workflowJob", since Workflow
got renamed to Pipeline and all. Adding these methods should help with
that. I didn't change everything referencing "workflowJob" in docs to
"pipelineJob", though. Not sure what the right approach there is.

cc @reviewbybees