### PR TITLE
Fixed problem with indentation in multi-line content

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ScriptRequestGenerator.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ScriptRequestGenerator.groovy
@@ -32,10 +32,11 @@ class ScriptRequestGenerator implements Closeable {
         if (additionalClasspath) {
             String expandedClasspath = env.expand(additionalClasspath)
             expandedClasspath.split('\n').each {
-                if (it.contains('*') || it.contains('?')) {
-                    classpath.addAll(workspace.list(it).collect { createClasspathURL(it) })
+                String classpathLine = it.trim()
+                if (classpathLine.contains('*') || classpathLine.contains('?')) {
+                    classpath.addAll(workspace.list(classpathLine).collect { createClasspathURL(it) })
                 } else {
-                    classpath << createClasspathURL(workspace.child(it))
+                    classpath << createClasspathURL(workspace.child(classpathLine))
                 }
             }
         }


### PR DESCRIPTION
Fixed problem with indentation in multi-line content when used in additionalClasspath variable. It happens when value contains tabs or spaces. This results in error:
```
...
Processing DSL script job.groovy
ERROR: startup failed:
workspace:/jobs/job.groovy: n: unable to resolve class ...
``` 

Sample XML file:
```xml
<project>
    ...
    <builders>
       <javaposse.jobdsl.plugin.ExecuteDslScripts plugin="job-dsl@1.50">
            <targets>jobs/job.groovy</targets>
            <usingScriptText>false</usingScriptText>
            <ignoreExisting>false</ignoreExisting>
            <ignoreMissingFiles>false</ignoreMissingFiles>
            <removedJobAction>DELETE</removedJobAction>
            <removedViewAction>DELETE</removedViewAction>
            <lookupStrategy>JENKINS_ROOT</lookupStrategy>
            <additionalClasspath>src/main/resources
              src/main/groovy
              lib/*.jar</additionalClasspath>
        </javaposse.jobdsl.plugin.ExecuteDslScripts>
    ...
    </builders>
</project>
```

Job can be created with CLI command:
```bash
java -jar ./.cli/jenkins-cli.jar -s http://localhost:8080/ create-job job < job.xml
```