### PR TITLE
Add classpath attribute for groovy post build plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/GroovyPostbuildContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/GroovyPostbuildContext.groovy
@@ -7,6 +7,7 @@ class GroovyPostbuildContext extends AbstractContext {
     String script
     PublisherContext.Behavior behavior = PublisherContext.Behavior.DoNothing
     boolean sandbox
+    List<String> classpath
 
     GroovyPostbuildContext(JobManagement jobManagement) {
         super(jobManagement)
@@ -32,5 +33,12 @@ class GroovyPostbuildContext extends AbstractContext {
      */
     void sandbox(boolean sandbox = true) {
         this.sandbox = sandbox
+    }
+
+    /**
+     * Specify the additional classpath for post build script
+     */
+    void classpath(List<String> classpath) {
+        this.classpath = classpath
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -2272,6 +2272,7 @@ class PublisherContextSpec extends Specification {
             script('foo')
             behavior(PublisherContext.Behavior.MarkFailed)
             sandbox()
+            classpath(['foo', 'bar'])
         }
 
         then:
@@ -2279,9 +2280,20 @@ class PublisherContextSpec extends Specification {
             name() == 'org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder'
             children().size() == 2
             with(script[0]) {
-                children().size() == 2
+                children().size() == 3
                 script[0].value() == 'foo'
                 sandbox[0].value() == true
+                with(classpath[0]) {
+                    children().size() == 2
+                    with(entry[0]) {
+                        children().size() == 1
+                        url[0].value().toString().contains('foo')
+                    }
+                    with(entry[1]) {
+                        children().size() == 1
+                        url[0].value().toString().contains('bar')
+                    }
+                }
             }
             behavior[0].value() == 2
         }


### PR DESCRIPTION
Add possibility for user to define classpath for groovy post build plugin.
groovyPostBuild {
            script('foo')
            behavior(PublisherContext.Behavior.MarkFailed)
            sandbox()
            classpath(["foo","bar"])
        }