### PR TITLE
Add support to select a rundeck instance

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1109,6 +1109,8 @@ class PublisherContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'rundeck', minimumVersion = '3.4')
     void rundeck(String jobIdentifier, @DslContext(RundeckContext) Closure rundeckClosure = null) {
+        jobManagement.logPluginDeprecationWarning('rundeck', '3.5.4')
+
         checkNotNullOrEmpty(jobIdentifier, 'jobIdentifier cannot be null or empty')
 
         RundeckContext rundeckContext = new RundeckContext(jobManagement)
@@ -1122,6 +1124,9 @@ class PublisherContext extends AbstractExtensibleContext {
             shouldWaitForRundeckJob(rundeckContext.shouldWaitForRundeckJob)
             shouldFailTheBuild(rundeckContext.shouldFailTheBuild)
             includeRundeckLogs(rundeckContext.includeRundeckLogs)
+            if (jobManagement.isMinimumPluginVersionInstalled('rundeck', '3.5.4')) {
+                rundeckInstance(rundeckContext.rundeckInstance)
+            }
         }
     }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/RundeckContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/RundeckContext.groovy
@@ -2,6 +2,7 @@ package javaposse.jobdsl.dsl.helpers.publisher
 
 import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.RequiresPlugin
 
 class RundeckContext extends AbstractContext {
     Map<String, String> options = [:]
@@ -10,6 +11,7 @@ class RundeckContext extends AbstractContext {
     boolean shouldWaitForRundeckJob
     boolean shouldFailTheBuild
     boolean includeRundeckLogs
+    String rundeckInstance
 
     RundeckContext(JobManagement jobManagement) {
         super(jobManagement)
@@ -80,4 +82,17 @@ class RundeckContext extends AbstractContext {
             this.shouldWaitForRundeckJob = true
         }
     }
+
+    /**
+     * If set, selects the configured rundeck instance from the global config.
+     *
+     * Note: Running rundeck plugin >= 3.5.4 - this parameter is mandatory!
+     *
+     * @since 1.49
+     */
+    @RequiresPlugin(id = 'rundeck', minimumVersion = '3.5.4')
+    void rundeckInstance(String rundeckInstance) {
+        this.rundeckInstance = rundeckInstance
+    }
+
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -3211,6 +3211,33 @@ class PublisherContextSpec extends Specification {
         1 * jobManagement.requireMinimumPluginVersion('rundeck', '3.4')
     }
 
+    def 'call rundeck with rundeckInstance selected (version 3.5.4)'() {
+        setup:
+        jobManagement.isMinimumPluginVersionInstalled('rundeck', '3.5.4') >> true
+
+        when:
+        context.rundeck('jobId') {
+            rundeckInstance('myRundeckInstance')
+        }
+
+        then:
+        with(context.publisherNodes[0]) {
+            name() == 'org.jenkinsci.plugins.rundeck.RundeckNotifier'
+            children().size() == 8
+            jobId[0].value() == 'jobId'
+            options[0].value().isEmpty()
+            nodeFilters[0].value().isEmpty()
+            tag[0].value() == ''
+            shouldWaitForRundeckJob[0].value() == false
+            shouldFailTheBuild[0].value() == false
+            includeRundeckLogs[0].value() == false
+            rundeckInstance[0].value() == 'myRundeckInstance'
+        }
+
+        1 * jobManagement.requireMinimumPluginVersion('rundeck', '3.5.4')
+        1 * jobManagement.logPluginDeprecationWarning('rundeck', '3.5.4')
+    }
+
     def 'call s3 without profile'(String profile) {
         when:
         context.s3(profile) {


### PR DESCRIPTION
With rundeck plugin version 3.5.4 (May 19, 2016), you have to select a
configured rundeck instance - or the job won't work.

Hint: No rundeck info for your job is displayed on the job page, when no
instance is selected!