### PR TITLE
Make CredentialsBindingContext extensible

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/CredentialsBindingContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/CredentialsBindingContext.groovy
@@ -1,14 +1,17 @@
 package javaposse.jobdsl.dsl.helpers.wrapper
 
-import javaposse.jobdsl.dsl.AbstractContext
+import javaposse.jobdsl.dsl.AbstractExtensibleContext
+import javaposse.jobdsl.dsl.ContextType
+import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.RequiresPlugin
 
-class CredentialsBindingContext extends AbstractContext {
+@ContextType('org.jenkinsci.plugins.credentialsbinding.MultiBinding')
+class CredentialsBindingContext extends AbstractExtensibleContext {
     final List<Node> nodes = []
 
-    CredentialsBindingContext(JobManagement jobManagement) {
-        super(jobManagement)
+    CredentialsBindingContext(JobManagement jobManagement, Item item) {
+        super(jobManagement, item)
     }
 
     /**
@@ -58,5 +61,10 @@ class CredentialsBindingContext extends AbstractContext {
             variable(variableName)
             credentialsId(credentials)
         }
+    }
+
+    @Override
+    protected void addExtensionNode(Node node) {
+        nodes << node
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -537,7 +537,7 @@ class WrapperContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'credentials-binding')
     void credentialsBinding(@DslContext(CredentialsBindingContext) Closure closure) {
-        CredentialsBindingContext context = new CredentialsBindingContext(jobManagement)
+        CredentialsBindingContext context = new CredentialsBindingContext(jobManagement, item)
         ContextHelper.executeInContext(closure, context)
 
         wrapperNodes << new NodeBuilder().'org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper' {


### PR DESCRIPTION
Make CredentialsBindingContext extensible, in order to allow credentials binding for any type
of StandardCredentials for which a (Multi)Binding implementation is available.

For instance, I have a custom binding implementation for DockerServerCredentials (jenkinsci/docker-commons-plugin#54) and I would like to use it from job DSL scripts.