### PR TITLE
Add support for S3 Copy Artifact build step

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -27,6 +27,7 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
 
 ## Release Notes
 * 1.54 (unreleased)
+ * Enhance support for the [S3 plugin](https://wiki.jenkins-ci.org/display/JENKINS/S3+Plugin)
 * 1.53 (November 08 2016)
  * Enhanced support the
    [Config File Provider Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/S3CopyArtifactContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/S3CopyArtifactContext.groovy
@@ -1,0 +1,70 @@
+package javaposse.jobdsl.dsl.helpers.step
+
+import javaposse.jobdsl.dsl.AbstractContext
+import javaposse.jobdsl.dsl.ContextHelper
+import javaposse.jobdsl.dsl.DslContext
+import javaposse.jobdsl.dsl.Item
+import javaposse.jobdsl.dsl.JobManagement
+
+/**
+ * Root node for the S3CopyArtifacts build step. Almost identical to
+ * {@link javaposse.jobdsl.dsl.helpers.step.CopyArtifactContext}.
+ */
+@SuppressWarnings('ConfusingMethodName')
+class S3CopyArtifactContext extends AbstractContext {
+    final List<String> includePatterns = []
+    final List<String> excludePatterns = []
+    String targetDirectory
+    boolean flatten
+    boolean optional
+    final CopyArtifactSelectorContext selectorContext
+
+    S3CopyArtifactContext(JobManagement jobManagement, Item item) {
+        super(jobManagement)
+        selectorContext = new CopyArtifactSelectorContext(jobManagement, item)
+    }
+
+    /**
+     * Relative paths to artifact(s) to copy or leave blank to copy all artifacts. Can be called multiple times to add
+     * more patterns.
+     */
+    void includePatterns(String... includePatterns) {
+        this.includePatterns.addAll(includePatterns)
+    }
+
+    /**
+     * Specify paths or patterns of artifacts to exclude. Can be called multiple times to add more patterns.
+     */
+    void excludePatterns(String... excludePatterns) {
+        this.excludePatterns.addAll(excludePatterns)
+    }
+
+    /**
+     * Specifies the target directory. Defaults to the workspace directory.
+     */
+    void targetDirectory(String targetDirectory) {
+        this.targetDirectory = targetDirectory
+    }
+
+    /**
+     * Ignores the directory structure of the artifacts.
+     */
+    void flatten(boolean flatten = true) {
+        this.flatten = flatten
+    }
+
+    /**
+     * Allows this build to continue even if no build is found matching the build selector.
+     */
+    void optional(boolean optional = true) {
+        this.optional = optional
+    }
+
+    /**
+     * Selects the build to copy artifacts from.
+     */
+    void buildSelector(@DslContext(javaposse.jobdsl.dsl.helpers.step.CopyArtifactSelectorContext)
+                               Closure selectorClosure) {
+        ContextHelper.executeInContext(selectorClosure, selectorContext)
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -528,6 +528,34 @@ class StepContext extends AbstractExtensibleContext {
     }
 
     /**
+     * Copies artifacts from another project using S3.
+     *
+     * @since 1.54
+     */
+    @RequiresPlugin(id = 's3', minimumVersion = '0.7')
+    void s3CopyArtifacts(String jobName, @DslContext(S3CopyArtifactContext) Closure s3CopyArtifactClosure = null) {
+        S3CopyArtifactContext s3CopyArtifactContext = new S3CopyArtifactContext(jobManagement, item)
+        ContextHelper.executeInContext(s3CopyArtifactClosure, s3CopyArtifactContext)
+
+        Node s3CopyArtifactNode = new NodeBuilder().'hudson.plugins.s3.S3CopyArtifact' {
+            projectName(jobName)
+            filter(s3CopyArtifactContext.includePatterns.join(', '))
+            target(s3CopyArtifactContext.targetDirectory ?: '')
+            if (s3CopyArtifactContext.excludePatterns) {
+                excludeFilter(s3CopyArtifactContext.excludePatterns.join(', '))
+            }
+            if (s3CopyArtifactContext.flatten) {
+                flatten(true)
+            }
+            if (s3CopyArtifactContext.optional) {
+                optional(true)
+            }
+        }
+        s3CopyArtifactNode.append(s3CopyArtifactContext.selectorContext.selector)
+        self.stepNodes << s3CopyArtifactNode
+    }
+
+    /**
      * Resolves artifacts from a Maven repository.
      *
      * @since 1.29


### PR DESCRIPTION
Add support for the "S3 Copy Artifact" build step provided by the S3 plugin
similar to the existing support for the "Copy artifacts from another
project" build step.