### PR TITLE
Added parentCredentials option to the git submodule options

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitExtensionContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitExtensionContext.groovy
@@ -93,6 +93,9 @@ class GitExtensionContext extends AbstractExtensibleContext {
             if (jobManagement.isMinimumPluginVersionInstalled('git', '2.2.8') && context.timeout != null) {
                 timeout(context.timeout)
             }
+            if (jobManagement.isMinimumPluginVersionInstalled('git', '3.0.0')) {
+                parentCredentials(context.parentCredentials)
+            }
         }
     }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitSubmoduleOptionsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitSubmoduleOptionsContext.groovy
@@ -10,6 +10,7 @@ class GitSubmoduleOptionsContext extends AbstractContext {
     boolean tracking
     String reference
     Integer timeout
+    boolean parentCredentials
 
     protected GitSubmoduleOptionsContext(JobManagement jobManagement) {
         super(jobManagement)
@@ -54,5 +55,13 @@ class GitSubmoduleOptionsContext extends AbstractContext {
     @RequiresPlugin(id = 'git', minimumVersion = '2.2.8')
     void timeout(Integer timeout) {
         this.timeout = timeout
+    }
+
+    /**
+     * Allows to use credentials from the default remote of the parent project.
+     */
+    @RequiresPlugin(id = 'git', minimumVersion = '3.0.0')
+    void parentCredentials(boolean parentCredentials = true) {
+        this.parentCredentials = parentCredentials
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
@@ -1089,7 +1089,44 @@ class ScmContextSpec extends Specification {
         1 * mockJobManagement.logPluginDeprecationWarning('git', '2.5.3')
     }
 
-    def 'call git scm with full submodule options'() {
+    def 'call git scm with full submodule options and plugin version 3.0.0'() {
+        setup:
+        mockJobManagement.isMinimumPluginVersionInstalled('git', '3.0.0') >> true
+
+        when:
+        context.git {
+            remote {
+                url('https://github.com/jenkinsci/job-dsl-plugin.git')
+            }
+            extensions {
+                submoduleOptions {
+                    disable()
+                    recursive()
+                    tracking()
+                    parentCredentials()
+                }
+            }
+        }
+
+        then:
+        context.scmNodes[0] != null
+        with(context.scmNodes[0]) {
+            extensions.size() == 1
+            extensions[0].children().size() == 1
+            with(extensions[0].'hudson.plugins.git.extensions.impl.SubmoduleOption'[0]) {
+                children().size() == 4
+                disableSubmodules[0].value() == true
+                recursiveSubmodules[0].value() == true
+                trackingSubmodules[0].value() == true
+                parentCredentials[0].value() == true
+            }
+        }
+        1 * mockJobManagement.requireMinimumPluginVersion('git', '2.2.6')
+        1 * mockJobManagement.requireMinimumPluginVersion('git', '3.0.0')
+        1 * mockJobManagement.logPluginDeprecationWarning('git', '2.5.3')
+    }
+
+    def 'call git scm with full submodule options and plugin version 2.2.8'() {
         setup:
         mockJobManagement.isMinimumPluginVersionInstalled('git', '2.2.8') >> true
 


### PR DESCRIPTION
According to a feature in the git plugin, which was added since 3.0.0 version. See https://issues.jenkins-ci.org/browse/JENKINS-20941