### PR TITLE
[FIXED JENKINS-37103] Use coreSource instead of default update center

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JobDslPlugin.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JobDslPlugin.groovy
@@ -11,8 +11,6 @@ import org.kohsuke.stapler.StaplerResponse
 
 import javax.servlet.ServletException
 
-import static hudson.model.UpdateCenter.ID_DEFAULT
-
 class JobDslPlugin extends Plugin {
     private volatile String cachedApi
 
@@ -32,7 +30,7 @@ class JobDslPlugin extends Plugin {
         if (path == '/api-viewer') {
             response.sendRedirect("${request.requestURI}${request.requestURI.endsWith('/') ? '' : '/'}index.html")
         } else if (path == '/api-viewer/build/data/update-center.jsonp') {
-            JSONObject data = Jenkins.instance.updateCenter.getById(ID_DEFAULT).JSONObject
+            JSONObject data = Jenkins.instance.updateCenter.coreSource.JSONObject
             response.contentType = 'application/javascript'
             response.writer.print("updateCenter.post(${data.toString()})")
         } else if (path == '/api-viewer/build/data/dsl.json') {


### PR DESCRIPTION
Not all masters may actually have the default update center configured
- if they're only using custom update centers with ids other than
"default", the API viewer barfs. This change instead uses
Jenkins.instance.updateCenter.coreSource, which will get the first
update site that provides core updates. If you've got the default
update center configured, that'll be used. If there are no update
centers supplying core updates configured (which can happen in some
weird edge cases), then it'll still fail, but I think this is the
cleanest fix for most use cases.

cc @reviewbybees