### PR TITLE
Fix api-viewer with unknown plugins

### DIFF
--- a/job-dsl-api-viewer/src/assets/javascripts/Settings.js
+++ b/job-dsl-api-viewer/src/assets/javascripts/Settings.js
@@ -17,7 +17,9 @@ App.Settings = Marionette.Object.extend({
     },
 
     isPluginsExcluded: function(plugins) {
-        return plugins.length > 0 && _.pluck(plugins, 'name').some(this.isPluginExcluded.bind(this));
+        return _.isEmpty(plugins)
+            || _.some(plugins, _.isUndefined)
+            || _.pluck(plugins, 'name').some(this.isPluginExcluded.bind(this));
     },
 
     setPluginExcluded: function(name, isExcluded) {


### PR DESCRIPTION
Following #921 and #922, here is a fix for a JS error I get when running without access to an update center: the "Settings.isPluginsExcluded(plugins)" function is called with lists of plugins, some of which being "undefined" (because they are neither installed, nor found in the updateCenter data), and the function exits in error instead of returning a boolean.  This breaks initialisation of the application (IIRC, because of exception in "TreeView.loadTreeData()").
This patch treats "undefined" as an excluded plugin.  This way, when running with no access to an update center, I get a DSL doc focused on what is actually available in this Jenkins instance.