### PR TITLE
Added executionType parameter to have an ability to run phase jobs SE…

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContext.groovy
@@ -11,10 +11,6 @@ class MultiJobStepContext extends StepContext {
             'SUCCESSFUL', 'UNSTABLE', 'COMPLETED', 'FAILURE', 'ALWAYS'
     ]
 
-    private static final List<String> VALID_EXECUTION_TYPES = [
-            'PARALLEL', 'SEQUENTIALLY'
-    ]
-
     MultiJobStepContext(JobManagement jobManagement, Item item) {
         super(jobManagement, item)
     }
@@ -23,14 +19,14 @@ class MultiJobStepContext extends StepContext {
      * Adds a MultiJob phase.
      */
     void phase(@DslContext(PhaseContext) Closure phaseContext) {
-        phase(null, 'SUCCESSFUL', 'PARALLEL', phaseContext)
+        phase(null, 'SUCCESSFUL', phaseContext)
     }
 
     /**
      * Adds a MultiJob phase.
      */
     void phase(String phaseName, @DslContext(PhaseContext) Closure phaseContext = null) {
-        phase(phaseName, 'SUCCESSFUL', 'PARALLEL', phaseContext)
+        phase(phaseName, 'SUCCESSFUL', phaseContext)
     }
 
     /**
@@ -39,23 +35,15 @@ class MultiJobStepContext extends StepContext {
      * {@code continuationCondition} must be one of {@code 'SUCCESSFUL'}, {@code 'UNSTABLE'}, {@code 'COMPLETED'} or
      * {@code 'FAILURE'}. When version 1.16 or later of the MultiJob plugin is installed, {@code continuationCondition}
      * can also be set to {@code 'ALWAYS'}.
-     * {@code executionType} must be one of {@code 'PARALLEL'} or {@code 'SEQUENTIALLY'}
      */
-    void phase(
-        String name, String continuationCondition, String executionType,
-        @DslContext(PhaseContext) Closure phaseClosure
-    ) {
-        PhaseContext phaseContext = new PhaseContext(jobManagement, item, name, continuationCondition, executionType)
+    void phase(String name, String continuationCondition, @DslContext(PhaseContext) Closure phaseClosure) {
+        PhaseContext phaseContext = new PhaseContext(jobManagement, item, name, continuationCondition)
         ContextHelper.executeInContext(phaseClosure, phaseContext)
 
         Preconditions.checkNotNullOrEmpty(phaseContext.phaseName, 'A phase needs a name')
         Preconditions.checkArgument(
                 VALID_CONTINUATION_CONDITIONS.contains(phaseContext.continuationCondition),
                 "Continuation Condition needs to be one of these values: ${VALID_CONTINUATION_CONDITIONS.join(', ')}"
-        )
-        Preconditions.checkArgument(
-                VALID_EXECUTION_TYPES.contains(phaseContext.executionType),
-                "Execution Type needs to be one of these values: ${VALID_EXECUTION_TYPES.join(', ')}"
         )
 
         stepNodes << new NodeBuilder().'com.tikal.jenkins.plugins.multijob.MultiJobBuilder' {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContext.groovy
@@ -49,7 +49,9 @@ class MultiJobStepContext extends StepContext {
         stepNodes << new NodeBuilder().'com.tikal.jenkins.plugins.multijob.MultiJobBuilder' {
             phaseName phaseContext.phaseName
             delegate.continuationCondition(phaseContext.continuationCondition)
-            delegate.executionType(phaseContext.executionType)
+            if (jobManagement.isMinimumPluginVersionInstalled('jenkins-multijob-plugin', '1.22')) {
+                delegate.executionType(phaseContext.executionType)
+            }
             phaseJobs {
                 phaseContext.jobsInPhase.each { PhaseJobContext jobInPhase ->
                     Node phaseJobNode = 'com.tikal.jenkins.plugins.multijob.PhaseJobsConfig' {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/PhaseContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/PhaseContext.groovy
@@ -5,20 +5,23 @@ import javaposse.jobdsl.dsl.ContextHelper
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.Item
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.RequiresPlugin
+import javaposse.jobdsl.dsl.Preconditions
 
 class PhaseContext extends AbstractContext {
+    private static final List<String> VALID_EXECUTION_TYPES = [
+        'PARALLEL', 'SEQUENTIALLY'
+    ]
+
     protected final Item item
 
     String phaseName
     String continuationCondition
-    String executionType
+    String executionType = 'PARALLEL'
 
     List<PhaseJobContext> jobsInPhase = []
 
-    PhaseContext(
-        JobManagement jobManagement, Item item, String phaseName, String continuationCondition,
-        String executionType
-    ) {
+    PhaseContext(JobManagement jobManagement, Item item, String phaseName, String continuationCondition) {
         super(jobManagement)
         this.item = item
         this.phaseName = phaseName
@@ -42,8 +45,14 @@ class PhaseContext extends AbstractContext {
 
     /**
      * Defines how to run the whole MultiJob phase.
+     * @since 1.52
      */
+    @RequiresPlugin(id = 'jenkins-multijob-plugin', minimumVersion = '1.22')
     void executionType(String executionType) {
+        Preconditions.checkArgument(
+            VALID_EXECUTION_TYPES.contains(executionType),
+            "Execution Type needs to be one of these values: ${VALID_EXECUTION_TYPES.join(', ')}"
+        )
         this.executionType = executionType
     }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/PhaseContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/PhaseContext.groovy
@@ -11,14 +11,19 @@ class PhaseContext extends AbstractContext {
 
     String phaseName
     String continuationCondition
+    String executionType
 
     List<PhaseJobContext> jobsInPhase = []
 
-    PhaseContext(JobManagement jobManagement, Item item, String phaseName, String continuationCondition) {
+    PhaseContext(
+        JobManagement jobManagement, Item item, String phaseName, String continuationCondition,
+        String executionType
+    ) {
         super(jobManagement)
         this.item = item
         this.phaseName = phaseName
         this.continuationCondition = continuationCondition
+        this.executionType = executionType
     }
 
     /**
@@ -33,6 +38,13 @@ class PhaseContext extends AbstractContext {
      */
     void continuationCondition(String continuationCondition) {
         this.continuationCondition = continuationCondition
+    }
+
+    /**
+     * Defines how to run the whole MultiJob phase.
+     */
+    void executionType(String executionType) {
+        this.executionType = executionType
     }
 
     /**

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContextSpec.groovy
@@ -17,10 +17,9 @@ class MultiJobStepContextSpec extends Specification {
         then:
         with(context.stepNodes[0]) {
             name() == 'com.tikal.jenkins.plugins.multijob.MultiJobBuilder'
-            children().size() == 4
+            children().size() == 3
             phaseName[0].value() == 'First'
             continuationCondition[0].value() == 'SUCCESSFUL'
-            executionType[0].value() == 'PARALLEL'
             phaseJobs[0].value().empty
         }
 
@@ -33,10 +32,9 @@ class MultiJobStepContextSpec extends Specification {
         then:
         with(context.stepNodes[1]) {
             name() == 'com.tikal.jenkins.plugins.multijob.MultiJobBuilder'
-            children().size() == 4
+            children().size() == 3
             phaseName[0].value() == 'Second'
             continuationCondition[0].value() == 'SUCCESSFUL'
-            executionType[0].value() == 'PARALLEL'
             phaseJobs[0].children().size() == 1
             with(phaseJobs[0].'com.tikal.jenkins.plugins.multijob.PhaseJobsConfig'[0]) {
                 children().size() == 7
@@ -62,10 +60,9 @@ class MultiJobStepContextSpec extends Specification {
         then:
         with(context.stepNodes[0]) {
             name() == 'com.tikal.jenkins.plugins.multijob.MultiJobBuilder'
-            children().size() == 4
+            children().size() == 3
             phaseName[0].value() == 'Third'
             continuationCondition[0].value() == 'SUCCESSFUL'
-            executionType[0].value() == 'PARALLEL'
             phaseJobs[0].children().size() == 3
             phaseJobs[0].'com.tikal.jenkins.plugins.multijob.PhaseJobsConfig'[0].jobName[0].value() == 'JobA'
             phaseJobs[0].'com.tikal.jenkins.plugins.multijob.PhaseJobsConfig'[1].jobName[0].value() == 'JobB'
@@ -103,10 +100,9 @@ class MultiJobStepContextSpec extends Specification {
 
         then:
         with(context.stepNodes[0]) {
-            children().size() == 4
+            children().size() == 3
             phaseName[0].value() == 'Fourth'
             continuationCondition[0].value() == 'SUCCESSFUL'
-            executionType[0].value() == 'PARALLEL'
             phaseJobs[0].children().size() == 1
             with(phaseJobs[0].'com.tikal.jenkins.plugins.multijob.PhaseJobsConfig'[0]) {
                 children().size() == 8
@@ -192,10 +188,9 @@ class MultiJobStepContextSpec extends Specification {
         then:
         with(context.stepNodes[0]) {
             name() == 'com.tikal.jenkins.plugins.multijob.MultiJobBuilder'
-            children().size() == 4
+            children().size() == 3
             phaseName[0].value() == 'Second'
             continuationCondition[0].value() == 'SUCCESSFUL'
-            executionType[0].value() == 'PARALLEL'
             phaseJobs[0].children().size() == 1
             with(phaseJobs[0].'com.tikal.jenkins.plugins.multijob.PhaseJobsConfig'[0]) {
                 children().size() == 7
@@ -232,20 +227,17 @@ class MultiJobStepContextSpec extends Specification {
         thrown(DslScriptException)
     }
 
-    def 'call phase with unsupported execution type'(String execution) {
+    def 'call phase with unsupported execution type'() {
         setup:
         jobManagement.isMinimumPluginVersionInstalled('jenkins-multijob-plugin', '1.22') >> true
 
         when:
         context.phase('test') {
-            executionType execution
+            executionType 'FOO'
         }
 
         then:
         thrown(DslScriptException)
-
-        where:
-        execution << ['FOO']
     }
 
     def 'call phase with supported condition'(String condition) {
@@ -290,7 +282,7 @@ class MultiJobStepContextSpec extends Specification {
         }
 
         where:
-        execution << ['SEQUENTIALLY']
+        execution << ['PARALLEL', 'SEQUENTIALLY']
     }
 
     def 'phase works inside conditionalSteps'() {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/MultiJobStepContextSpec.groovy
@@ -225,28 +225,35 @@ class MultiJobStepContextSpec extends Specification {
 
     def 'call phase with unsupported condition'() {
         when:
-        context.phase('test', 'FOO', 'PARALLEL') {
+        context.phase('test', 'FOO') {
         }
 
         then:
         thrown(DslScriptException)
     }
 
-    def 'call phase with unsupported execution type'() {
+    def 'call phase with unsupported execution type'(String execution) {
+        setup:
+        jobManagement.isMinimumPluginVersionInstalled('jenkins-multijob-plugin', '1.22') >> true
+
         when:
-        context.phase('test', 'SUCCESSFUL', 'BAR') {
+        context.phase('test') {
+            executionType execution
         }
 
         then:
         thrown(DslScriptException)
+
+        where:
+        execution << ['FOO']
     }
 
     def 'call phase with supported condition'(String condition) {
         setup:
-        jobManagement.isMinimumPluginVersionInstalled('jenkins-multijob-plugin', '1.16') >> true
+        jobManagement.isMinimumPluginVersionInstalled('jenkins-multijob-plugin', '1.22') >> true
 
         when:
-        context.phase('test', condition, 'PARALLEL') {
+        context.phase('test', condition) {
         }
 
         then:
@@ -265,10 +272,11 @@ class MultiJobStepContextSpec extends Specification {
 
     def 'call phase with supported execution type'(String execution) {
         setup:
-        jobManagement.isMinimumPluginVersionInstalled('jenkins-multijob-plugin', '1.16') >> true
+        jobManagement.isMinimumPluginVersionInstalled('jenkins-multijob-plugin', '1.22') >> true
 
         when:
-        context.phase('test', 'SUCCESSFUL', execution) {
+        context.phase('test') {
+            executionType execution
         }
 
         then:


### PR DESCRIPTION
I've added an ability to switch between execution types in multi jobs step plugin.
This options was missed in job dsl plugin.
Basically it can switch between sequential or parallel execution type of jobs within the phase.