### PR TITLE
[FIXED JENKINS-35228] Not possible to use String in absolute timeout

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -27,6 +27,8 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
 
 ## Release Notes
 * 1.48 (unreleased)
+ * Improved support for the [Build-timeout Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build-timeout+Plugin)
+   ([JENKINS-35228](https://issues.jenkins-ci.org/browse/JENKINS-35228))
  * Made `ExecuteDslScripts` build step compatible with [Pipeline Plugin](https://github.com/jenkinsci/pipeline-plugin)
    ([JENKINS-35282](https://issues.jenkins-ci.org/browse/JENKINS-35282))
  * Several classes and some constructors have been deprecated, see [Migration](Migration#migrating-to-148)

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext/timeout.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext/timeout.groovy
@@ -44,3 +44,35 @@ job('example-5') {
         }
     }
 }
+
+// defines an absolute timeout with a maximum build time of 5 minutes via String type
+job('example-6') {
+    wrappers {
+        timeout {
+            absolute('5')
+        }
+    }
+}
+
+// defines an absolute timeout using a prepare environment variable 
+job('example-7') {
+    wrappers {
+        timeout {
+          absolute('${JOB_TIMEOUT}')
+        }
+    }
+}
+
+// defines an absolute timeout using the string parameter
+// then you can use the parameterized build to set the absolute timeout 
+job('example-8') {
+    parameters {
+        stringParam('MY_JOB_TIMEOUT', '5', 'my description')
+    }
+  
+    wrappers {
+        timeout {
+          absolute('${MY_JOB_TIMEOUT}')
+        }
+    }
+}

--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext/timeout.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext/timeout.groovy
@@ -54,7 +54,7 @@ job('example-6') {
     }
 }
 
-// defines an absolute timeout using a prepare environment variable 
+// defines an absolute timeout using a prepare environment variable
 job('example-7') {
     wrappers {
         timeout {
@@ -64,12 +64,12 @@ job('example-7') {
 }
 
 // defines an absolute timeout using the string parameter
-// then you can use the parameterized build to set the absolute timeout 
+// then you can use the parameterized build to set the absolute timeout
 job('example-8') {
     parameters {
         stringParam('MY_JOB_TIMEOUT', '5', 'my description')
     }
-  
+
     wrappers {
         timeout {
           absolute('${MY_JOB_TIMEOUT}')

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/TimeoutContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/TimeoutContext.groovy
@@ -54,7 +54,7 @@ class TimeoutContext extends AbstractContext {
             timeoutMinutes(minutes)
         }
     }
-    
+
     /**
      * Aborts the build based on a fixed time-out. (may be a digital string or a Macro Token)
      *

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/TimeoutContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/TimeoutContext.groovy
@@ -54,6 +54,17 @@ class TimeoutContext extends AbstractContext {
             timeoutMinutes(minutes)
         }
     }
+    
+    /**
+     * Aborts the build based on a fixed time-out. (may be a digital string or a Macro Token)
+     *
+     * @since 1.48
+     */
+    void absolute(String minutes) {
+      setStrategy('Absolute') {
+            timeoutMinutes(minutes)
+      }
+    }
 
     /**
      * Uses a heuristics based approach to detect builds that are suspiciously running for a long time.

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -158,6 +158,23 @@ class WrapperContextSpec extends Specification {
         1 * mockJobManagement.requireMinimumPluginVersion('build-timeout', '1.12')
     }
 
+    def 'absolute timeout configuration working using string type'() {
+        when:
+        context.timeout {
+            absolute('${TEST_JOB_TIMEOUT}')
+        }
+
+        then:
+        with(context.wrapperNodes[0]) {
+            children().size() == 2
+            strategy[0].children().size() == 1
+            strategy[0].@class == 'hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy'
+            strategy[0].timeoutMinutes[0].value() == '${TEST_JOB_TIMEOUT}'
+            operationList[0].children().size() == 0
+        }
+        1 * mockJobManagement.requireMinimumPluginVersion('build-timeout', '1.12')
+    }
+
     def 'elastic timeout configuration working'() {
         when:
         context.timeout {


### PR DESCRIPTION
# DONE
* Now it can use "String type" in absolute timeout. (fixed [JENKINS-35228](https://issues.jenkins-ci.org/browse/JENKINS-35228))
* Added 3 examples to API document.
* Update the release note
* Added a test case: Test absolute timeout configuration working using string type