### PR TITLE
[FIXED JENKINS-34367] Add support for empty sendTo field for extendedEmail plugin

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -27,6 +27,8 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
 
 ## Release Notes
 * 1.48 (unreleased)
+ * Improved support for the [Email-ext plugin](https://wiki.jenkins-ci.org/display/JENKINS/Email-ext+plugin)
+   ([JENKINS-34367](https://issues.jenkins-ci.org/browse/JENKINS-34367))
  * Added option to ignore missing DSL script files or empty wildcards
    ([JENKINS-34060](https://issues.jenkins-ci.org/browse/JENKINS-34060))
  * Improved support for the [Build-timeout Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build-timeout+Plugin)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/ExtendedEmailTriggersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/ExtendedEmailTriggersContext.groovy
@@ -130,12 +130,6 @@ class ExtendedEmailTriggersContext implements Context {
         ExtendedEmailTriggerContext context = new ExtendedEmailTriggerContext()
         ContextHelper.executeInContext(closure, context)
 
-        if (context.sendToContext.recipientProviders.empty) {
-            context.sendTo {
-                recipientList()
-            }
-        }
-
         configuredTriggers << new NodeBuilder()."hudson.plugins.emailext.plugins.trigger.${name}Trigger" {
             email {
                 recipientList(context.recipientList.join(', '))

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -128,8 +128,7 @@ class PublisherContextSpec extends Specification {
                         subject[0].value() == '$PROJECT_DEFAULT_SUBJECT'
                         body[0].value() == '$PROJECT_DEFAULT_CONTENT'
                         with(recipientProviders[0]) {
-                            children().size() == 1
-                            children()[0].name() == 'hudson.plugins.emailext.plugins.recipients.ListRecipientProvider'
+                            children().size() == 0
                         }
                         attachmentsPattern[0].value().empty
                         attachBuildLog[0].value() == false


### PR DESCRIPTION
[Fixed [JENKINS-34367](https://issues.jenkins-ci.org/browse/JENKINS-34367)] Add support for empty sendTo field for extendedEmail plugin



Now user can use DSL to define empty sendTo field in Email-ext plugin (https://wiki.jenkins-ci.org/display/JENKINS/Email-ext+plugin)