### PR TITLE
Change ruby-class of rvm wrapper to Jenkins::Tasks::BuildWrapperProxy

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -87,8 +87,7 @@ class WrapperContext extends AbstractExtensibleContext {
         Preconditions.checkArgument(rubySpecification as Boolean, 'Please specify at least the ruby version')
 
         wrapperNodes << new NodeBuilder().'ruby-proxy-object' {
-            'ruby-object'('ruby-class': 'Jenkins::Plugin::Proxies::BuildWrapper', pluginid: 'rvm') {
-
+            'ruby-object'('ruby-class': 'Jenkins::Tasks::BuildWrapperProxy', pluginid: 'rvm') {
                 pluginid('rvm', [pluginid: 'rvm', 'ruby-class': 'String'])
                 object('ruby-class': 'RvmWrapper', pluginid: 'rvm') {
                     impl(rubySpecification, [pluginid: 'rvm', 'ruby-class': 'String'])


### PR DESCRIPTION
This is due to version of jenkins-plugin-runtime that rvm-plugin depends has been changed to 0.2.3. This PR should partially fix JENKINS-37422.