### PR TITLE
add job-dsl for the github-issue plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/GitHubIssueContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/GitHubIssueContext.groovy
@@ -1,0 +1,61 @@
+package javaposse.jobdsl.dsl.helpers.publisher
+
+import javaposse.jobdsl.dsl.Context
+
+class GitHubIssueContext implements Context {
+
+  String project
+  String title
+  String label
+  String text
+  boolean append
+  boolean reopen
+  /**
+   * Sets the GitHub project on which the issues should be created. If not set, the GitHub project
+   * configured for the GitHub plugin is being used.
+   * @param project
+   */
+  void project(String project) {
+    this.project = project
+  }
+
+  /**
+   * Sets the title of the issue
+   * @param title
+   */
+  void title(String title) {
+    this.title = title
+  }
+
+  /**
+   * Sets the label(s) for the issue. Multiple labels can be space or commata separated.
+   * @param label
+   */
+  void label(String label) {
+    this.label = label
+  }
+
+  /**
+   * Sets the issue text or comment. Markdown content is supported.
+   * @param text
+   */
+  void text(String text) {
+    this.text = text
+  }
+
+  /**
+   * Append the fail message to the issue if issue is in state open.
+   * @param append
+   */
+  void append(boolean append = false) {
+    this.append = append
+  }
+
+  /**
+   * Reopen the issue if there is a former issue associated to this job and in state closed, otherwise create a new one.
+   * @param reopen
+   */
+  void reopen(boolean reopen = false) {
+    this.reopen = reopen
+  }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -2081,6 +2081,26 @@ class PublisherContext extends AbstractExtensibleContext {
         }
     }
 
+    /**
+     * Creates a Github issue if the job fails and closes it when it succeeds
+     *
+     * @since 1.2
+     */
+    @RequiresPlugin(id = 'github-issues')
+    void githubIssue(@DslContext(GitHubIssueContext) Closure closure) {
+       GitHubIssueContext context = new GitHubIssueContext()
+       ContextHelper.executeInContext(closure, context)
+
+        publisherNodes << new NodeBuilder().'org.jenkinsci.plugins.githubissues.GitHubIssueNotifier' {
+            issueRepo(context.project ?: '')
+            issueTitle(context.title ?: '')
+            issueLabel(context.label ?: '')
+            issueBody(context.text ?: '')
+            issueAppend(context.append)
+            issueReopen(context.reopen)
+        }
+    }
+
     @SuppressWarnings('NoDef')
     private static addStaticAnalysisContext(def nodeBuilder, StaticAnalysisContext context) {
         nodeBuilder.with {


### PR DESCRIPTION
example 

```groovy
...
publishers {
  issueRepo('https://github.com/fsimmend/github-issues-plugin')
  issueTitle('job $JOB_NAME failed')
  issueText('some log output')
  issueReopen()
  issueAppend()
  issueLabel('teamX buildjobs')
}
...
```