### PR TITLE
[JENKINS-36502] Fix Pipeline Snippet Generator

### DIFF
--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     compile project(':job-dsl-core')
     compile 'org.jenkins-ci:symbol-annotation:1.1'
     jenkinsPlugins 'org.jenkins-ci.plugins:structs:1.2@jar'
+    jenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-step-api:1.15@jar'
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:vsphere-cloud:1.1.11@jar'
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.8.1@jar'
     optionalJenkinsPlugins 'org.jenkinsci.plugins:managed-scripts:1.2.1@jar'


### PR DESCRIPTION
@daspilker
The snippet generator is apparently rather picky about databound values.
If there are databound setters without getters/public-fields, it just returns a class description.

Fix for issue: https://issues.jenkins-ci.org/browse/JENKINS-36502