### PR TITLE
Remove 'class' attribute from <trigger/> elements

### DIFF
--- a/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/jobs/BuildFlowJob-template.xml
+++ b/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/jobs/BuildFlowJob-template.xml
@@ -9,7 +9,7 @@
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-    <triggers class="vector"/>
+    <triggers/>
     <concurrentBuild>false</concurrentBuild>
     <builders/>
     <publishers/>

--- a/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/jobs/FreeStyleJob-template.xml
+++ b/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/jobs/FreeStyleJob-template.xml
@@ -9,7 +9,7 @@
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-    <triggers class="vector"/>
+    <triggers/>
     <concurrentBuild>false</concurrentBuild>
     <builders/>
     <publishers/>

--- a/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/jobs/IvyJob-template.xml
+++ b/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/jobs/IvyJob-template.xml
@@ -9,7 +9,7 @@
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-    <triggers class="vector"/>
+    <triggers/>
     <concurrentBuild>false</concurrentBuild>
     <aggregatorStyleBuild>true</aggregatorStyleBuild>
     <incrementalBuild>false</incrementalBuild>

--- a/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/jobs/MatrixJob-template.xml
+++ b/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/jobs/MatrixJob-template.xml
@@ -8,7 +8,7 @@
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-    <triggers class="vector"/>
+    <triggers/>
     <concurrentBuild>false</concurrentBuild>
     <axes/>
     <builders/>

--- a/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/jobs/MavenJob-template.xml
+++ b/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/jobs/MavenJob-template.xml
@@ -9,7 +9,7 @@
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-    <triggers class="vector"/>
+    <triggers/>
     <concurrentBuild>false</concurrentBuild>
     <aggregatorStyleBuild>true</aggregatorStyleBuild>
     <incrementalBuild>false</incrementalBuild>

--- a/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/jobs/MultiJob-template.xml
+++ b/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/jobs/MultiJob-template.xml
@@ -9,7 +9,7 @@
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-    <triggers class="vector"/>
+    <triggers/>
     <concurrentBuild>false</concurrentBuild>
     <builders/>
     <publishers/>

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslSampleSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/DslSampleSpec.groovy
@@ -138,7 +138,7 @@ class DslSampleSpec extends Specification {
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-    <triggers class="vector"/>
+    <triggers/>
     <concurrentBuild>false</concurrentBuild>
     <aggregatorStyleBuild>true</aggregatorStyleBuild>
     <incrementalBuild>false</incrementalBuild>
@@ -272,7 +272,7 @@ mavenJob('PROJ-maven-with-template') {
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-    <triggers class="vector"/>
+    <triggers/>
     <concurrentBuild>false</concurrentBuild>
     <aggregatorStyleBuild>true</aggregatorStyleBuild>
     <incrementalBuild>false</incrementalBuild>
@@ -318,7 +318,7 @@ mavenJob('PROJ-maven-with-template') {
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-    <triggers class="vector"/>
+    <triggers/>
     <concurrentBuild>false</concurrentBuild>
     <aggregatorStyleBuild>true</aggregatorStyleBuild>
     <incrementalBuild>false</incrementalBuild>

--- a/job-dsl-core/src/test/resources/JENKINS_32941.xml
+++ b/job-dsl-core/src/test/resources/JENKINS_32941.xml
@@ -8,7 +8,7 @@
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-    <triggers class='vector'></triggers>
+    <triggers/>
     <concurrentBuild>false</concurrentBuild>
     <builders>
         <org.jenkinsci.plugins.conditionalbuildstep.ConditionalBuilder>


### PR DESCRIPTION
This has been obsolete since 1.527, specifically https://github.com/jenkinsci/jenkins/commit/47de54d070f67af95b4fefb6d006a72bb31a5cb8