### PR TITLE
multiple credentialIds for ssh-agent

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -185,11 +185,13 @@ class WrapperContext extends AbstractExtensibleContext {
      * @param credentials name of the credentials to use
      */
     @RequiresPlugin(id = 'ssh-agent')
-    void sshAgent(String credentials) {
+    void sshAgent(String... credentials) {
         Preconditions.checkNotNull(credentials, 'credentials must not be null')
 
         wrapperNodes << new NodeBuilder().'com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper' {
-            user(credentials)
+            credentials.each {
+                user(it)
+            }
         }
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -401,6 +401,17 @@ class WrapperContextSpec extends Specification {
         1 * mockJobManagement.requirePlugin('ssh-agent')
     }
 
+    def 'sshAgent with multiple credentials'() {
+        when:
+        context.sshAgent('acme', 'bracme')
+
+        then:
+        context.wrapperNodes[0].name() == 'com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper'
+        context.wrapperNodes[0].user[0].value() == 'acme'
+        context.wrapperNodes[0].user[1].value() == 'bracme'
+        1 * mockJobManagement.requirePlugin('ssh-agent')
+    }
+    
     def 'ansiColor with map'() {
         when:
         context.colorizeOutput('foo')


### PR DESCRIPTION
The ssh-agent plugin can provide multiple SSH keys to a build. This pull request surfaces this functionality like this:
```
ssh-agent('acme', 'bracme')
```