### PR TITLE
Introduce cache for dsl script itself

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
@@ -29,6 +29,7 @@ abstract class JobParent extends Script implements DslFactory {
     Set<ConfigFile> referencedConfigFiles = new LinkedHashSet<>()
     Set<UserContent> referencedUserContents = new LinkedHashSet<>()
     List<String> queueToBuild = []
+    boolean canBeCached = true
 
     /**
      * @since 1.30
@@ -124,7 +125,6 @@ abstract class JobParent extends Script implements DslFactory {
         processItem(name, MultibranchWorkflowJob, closure)
     }
 
-    // this method cannot be private due to http://jira.codehaus.org/browse/GROOVY-6263
     protected <T extends Item> T processItem(String name, Class<T> jobClass, Closure closure) {
         checkNotNullOrEmpty(name, 'name must be specified')
 
@@ -137,6 +137,7 @@ abstract class JobParent extends Script implements DslFactory {
         job
     }
 
+    // this method cannot be private due to http://jira.codehaus.org/browse/GROOVY-6263
     /**
      * @since 1.30
      */
@@ -201,7 +202,6 @@ abstract class JobParent extends Script implements DslFactory {
         processView(name, DashboardView, closure)
     }
 
-    // this method cannot be private due to http://jira.codehaus.org/browse/GROOVY-6263
     protected <T extends View> T processView(String name, Class<T> viewClass, Closure closure) {
         checkNotNullOrEmpty(name, 'name must be specified')
 
@@ -214,6 +214,7 @@ abstract class JobParent extends Script implements DslFactory {
         view
     }
 
+    // this method cannot be private due to http://jira.codehaus.org/browse/GROOVY-6263
     /**
      * @since 1.30
      */
@@ -251,10 +252,10 @@ abstract class JobParent extends Script implements DslFactory {
         processConfigFile(name, ConfigFileType.ManagedScript, ParametrizedConfigFile, closure)
     }
 
-    // this method cannot be private due to http://jira.codehaus.org/browse/GROOVY-6263
     protected <T extends ConfigFile> T processConfigFile(String name, ConfigFileType configFileType,
                                                          Class<T> type = ConfigFile, Closure closure) {
         checkNotNullOrEmpty(name, 'name must be specified')
+        canBeCached = false
 
         T configFile = type.newInstance(configFileType, jm)
         configFile.name = name
@@ -265,6 +266,7 @@ abstract class JobParent extends Script implements DslFactory {
         configFile
     }
 
+    // this method cannot be private due to http://jira.codehaus.org/browse/GROOVY-6263
     @Override
     void userContent(String path, InputStream content) {
         referencedUserContents << new UserContent(path, content)
@@ -294,6 +296,7 @@ abstract class JobParent extends Script implements DslFactory {
     @Override
     InputStream streamFileFromWorkspace(String filePath) {
         checkNotNullOrEmpty(filePath, 'filePath must not be null or empty')
+        canBeCached = false
         jm.streamFileInWorkspace(filePath)
     }
 
@@ -303,6 +306,7 @@ abstract class JobParent extends Script implements DslFactory {
     @Override
     String readFileFromWorkspace(String filePath) {
         checkNotNullOrEmpty(filePath, 'filePath must not be null or empty')
+        canBeCached = false
         jm.readFileInWorkspace(filePath)
     }
 
@@ -313,6 +317,11 @@ abstract class JobParent extends Script implements DslFactory {
     String readFileFromWorkspace(String jobName, String filePath) {
         checkNotNullOrEmpty(jobName, 'jobName must not be null or empty')
         checkNotNullOrEmpty(filePath, 'filePath must not be null or empty')
+        canBeCached = false
         jm.readFileInWorkspace(jobName, filePath)
+    }
+
+    boolean canBeCached() {
+        return canBeCached
     }
 }


### PR DESCRIPTION
We faced out that DSL script compilation produces a huge memory impact and takes too much time sometimes. Mainly it happens because we are running several DSL scripts for each commit that we are testing.

So, I found that DSL plugin has several layers of caching:
1) Groovy Engine caches compiled groovy script if it stores in file (it checks dependencies as well)
2) DSL plugin are checking that job (and/or job config) didn't change

But I didn't find any cache for DSL code in case of pure text and didn't find any cache for JobParent.
I tested this PR in our test environment and it looks good. Probably, I don't know all corner cases for JobParent, but I hope that it's possible to cache it as it is.

So, waiting for your feedback :)
