### PR TITLE
Fixed outdated documentation.

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
@@ -158,7 +158,7 @@ interface DslFactory extends ViewFactory {
     WorkflowJob pipelineJob(String name)
 
     /**
-     * Create or updates a workflow job.
+     * Create or updates a pipeline job.
      * Alias for #workflowJob(java.lang.String, groovy.lang.Closure)
      *
      * @since 1.47


### PR DESCRIPTION
The overload for the pipelineJob method mentions a workflow job, but the new terminology (pipeline job) should be used.