### PR TITLE
[Jenkins-35084] (use sonar build wrapper)

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -190,6 +190,14 @@ class WrapperContext extends AbstractExtensibleContext {
     }
 
     /**
+     * Use sonar build wrapper
+     */
+    @RequiresPlugin(id = 'sonar', minimumVersion = '2.4')
+    void useSonarBuildWrapper() {
+        wrapperNodes << new NodeBuilder().'hudson.plugins.sonar.SonarBuildWrapper'()
+    }
+
+    /**
      * Run a Xvnc session during a build.
      *
      * @since 1.26

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -22,6 +22,17 @@ class WrapperContextSpec extends Specification {
         1 * mockJobManagement.requirePlugin('timestamper')
     }
 
+    def 'call use sonar build wrapper'() {
+        when:
+        context.useSonarBuildWrapper()
+
+        then:
+        context.wrapperNodes?.size() == 1
+        def sonarBuildWrapper = context.wrapperNodes[0]
+        sonarBuildWrapper.name() == 'hudson.plugins.sonar.SonarBuildWrapper'
+        1 * mockJobManagement.requireMinimumPluginVersion('sonar', '2.4')
+    }
+
     def 'run on same node'() {
         when:
         context.runOnSameNodeAs('testJob')


### PR DESCRIPTION
Allow for to use the sonar build wrapper thru job-dsl. https://issues.jenkins-ci.org/browse/JENKINS-35084