### PR TITLE
Fix NPE in JobDslPlugin.generateUpdateCenter()

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JobDslPlugin.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JobDslPlugin.groovy
@@ -4,6 +4,7 @@ import hudson.ExtensionList
 import hudson.ExtensionListListener
 import hudson.Plugin
 import hudson.model.Descriptor
+import hudson.model.UpdateSite
 import jenkins.model.Jenkins
 import net.sf.json.JSONObject
 import org.kohsuke.stapler.StaplerRequest
@@ -54,11 +55,12 @@ class JobDslPlugin extends Plugin {
     }
 
     private CachedFile generateUpdateCenter() {
-        long lastModified = Jenkins.instance.updateCenter.sites*.dataTimestamp.max()
+        Collection<UpdateSite> sites = Jenkins.instance.updateCenter.sites.findAll { it.JSONObject != null }
+        long lastModified = sites*.dataTimestamp.max() ?: 0
         CachedFile updateCenter = cachedUpdateCenter
         if (updateCenter == null || lastModified > updateCenter.timestamp) {
             Map<String, Object> plugins = [:]
-            Jenkins.instance.updateCenter.sites.each {
+            sites.each {
                 plugins.putAll(it.JSONObject.getJSONObject('plugins'))
             }
 


### PR DESCRIPTION
When there is an update site which could not be fetched (invalid URL, offline Jenkins server, etc), then UpdateSite.JSONObject will be null, which triggers a NullPointerException in JobDslPlugin.generateUpdateCenter().

Requests to /plugin/job-dsl/api-viewer/build/data/update-center.jsonp fail, and the API Viewer breaks
because some code in Dsl.js expect that window.updateCenter.data is defined.