### PR TITLE
[JENKINS-37620] Adds dsl support for copyArtifacts downstreamBuildOf

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -27,6 +27,8 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
 
 ## Release Notes
 * 1.51 (unreleased)
+ * Enhanced support for the [Copy Artifact Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Copy+Artifact+Plugin)
+   ([JENKINS-37620](https://issues.jenkins-ci.org/browse/JENKINS-37620))
 * 1.50 (August 17 2016)
  * Fixed regression when updating views
    ([JENKINS-37450](https://issues.jenkins-ci.org/browse/JENKINS-37450))

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/CopyArtifactSelectorContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/CopyArtifactSelectorContext.groovy
@@ -53,6 +53,19 @@ class CopyArtifactSelectorContext extends AbstractExtensibleContext {
     }
 
     /**
+     * Selects a specific build of a downstream project given a upstream project and build number
+     *
+     * @since 1.51
+     */
+    @RequiresPlugin(id = 'copyartifact', minimumVersion = '1.32')
+    void downstreamBuildOf(String upstreamProjectName, String upstreamBuildNumber) {
+        createSelectorNode('DownstreamBuild') {
+            delegate.upstreamProjectName(upstreamProjectName)
+            delegate.upstreamBuildNumber(upstreamBuildNumber)
+        }
+    }
+
+    /**
      * Selects the latest successful build. This is the default selector.
      */
     void latestSuccessful(boolean stable = false) {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
@@ -1058,6 +1058,32 @@ class StepContextSpec extends Specification {
         }
     }
 
+
+    def 'call copyArtifacts with downstreamBuild'() {
+        when:
+        context.copyArtifacts('upstream') {
+            buildSelector {
+                downstreamBuildOf ('UpDown', '$LATEST')
+            }
+        }
+
+        then:
+        with(context.stepNodes[0]) {
+            name() == 'hudson.plugins.copyartifact.CopyArtifact'
+            children().size() == 5
+            project[0].value() == 'upstream'
+            filter[0].value() == ''
+            target[0].value() == ''
+            doNotFingerprintArtifacts[0].value() == false
+            with(selector[0]) {
+                children().size() == 2
+                attribute('class') == 'hudson.plugins.copyartifact.DownstreamBuildSelector'
+                upstreamProjectName[0].value() == 'UpDown'
+                upstreamBuildNumber[0].value() == '$LATEST'
+            }
+        }
+    }
+
     def 'call copyArtifacts with upstreamBuild closure'() {
         when:
         context.copyArtifacts('upstream') {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
@@ -1058,7 +1058,6 @@ class StepContextSpec extends Specification {
         }
     }
 
-
     def 'call copyArtifacts with downstreamBuild'() {
         when:
         context.copyArtifacts('upstream') {


### PR DESCRIPTION
Make it possible to configure the downstreamBuildOf feature of the copyartifact plugin from dsl

Signed-off-by: Aske Olsson <aske@schantz.com>