### PR TITLE
deprecated support for the Rundeck plugin

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -52,6 +52,8 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
  * Support for the older versions of the
    [Exclusion Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Exclusion-Plugin) is deprecated, see
    [Migration](Migration#migrating-to-152)
+ * Support for the [RunDeck Plugin](https://wiki.jenkins-ci.org/display/JENKINS/RunDeck+Plugin) is deprecated, see
+   [Migration](Migration#migrating-to-152)
  * Removed anything that has been deprecated in 1.45, see [Migration](Migration#migrating-to-145)
 * 1.51 (September 13 2016)
  * Enhanced support for the [RunDeck Plugin](https://wiki.jenkins-ci.org/display/JENKINS/RunDeck+Plugin)

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -18,6 +18,69 @@ Support for versions older than 0.12 of the
 [Exclusion Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Exclusion-Plugin) is [[deprecated|Deprecation-Policy]]
 and will be removed.
 
+### Rundeck
+
+Support for the [RunDeck Plugin](https://wiki.jenkins-ci.org/display/JENKINS/RunDeck+Plugin) is
+[deprecated|Deprecation-Policy]] and will be removed. Use the syntax provided by the [[Automatically Generated DSL]]
+instead.
+
+DSL prior to 1.52
+```groovy
+job('example') {
+    triggers {
+        rundeck {
+            jobIdentifiers(
+                    '2027ce89-7924-4ecf-a963-30090ada834f',
+                    'my-project-name:main-group/sub-group/my-job'
+            )
+            executionStatuses('FAILED', 'ABORTED')
+        }
+    }
+    publishers {
+        rundeck('13eba461-179d-40a1-8a08-bafee33fdc12') {
+            rundeckInstance('prod')
+            options(artifact: 'app', env: 'dev')
+            option('version', '1.1')
+            tag('#deploy')
+            nodeFilters(hostname: 'dev(\\d+).company.net')
+            nodeFilter('tags', 'www+dev')
+            shouldWaitForRundeckJob()
+            shouldFailTheBuild()
+            includeRundeckLogs()
+        }
+    }
+}
+```
+
+DSL since 1.52
+```groovy
+job('example') {
+    triggers {
+        rundeckTrigger {
+            jobsIdentifiers([
+                    '2027ce89-7924-4ecf-a963-30090ada834f',
+                    'my-project-name:main-group/sub-group/my-job'
+            ])
+            executionStatuses(['FAILED', 'ABORTED'])
+            filterJobs(true)
+        }
+    }
+    publishers {
+        rundeckNotifier {
+            jobId('13eba461-179d-40a1-8a08-bafee33fdc12')
+            rundeckInstance('prod')
+            options(['artifact=app', 'env=dev', 'version=1.1'].join('\n'))
+            tags('#deploy')
+            nodeFilters(['hostname=dev(\\d+).company.net', 'tags=www+dev'].join('\n'))
+            shouldWaitForRundeckJob(true)
+            shouldFailTheBuild(true)
+            includeRundeckLogs(true)
+            tailLog(false)
+        }
+    }
+}
+```
+
 ## Migrating to 1.51
 
 ### Rundeck

--- a/job-dsl-api-viewer/src/assets/javascripts/Dsl.js
+++ b/job-dsl-api-viewer/src/assets/javascripts/Dsl.js
@@ -198,6 +198,7 @@ _.extend(App.Dsl.prototype, {
                 availableSince: signature.availableSince,
                 deprecated: signature.deprecated,
                 deprecatedText: deprecatedText,
+                deprecatedHtml: signature.deprecatedHtml || deprecatedText,
                 generated: signature.generated,
                 extension: signature.extension,
                 required: signature.required,

--- a/job-dsl-api-viewer/src/assets/javascripts/templates/context.hbs
+++ b/job-dsl-api-viewer/src/assets/javascripts/templates/context.hbs
@@ -3,7 +3,7 @@
         <li>
             {{# if comment}}
                 <div class="firstSentenceCommentText">
-                    // {{comment}} {{#if deprecated}}Deprecated{{#if deprecatedText}} {{deprecatedText}}{{/if}}.{{/if}}
+                    // {{comment}} {{#if deprecated}}Deprecated{{#if deprecatedText}}: {{deprecatedText}}{{/if}}.{{/if}}
                 </div>
             {{/if}}
             <a href="#path/{{path}}">{{name}}</a><span class="highlight groovy inline">{{text}}</span>

--- a/job-dsl-api-viewer/src/assets/javascripts/templates/detail.hbs
+++ b/job-dsl-api-viewer/src/assets/javascripts/templates/detail.hbs
@@ -58,6 +58,9 @@
                     {{/each}}
                     </div>
                 {{/if}}
+                {{#if deprecatedHtml}}
+                    <div class="method-doc"><strong>Deprecated:</strong> {{{deprecatedHtml}}}</div>
+                {{/if}}
             {{/each}}
         </div>
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/doc/ApiDocGenerator.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/doc/ApiDocGenerator.groovy
@@ -169,7 +169,8 @@ class ApiDocGenerator {
             map.deprecated = true
             String deprecatedText = tags.find { it.name() == 'deprecated' }?.text()?.trim()
             if (deprecatedText) {
-                map.deprecatedText = deprecatedText
+                map.deprecatedText = stripTags(deprecatedText)
+                map.deprecatedHtml = deprecatedText
             }
         }
 
@@ -210,7 +211,7 @@ class ApiDocGenerator {
                 firstSentenceCommentText = firstSentenceCommentText[0..<annotationIndex]
             }
             if (firstSentenceCommentText) {
-                firstSentenceCommentText = firstSentenceCommentText.replaceAll('<[^>]*>', '') // strip tags
+                firstSentenceCommentText = stripTags(firstSentenceCommentText)
                 map.firstSentenceCommentText = firstSentenceCommentText
             }
         }
@@ -289,5 +290,9 @@ class ApiDocGenerator {
             plugin.minimumVersion = requiresPluginAnnotation.minimumVersion()
         }
         plugin
+    }
+
+    private static String stripTags(String text) {
+        text.replaceAll('<[^>]*>', '')
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1107,11 +1107,13 @@ class PublisherContext extends AbstractExtensibleContext {
      * Triggers a Rundeck job.
      *
      * @since 1.24
+     * @deprecated use the
+     *    <a href="https://github.com/jenkinsci/job-dsl-plugin/wiki/Automatically-Generated-DSL">Automatically Generated
+     *    DSL</a> instead
      */
+    @Deprecated
     @RequiresPlugin(id = 'rundeck', minimumVersion = '3.4')
     void rundeck(String jobIdentifier, @DslContext(RundeckContext) Closure rundeckClosure = null) {
-        jobManagement.logPluginDeprecationWarning('rundeck', '3.5.4')
-
         checkNotNullOrEmpty(jobIdentifier, 'jobIdentifier cannot be null or empty')
 
         RundeckContext rundeckContext = new RundeckContext(jobManagement)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
@@ -163,11 +163,13 @@ class TriggerContext extends ItemTriggerContext {
      * Allows to schedule a build on Jenkins after a job execution on RunDeck.
      *
      * @since 1.33
+     * @deprecated use the
+     *    <a href="https://github.com/jenkinsci/job-dsl-plugin/wiki/Automatically-Generated-DSL">Automatically Generated
+     *    DSL</a> instead
      */
+    @Deprecated
     @RequiresPlugin(id = 'rundeck', minimumVersion = '3.4')
     void rundeck(@DslContext(RundeckTriggerContext) Closure closure = null) {
-        jobManagement.logPluginDeprecationWarning('rundeck', '3.5.4')
-
         RundeckTriggerContext context = new RundeckTriggerContext()
         ContextHelper.executeInContext(closure, context)
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -3189,7 +3189,7 @@ class PublisherContextSpec extends Specification {
             includeRundeckLogs[0].value() == true
         }
         1 * jobManagement.requireMinimumPluginVersion('rundeck', '3.4')
-        1 * jobManagement.logPluginDeprecationWarning('rundeck', '3.5.4')
+        1 * jobManagement.logDeprecationWarning()
     }
 
     def 'call rundeck with default values'() {
@@ -3209,7 +3209,7 @@ class PublisherContextSpec extends Specification {
             includeRundeckLogs[0].value() == false
         }
         1 * jobManagement.requireMinimumPluginVersion('rundeck', '3.4')
-        1 * jobManagement.logPluginDeprecationWarning('rundeck', '3.5.4')
+        1 * jobManagement.logDeprecationWarning()
     }
 
     def 'call rundeck with rundeckInstance selected (version 3.5.4)'() {
@@ -3236,7 +3236,7 @@ class PublisherContextSpec extends Specification {
         }
         1 * jobManagement.requireMinimumPluginVersion('rundeck', '3.4')
         1 * jobManagement.requireMinimumPluginVersion('rundeck', '3.5.4')
-        1 * jobManagement.logPluginDeprecationWarning('rundeck', '3.5.4')
+        1 * jobManagement.logDeprecationWarning()
     }
 
     def 'call rundeck without rundeckInstance selected (version 3.5.4)'() {
@@ -3260,7 +3260,7 @@ class PublisherContextSpec extends Specification {
             rundeckInstance[0].value() == 'Default'
         }
         1 * jobManagement.requireMinimumPluginVersion('rundeck', '3.4')
-        1 * jobManagement.logPluginDeprecationWarning('rundeck', '3.5.4')
+        1 * jobManagement.logDeprecationWarning()
     }
 
     def 'call s3 without profile'(String profile) {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
@@ -299,7 +299,7 @@ class TriggerContextSpec extends Specification {
             executionStatuses[0].value().empty
         }
         1 * mockJobManagement.requireMinimumPluginVersion('rundeck', '3.4')
-        1 * mockJobManagement.logPluginDeprecationWarning('rundeck', '3.5.4')
+        1 * mockJobManagement.logDeprecationWarning()
     }
 
     def 'call rundeck trigger with all options'() {
@@ -327,7 +327,7 @@ class TriggerContextSpec extends Specification {
             }
         }
         1 * mockJobManagement.requireMinimumPluginVersion('rundeck', '3.4')
-        1 * mockJobManagement.logPluginDeprecationWarning('rundeck', '3.5.4')
+        1 * mockJobManagement.logDeprecationWarning()
     }
 
     def 'call rundeck trigger with invalid execution status'() {


### PR DESCRIPTION
The DSL support for the Rundeck plugin is a pain to test. It's not possible to configure the Rundeck notifier and save a job's config page without a running instance of Rundeck. I do not want to setup Rundeck for testing Job DSL. Because of that, built-in DSL support is deprecated and will eventually be removed. The [Automatically Generated DSL](https://github.com/jenkinsci/job-dsl-plugin/wiki/Automatically-Generated-DSL) is a suitable replacement.