### PR TITLE
Fix JS files ordering in the combineJs Gradle task

### DIFF
--- a/job-dsl-api-viewer/build.gradle
+++ b/job-dsl-api-viewer/build.gradle
@@ -35,8 +35,8 @@ assets {
 }
 
 combineJs {
-    source 'build/assets'
-    include '**/*.js'
+    def jsFiles = fileTree(dir: "build/assets", include: "**/*.js")
+    source jsFiles.files.sort() // ensure App.js comes first
     dest = file("${buildDir}/dist/js/app.js")
     dependsOn 'assetCompile'
 }


### PR DESCRIPTION
When I build job-dsl here, I very often (but not always...) get an invalid combined "app.js" file in the api-viewer module. The "App.js" is not included first, thus "App" is accessed before being defined, and the JS application fails to load.
This might be linked to the OS and/or underlying filesystem, or something like that (I'm on Linux, with an ext4 filesystem). Anyway, by applying "sort()" to the list of files we give to "combineJs", I think we get a more deterministic behaviour, with App.js being included first thanks to alphabetic order.