### PR TITLE
Add classpath attribute for groovy post build plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/GroovyPostbuildContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/GroovyPostbuildContext.groovy
@@ -7,6 +7,7 @@ class GroovyPostbuildContext extends AbstractContext {
     String script
     PublisherContext.Behavior behavior = PublisherContext.Behavior.DoNothing
     boolean sandbox
+    List<String> classpath
 
     GroovyPostbuildContext(JobManagement jobManagement) {
         super(jobManagement)
@@ -32,5 +33,12 @@ class GroovyPostbuildContext extends AbstractContext {
      */
     void sandbox(boolean sandbox = true) {
         this.sandbox = sandbox
+    }
+
+    /**
+     * Specify the additional classpath for post build script
+     */
+    void classpath(List<String> classpath) {
+        this.classpath = classpath
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -863,10 +863,28 @@ class PublisherContext extends AbstractExtensibleContext {
         GroovyPostbuildContext groovyPostbuildContext = new GroovyPostbuildContext(jobManagement)
         ContextHelper.executeInContext(groovyPostbuildClosure, groovyPostbuildContext)
 
+        pathToURL = { path ->
+            try {
+                return new URL(path)
+            } catch (MalformedURLException e) {
+                return new File(path).toURI().toURL()
+            }
+        }
+
         publisherNodes << new NodeBuilder().'org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder' {
             script {
                 script(groovyPostbuildContext.script ?: '')
                 sandbox(groovyPostbuildContext.sandbox)
+                if (groovyPostbuildContext.classpath != null && !groovyPostbuildContext.classpath.isEmpty()) {
+                    classpath {
+                        groovyPostbuildContext.classpath.each { value ->
+                            urlAsString = pathToURL(value)
+                            entry {
+                                url(urlAsString)
+                            }
+                        }
+                    }
+                }
             }
             behavior(groovyPostbuildContext.behavior.value)
         }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -2272,16 +2272,29 @@ class PublisherContextSpec extends Specification {
             script('foo')
             behavior(PublisherContext.Behavior.MarkFailed)
             sandbox()
+            classpath(["foo","bar"])
         }
+
 
         then:
         with(context.publisherNodes[0]) {
             name() == 'org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder'
             children().size() == 2
             with(script[0]) {
-                children().size() == 2
+                children().size() == 3
                 script[0].value() == 'foo'
                 sandbox[0].value() == true
+                with(classpath[0]){
+                    children().size() == 2
+                    with(entry[0]){
+                        children().size() == 1
+                        url[0].value().toString().contains("foo")
+                    }
+                    with(entry[1]){
+                        children().size() == 1
+                        url[0].value().toString().contains("bar")
+                    }
+                }
             }
             behavior[0].value() == 2
         }


### PR DESCRIPTION
Add possibility for user to setup groovy post build classpath inside dsl script.

groovyPostBuild {
            script('foo')
            behavior(PublisherContext.Behavior.MarkFailed)
            sandbox()
            classpath(["foo","bar"])
        }