### PR TITLE
fixed wrapper for xvfb-plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -219,7 +219,7 @@ class WrapperContext extends AbstractExtensibleContext {
         XvfbContext context = new XvfbContext()
         ContextHelper.executeInContext(closure, context)
 
-        wrapperNodes << new NodeBuilder().'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper' {
+        wrapperNodes << new NodeBuilder().'org.jenkinsci.plugins.xvfb.Xvfb' {
             installationName(installation)
             screen(context.screen)
             debug(context.debug)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -400,7 +400,7 @@ class WrapperContextSpec extends Specification {
 
         then:
         with(context.wrapperNodes[0]) {
-            name() == 'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'
+            name() == 'org.jenkinsci.plugins.xvfb.Xvfb'
             children().size() == 8
             installationName[0].value() == 'default'
             screen[0].value() == '1024x768x24'

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -429,7 +429,7 @@ class WrapperContextSpec extends Specification {
 
         then:
         with(context.wrapperNodes[0]) {
-            name() == 'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'
+            name() == 'org.jenkinsci.plugins.xvfb.Xvfb'
             children().size() == 9
             installationName[0].value() == 'default'
             screen[0].value() == '1920x1080x32'


### PR DESCRIPTION
- the dsl plugin is now generating proper xml for the xvfb-plugin
- the xvfb-plugin seems to have compatibility code that still should allow to use XvfbBuildWrapper but when configuring the job the plugin is not enabled. when saving the job, all configurations are removed.
