### PR TITLE
Fix rvm plugin update 0.4 -> 0.6

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -82,12 +82,12 @@ class WrapperContext extends AbstractExtensibleContext {
      *                          optionally containing a gemset
      *                          (i.e. ruby-1.9.3, ruby-2.0.0@gemset-foo)
      */
-    @RequiresPlugin(id = 'rvm')
+    @RequiresPlugin(id = 'rvm', minimumVersion = '0.6')
     void rvm(String rubySpecification) {
         Preconditions.checkArgument(rubySpecification as Boolean, 'Please specify at least the ruby version')
 
         wrapperNodes << new NodeBuilder().'ruby-proxy-object' {
-            'ruby-object'('ruby-class': 'Jenkins::Plugin::Proxies::BuildWrapper', pluginid: 'rvm') {
+            'ruby-object'('ruby-class': 'Jenkins::Tasks::BuildWrapperProxy', pluginid: 'rvm') {
 
                 pluginid('rvm', [pluginid: 'rvm', 'ruby-class': 'String'])
                 object('ruby-class': 'RvmWrapper', pluginid: 'rvm') {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -117,13 +117,34 @@ class WrapperContextSpec extends Specification {
     }
 
     def 'add rvm-controlled ruby version'() {
+        setup:
+        mockJobManagement.isMinimumPluginVersionInstalled('rvm', '0.6') >> true
+
         when:
         context.rvm('ruby-1.9.3')
 
         then:
         context.wrapperNodes[0].name() == 'ruby-proxy-object'
-        context.wrapperNodes[0].'ruby-object'[0].object[0].impl[0].value() == 'ruby-1.9.3'
-        1 * mockJobManagement.requirePlugin('rvm')
+        def rootObject = context.wrapperNodes[0].'ruby-object'[0]
+
+        rootObject.'@pluginid' == 'rvm'
+        rootObject.'@ruby-class' == 'Jenkins::Tasks::BuildWrapperProxy'
+
+        def pluginid = rootObject.pluginid[0]
+        pluginid.'@ruby-class' == 'String'
+        pluginid.'@pluginid' == 'rvm'
+        pluginid.value() == 'rvm'
+
+        def innerObject = rootObject.object[0]
+        innerObject.'@ruby-class' == 'RvmWrapper'
+        innerObject.'@pluginid' == 'rvm'
+
+        def impl = innerObject.impl[0]
+        impl.'@ruby-class' == 'String'
+        impl.'@pluginid' == 'rvm'
+        impl.value() == 'ruby-1.9.3'
+
+        1 * mockJobManagement.requireMinimumPluginVersion('rvm', '0.6')
     }
 
     def 'default timeout works'() {


### PR DESCRIPTION
There is a change with rvm plugin update to 0.6 where the outer ruby-
class has changed its type