### PR TITLE
Add "Next Launch" / "Next Possible Launch" column support

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -31,6 +31,7 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
    [Config File Provider Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin)
    ([JENKINS-38637](https://issues.jenkins-ci.org/browse/JENKINS-38637))
  * Added "Next Launch" and "Next Possible Launch" columns for [Next Executions Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Next+Executions)
+   ([#940](https://github.com/jenkinsci/job-dsl-plugin/pull/940))
 * 1.52 (October 17 2016)
  * Increased the minimum supported Jenkins version to 1.642
  * Enhanced support for the [Exclusion Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Exclusion-Plugin)

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -30,6 +30,7 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
  * Enhanced support the
    [Config File Provider Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin)
    ([JENKINS-38637](https://issues.jenkins-ci.org/browse/JENKINS-38637))
+ * Added "Next Launch" column for [Next Executions Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Next+Executions)
 * 1.52 (October 17 2016)
  * Increased the minimum supported Jenkins version to 1.642
  * Enhanced support for the [Exclusion Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Exclusion-Plugin)

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -30,7 +30,7 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
  * Enhanced support the
    [Config File Provider Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin)
    ([JENKINS-38637](https://issues.jenkins-ci.org/browse/JENKINS-38637))
- * Added "Next Launch" column for [Next Executions Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Next+Executions)
+ * Added "Next Launch" and "Next Possible Launch" columns for [Next Executions Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Next+Executions)
 * 1.52 (October 17 2016)
  * Increased the minimum supported Jenkins version to 1.642
  * Enhanced support for the [Exclusion Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Exclusion-Plugin)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
@@ -261,6 +261,8 @@ class ColumnsContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'next-executions', minimumVersion = '1.0.12')
     void nextLaunch() {
-        columnNodes << new Node(null, 'hudson.plugins.nextexecutions.columns.NextExecutionColumn')
+        columnNodes << new NodeBuilder().'hudson.plugins.nextexecutions.columns.NextExecutionColumn' {
+          triggerClass('hudson.triggers.TimerTrigger')
+        }
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
@@ -265,4 +265,16 @@ class ColumnsContext extends AbstractExtensibleContext {
           triggerClass('hudson.triggers.TimerTrigger')
         }
     }
+
+    /**
+     * Adds a column showing job's next possible launch.
+     *
+     * @since 1.53
+     */
+    @RequiresPlugin(id = 'next-executions', minimumVersion = '1.0.12')
+    void nextPossibleLaunch() {
+        columnNodes << new NodeBuilder().'hudson.plugins.nextexecutions.columns.PossibleNextExecutionColumn' {
+          triggerClass('hudson.triggers.SCMTrigger')
+        }
+    }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
@@ -255,7 +255,7 @@ class ColumnsContext extends AbstractExtensibleContext {
     }
 
     /**
-     * Adds a column showing job's next execution.
+     * Adds a column showing job's next launch.
      *
      * @since 1.53
      */

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
@@ -253,4 +253,14 @@ class ColumnsContext extends AbstractExtensibleContext {
             useIcon(icon)
         }
     }
+
+    /**
+     * Adds a column showing job's next execution.
+     *
+     * @since 1.53
+     */
+    @RequiresPlugin(id = 'next-executions', minimumVersion = '1.0.12')
+    void nextLaunch() {
+        columnNodes << new Node(null, 'hudson.plugins.nextexecutions.columns.NextExecutionColumn')
+    }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
@@ -783,6 +783,20 @@ class ListViewSpec<T extends ListView> extends Specification {
         1 * jobManagement.requireMinimumPluginVersion('extra-columns', '1.6')
     }
 
+    def 'next execution column'() {
+        when:
+        view.columns {
+            nextLaunch()
+        }
+
+        then:
+        Node root = view.node
+        root.columns.size() == 1
+        root.columns[0].value().size() == 1
+        root.columns[0].value()[0].name() == 'hudson.plugins.nextexecutions.columns.NextExecutionColumn'
+        1 * jobManagement.requireMinimumPluginVersion('next-executions', '1.0.12')
+    }
+
     protected String getDefaultXml() {
         '''<?xml version='1.0' encoding='UTF-8'?>
 <hudson.model.ListView>

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
@@ -798,6 +798,21 @@ class ListViewSpec<T extends ListView> extends Specification {
         1 * jobManagement.requireMinimumPluginVersion('next-executions', '1.0.12')
     }
 
+    def 'next possible launch column'() {
+        when:
+        view.columns {
+            nextPossibleLaunch()
+        }
+
+        then:
+        Node root = view.node
+        root.columns.size() == 1
+        root.columns[0].value().size() == 1
+        root.columns[0].value()[0].name() == 'hudson.plugins.nextexecutions.columns.PossibleNextExecutionColumn'
+        root.columns[0].value().triggerClass[0].value() == 'hudson.triggers.SCMTrigger'
+        1 * jobManagement.requireMinimumPluginVersion('next-executions', '1.0.12')
+    }
+
     protected String getDefaultXml() {
         '''<?xml version='1.0' encoding='UTF-8'?>
 <hudson.model.ListView>

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
@@ -783,7 +783,7 @@ class ListViewSpec<T extends ListView> extends Specification {
         1 * jobManagement.requireMinimumPluginVersion('extra-columns', '1.6')
     }
 
-    def 'next execution column'() {
+    def 'next launch column'() {
         when:
         view.columns {
             nextLaunch()

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
@@ -794,6 +794,7 @@ class ListViewSpec<T extends ListView> extends Specification {
         root.columns.size() == 1
         root.columns[0].value().size() == 1
         root.columns[0].value()[0].name() == 'hudson.plugins.nextexecutions.columns.NextExecutionColumn'
+        root.columns[0].value().triggerClass[0].value() == 'hudson.triggers.TimerTrigger'
         1 * jobManagement.requireMinimumPluginVersion('next-executions', '1.0.12')
     }
 


### PR DESCRIPTION
Support the "Next Launch" and "Next Possible Launch" columns from [Next Executions Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Next+Executions) in views.