### PR TITLE
Updates Migration Doc for GitHub Pull Request Builder Plugin

### DIFF
--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -493,34 +493,6 @@ Built-in support for the
 [[deprecated|Deprecation-Policy]] and will be removed. The GitHub Pull Request Builder Plugin implements the Job DSL
 extension point and provides it's own Job DSL syntax since version 1.29.7.
 
-DSL prior to 1.43
-```groovy
-job('example') {
-    triggers {
-        pullRequest {
-        }
-    }
-    publishers {
-        mergePullRequest {
-        }
-    }
-}
-```
-
-DSL since 1.43
-```groovy
-job('example') {
-    triggers {
-        githubPullRequest {
-        }
-    }
-    publishers {
-        mergeGithubPullRequest {
-        }
-    }
-}
-```
-
 ### Docker Custom Build Environment
 
 Support for versions older than 1.6.2 of the [CloudBees Docker Custom Build Environment


### PR DESCRIPTION
Per the README at [ghprb-plugin](https://github.com/jenkinsci/ghprb-plugin) the Triggers method is `pullRequest`. 

The change was made with [this merge](https://github.com/jenkinsci/ghprb-plugin/pull/276)

The update to the Publishers section for mergePullRequest is submitted with [this pull request](https://github.com/jenkinsci/ghprb-plugin/pull/372)