### PR TITLE
Job Dsl Whitelisting Option

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
@@ -11,6 +11,24 @@ abstract class AbstractJobManagement implements JobManagement {
         this.outputStream = out
     }
 
+    /**
+     * We set this for Jenkins Job Management, since we need it for processing Job-Dsl. For other Job Management types
+     * we will simply return false.
+     */
+    @Override
+    public boolean executeOnlyWhitelistedDsl() {
+        return false;
+    }
+
+    /**
+     * We set this for Jenkins Job Management, since we need it for processing Job-Dsl. For other Job Management types
+     * we will simply return an empty array.
+     */
+    @Override
+    public String[] getJobDslWhitelist() {
+        return [];
+    }
+
     @Override
     void logDeprecationWarning() {
         List<StackTraceElement> currentStackTrack = DslScriptHelper.stackTrace

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Item.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Item.groovy
@@ -15,13 +15,13 @@ abstract class Item extends AbstractContext {
     protected Item(JobManagement jobManagement, String name) {
         super(jobManagement)
         this.name = name
-        this.jobDslWhitelist = jobManagement.getJobDslWhitelist()
+        this.jobDslWhitelist = (jobManagement) ? jobManagement.getJobDslWhitelist() : new String[0]
     }
 
     @Deprecated
     protected Item(JobManagement jobManagement) {
         super(jobManagement)
-        this.jobDslWhitelist = jobManagement.getJobDslWhitelist()
+        this.jobDslWhitelist = (jobManagement) ? jobManagement.getJobDslWhitelist() : new String[0]
     }
 
     @Deprecated
@@ -42,9 +42,13 @@ abstract class Item extends AbstractContext {
                 String closureParentClass = configureBlock.thisObject['name'];
                 checkExternalClassIsWhitelisted(closureParentClass, jobDslWhitelist)
             } else {
-                // we do not allow raw configure blocks that do are not loaded from a whitelisted external class when whitelisting is turned on
-                throw new DslScriptException("The configure block at the current line is not added to the whitelist. To avoid this error, " +
-                        "either pull this block into an external class and whitelist that class, or turn whitelisting off.");
+                // we do not allow raw configure blocks that do are not loaded from a whitelisted external class when
+                // whitelisting is turned on
+                throw new DslScriptException("The job dsl block at the current line is not added to the whitelist.\n" +
+                        "If this is a raw configure block, you can avoid this error, by either pull this block into an " +
+                        "external class and whitelist that class, or turn whitelisting off.\n" +
+                        "If this is not a raw Configure block, this job dsl is not eligable to be whitelisted, so your" +
+                        "only option is to not use this job dsl block type, or turn whitelisting off.");
             }
         }
         configureBlocks << configureBlock

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Item.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Item.groovy
@@ -1,24 +1,33 @@
 package javaposse.jobdsl.dsl
 
+import javaposse.jobdsl.dsl.helpers.ScmContext
+import javaposse.jobdsl.dsl.helpers.publisher.PublisherContext
+import javaposse.jobdsl.dsl.helpers.step.StepContext
+import javaposse.jobdsl.dsl.helpers.triggers.TriggerContext
+import javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext
+
 abstract class Item extends AbstractContext {
     String name
+    String[] jobDslWhitelist
 
     private final List<Closure> configureBlocks = []
 
     protected Item(JobManagement jobManagement, String name) {
         super(jobManagement)
         this.name = name
+        this.jobDslWhitelist = jobManagement.getJobDslWhitelist()
     }
 
     @Deprecated
     protected Item(JobManagement jobManagement) {
         super(jobManagement)
+        this.jobDslWhitelist = jobManagement.getJobDslWhitelist()
     }
 
     @Deprecated
     void setName(String name) {
         this.name = name
-    }
+}
 
     /**
      * Allows direct manipulation of the generated XML.
@@ -26,6 +35,32 @@ abstract class Item extends AbstractContext {
      * @see <a href="https://github.com/jenkinsci/job-dsl-plugin/wiki/The-Configure-Block">The Configure Block</a>
      */
     void configure(Closure configureBlock) {
+        if(jobManagement.executeOnlyWhitelistedDsl()) {
+            // whitelisting is turned on
+            if (isClosureFromExternalClass(configureBlock)) {
+                // closure is loaded from an external class
+                String closureParentClass = configureBlock.thisObject['name'];
+                checkExternalClassIsWhitelisted(closureParentClass, jobDslWhitelist)
+            } else {
+                // we do not allow raw configure blocks that do are not loaded from a whitelisted external class when whitelisting is turned on
+                throw new DslScriptException("The configure block at the current line is not added to the whitelist. To avoid this error, " +
+                        "either pull this block into an external class and whitelist that class, or turn whitelisting off.");
+            }
+        }
+        configureBlocks << configureBlock
+    }
+
+    /**
+     * Configure block called by steps, publishers, scm, or wrapper job methods. These are only job part types
+     * that have the option to be whitelisted (besides base configure blocks pulled into external classes)
+     *
+     * Checks if job part is in whitelist if whitelisting is turned on.
+     */
+    void configure(Closure configureBlock, Closure originalClosure, Context originalContext) {
+        if(jobManagement.executeOnlyWhitelistedDsl()) {
+            // whitelisting is turned on
+            checkConfigureBlockOrContextIsValid(originalClosure, originalContext, jobDslWhitelist)
+        }
         configureBlocks << configureBlock
     }
 
@@ -65,4 +100,102 @@ abstract class Item extends AbstractContext {
     void executeWithXmlActions(Node root) {
         ContextHelper.executeConfigureBlocks(root, configureBlocks)
     }
+
+    /**
+     * Checks if external class is whitelisted
+     *
+     * Throws error with proper messaging if it is not
+     */
+    private static void checkExternalClassIsWhitelisted(String externalClassName, String[] jobDslWhitelist) {
+            // This closure was inherited from an external class. Let's check if it's on our whitelist
+            if (!jobDslWhitelist.contains(externalClassName)) {
+                throw new DslScriptException(String.format("The parent class for the job dsl on this line - %s - is not " +
+                        "added to the whitelist. To avoid this error, " +
+                        "either add this class to the whitelist, or turn whitelisting off", externalClassName));
+            }
+    }
+
+    /**
+     * Checks if external class is whitelisted
+     *
+     * Throws error with proper messaging if it is not
+     */
+    private static void checkJobDslNodeIsWhitelisted(String nodeClassName, String[] jobDslWhitelist) {
+        // This closure was inherited from an external class. Let's check if it's on our whitelist
+        if (!jobDslWhitelist.contains(nodeClassName)) {
+            throw new DslScriptException(String.format("The parent class for the job dsl on this line - %s - is not " +
+                    "added to the whitelist. To avoid this error, " +
+                    "either add this class to the whitelist, or turn whitelisting off", nodeClassName));
+        }
+    }
+
+    private static boolean isClosureFromExternalClass(Closure closure){
+        if(closure.thisObject.hasProperty('name') && closure.thisObject['name']) {
+            return true
+        }
+        return false
+    }
+
+        private static void checkConfigureBlockOrContextIsValid(Closure closure, Context context, String[] jobDslWhitelist) {
+            if(isClosureFromExternalClass(closure)) {
+                // if closure is loaded from an external class
+                String closureParentClass = closure.thisObject['name'];
+                checkExternalClassIsWhitelisted(closureParentClass, jobDslWhitelist)
+            }
+            else {
+                // check which Context it inherits from
+                if(context instanceof PublisherContext) {
+                    // if we didn't inherit this closure from an external class - we check what type of StepNodes we have
+                    ((PublisherContext)context).publisherNodes.each {
+                        if(it.name() != null) {
+                            checkJobDslNodeIsWhitelisted((String)it.name(), jobDslWhitelist)
+                        } else {
+                            // todo - should we do something if the it.name() is null??
+                        }
+                    }
+                } else if(context instanceof WrapperContext) {
+                    // if we didn't inherit this closure from an external class - we check what type of StepNodes we have
+                    ((WrapperContext)context).wrapperNodes.each {
+                        if(it.name() != null) {
+                            checkJobDslNodeIsWhitelisted((String)it.name(), jobDslWhitelist)
+                        } else {
+                            // todo - should we do something if the it.name() is null??
+                        }
+                    }
+                } else if(context instanceof StepContext) {
+                    ((StepContext)context).stepNodes.each {
+                        if(it.name() != null) {
+                            checkJobDslNodeIsWhitelisted((String)it.name(), jobDslWhitelist)
+                        } else {
+                            // todo - should we do something if the it.name() is null??
+                        }
+                    }
+                    // if we've gotten to this point and not thrown an exception, all of the step nodes were
+                    // apart of our whitelist
+                } else if(context instanceof ScmContext) {
+                    // if we didn't inherit this closure from an external class - we check what type of StepNodes we have
+                    ((ScmContext)context).scmNodes.each {
+                        if(it.name() != null) {
+                            checkJobDslNodeIsWhitelisted((String)it.name(), jobDslWhitelist)
+                        } else {
+                            // todo - should we do something if the it.name() is null??
+                        }
+                    }
+                }
+                else if(context instanceof TriggerContext) {
+                    // if we didn't inherit this closure from an external class - we check what type of StepNodes we have
+                    ((TriggerContext)context).triggerNodes.each {
+                        if(it.name() != null) {
+                            checkJobDslNodeIsWhitelisted((String)it.name(), jobDslWhitelist)
+                        } else {
+                            // todo - should we do something if the it.name() is null??
+                        }
+                    }
+                }
+                else {
+                    throw new DslScriptException(String.format("This context - %s - is not eligable to be whitelisted. To avoid this error, " +
+                            "do not use jobdsl from this context type or turn whitelisting off", context.toString()));
+                }
+            }
+        }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
@@ -526,7 +526,7 @@ abstract class Job extends Item {
         if (!context.scmNodes.empty) {
             checkState(context.scmNodes.size() == 1, 'Outside "multiscm", only one SCM can be specified')
 
-            configure { Node project ->
+            configure ({ Node project ->
                 Node scm = project / scm
                 if (scm) {
                     // There can only be only one SCM, so remove if there
@@ -535,7 +535,7 @@ abstract class Job extends Item {
 
                 // Assuming append the only child
                 project << context.scmNodes[0]
-            }
+            }, closure, context)
         }
     }
 
@@ -572,11 +572,11 @@ abstract class Job extends Item {
         TriggerContext context = new TriggerContext(jobManagement, this)
         ContextHelper.executeInContext(closure, context)
 
-        configure { Node project ->
+        configure ({ Node project ->
             context.triggerNodes.each {
                 project / 'triggers' << it
             }
-        }
+        }, closure, context)
     }
 
     /**
@@ -588,11 +588,11 @@ abstract class Job extends Item {
         WrapperContext context = new WrapperContext(jobManagement, this)
         ContextHelper.executeInContext(closure, context)
 
-        configure { Node project ->
+        configure ({ Node project ->
             context.wrapperNodes.each {
                 project / 'buildWrappers' << it
             }
-        }
+        }, closure, context)
     }
 
     /**
@@ -616,11 +616,11 @@ abstract class Job extends Item {
         StepContext context = new StepContext(jobManagement, this)
         ContextHelper.executeInContext(closure, context)
 
-        configure { Node project ->
+        configure ({ Node project ->
             context.stepNodes.each {
                 project / 'builders' << it
             }
-        }
+        }, closure, context)
     }
 
     /**
@@ -630,11 +630,11 @@ abstract class Job extends Item {
         PublisherContext context = new PublisherContext(jobManagement, this)
         ContextHelper.executeInContext(closure, context)
 
-        configure { Node project ->
+        configure ({ Node project ->
             context.publisherNodes.each {
                 project / 'publishers' << it
             }
-        }
+        }, closure, context)
     }
 
     @Override

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
@@ -196,6 +196,16 @@ interface JobManagement {
     boolean isMinimumPluginVersionInstalled(String pluginShortName, String version)
 
     /**
+     * Returns true if the current Process JobDsl step will execute only whitelisted JobDsl blocks
+     */
+    boolean executeOnlyWhitelistedDsl()
+
+    /**
+     * Returns the whitelist for what's allowed in this Process JobDsl step
+     */
+    String[] getJobDslWhitelist()
+
+    /**
      * Returns the version of Jenkins.
      *
      * @since 1.33

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobSpec.groovy
@@ -78,7 +78,7 @@ class JobSpec extends Specification {
 
     def 'update Node using withXml'() {
         setup:
-        TestJob job = new TestJob(null)
+        TestJob job = new TestJob(jobManagement)
         AtomicBoolean boolOutside = new AtomicBoolean(true)
 
         when: 'Simple update'

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
@@ -137,6 +137,8 @@ public class ExecuteDslScripts extends Builder implements SimpleBuildStep {
 
     private boolean unstableOnDeprecation;
 
+    private String jobDslWhitelist;
+
     private RemovedJobAction removedJobAction = RemovedJobAction.IGNORE;
 
     private RemovedViewAction removedViewAction = RemovedViewAction.IGNORE;
@@ -267,6 +269,15 @@ public class ExecuteDslScripts extends Builder implements SimpleBuildStep {
         this.unstableOnDeprecation = unstableOnDeprecation;
     }
 
+    public String getJobDslWhitelist() {
+        return jobDslWhitelist;
+    }
+
+    @DataBoundSetter
+    public void setJobDslWhitelist(String jobDslWhitelist) {
+        this.jobDslWhitelist = fixEmptyAndTrim(jobDslWhitelist);
+    }
+
     public RemovedJobAction getRemovedJobAction() {
         return removedJobAction;
     }
@@ -291,6 +302,7 @@ public class ExecuteDslScripts extends Builder implements SimpleBuildStep {
 
     @DataBoundSetter
     public void setLookupStrategy(LookupStrategy lookupStrategy) {
+
         this.lookupStrategy = lookupStrategy;
     }
 
@@ -340,6 +352,7 @@ public class ExecuteDslScripts extends Builder implements SimpleBuildStep {
             );
             jenkinsJobManagement.setFailOnMissingPlugin(failOnMissingPlugin);
             jenkinsJobManagement.setUnstableOnDeprecation(unstableOnDeprecation);
+            jenkinsJobManagement.setJobDslWhitelist(jobDslWhitelist);
             JobManagement jobManagement = new InterruptibleJobManagement(jenkinsJobManagement);
 
             ScriptRequestGenerator generator = new ScriptRequestGenerator(workspace, env);

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/InterruptibleJobManagement.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/InterruptibleJobManagement.groovy
@@ -139,6 +139,16 @@ class InterruptibleJobManagement implements JobManagement {
     }
 
     @Override
+    boolean executeOnlyWhitelistedDsl() {
+        delegate.executeOnlyWhitelistedDsl()
+    }
+
+    @Override
+    String[] getJobDslWhitelist() {
+        delegate.getJobDslWhitelist()
+    }
+
+    @Override
     Integer getVSphereCloudHash(String name) {
         delegate.getVSphereCloudHash(name)
     }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -39,6 +39,7 @@ import jenkins.model.DirectlyModifiableTopLevelItemGroup;
 import jenkins.model.Jenkins;
 import jenkins.model.ModifiableTopLevelItemGroup;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
 import org.custommonkey.xmlunit.Diff;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
@@ -85,6 +86,7 @@ public class JenkinsJobManagement extends AbstractJobManagement {
             new HashMap<javaposse.jobdsl.dsl.Item, DslEnvironment>();
     private boolean failOnMissingPlugin;
     private boolean unstableOnDeprecation;
+    private String[] jobDslWhitelist;
 
     @Deprecated
     public JenkinsJobManagement(PrintStream outputLogger, Map<String, ?> envVars, AbstractBuild<?, ?> build,
@@ -115,9 +117,28 @@ public class JenkinsJobManagement extends AbstractJobManagement {
         this.failOnMissingPlugin = failOnMissingPlugin;
     }
 
+    void setJobDslWhitelist(String jobDslWhitelist) {
+        this.jobDslWhitelist = (StringUtils.isEmpty(jobDslWhitelist)) ? new String[0] : jobDslWhitelist.split("\n");
+    }
+
+    @Override
+    public String[] getJobDslWhitelist() {
+        return jobDslWhitelist;
+    }
+
+    /**
+     * Returns true if the current Process JobDsl step will execute only whitelisted JobDsl blocks
+     */
+    @Override
+    public boolean executeOnlyWhitelistedDsl() {
+        return (jobDslWhitelist.length > 0);
+    }
+
     void setUnstableOnDeprecation(boolean unstableOnDeprecation) {
         this.unstableOnDeprecation = unstableOnDeprecation;
     }
+
+
 
     @Override
     public String getConfig(String path) throws JobConfigurationNotFoundException {

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/config.jelly
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/config.jelly
@@ -45,5 +45,9 @@
         <f:entry title="Mark build as unstable when using deprecated features:" field="unstableOnDeprecation">
             <f:checkbox name="unstableOnDeprecation" checked="${instance.unstableOnDeprecation}"/>
         </f:entry>
+
+         <f:entry title="Job DSL Whitelist" field="jobDslWhitelist">
+                     <f:expandableTextbox/>
+        </f:entry>
     </f:advanced>
 </j:jelly>

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-jobDslWhitelist.html
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-jobDslWhitelist.html
@@ -1,0 +1,44 @@
+<div>
+    Define a whitelist if you would like to restrict the type of job dsl that is allowed to be processed to create new
+    jobs.
+    <h3>There are three types of job dsl blocks that you can define using the whitelist</h3>
+    <ul>
+        <li>
+            <b>Publish, Step, Wrapper, and scm job dsl blocks</b>
+            If you want to whitelist Publish, Step, Wrapper, and scm job dsl blocks, simply whitelist the class that
+            defines the Perform method for that particular build, publish, wrapper, or scm plugin step. If you don't
+            know this, or can't find the class path, simply run the Process JobDsl Step with Whitelisting turned on
+            (just put a dummy class name in the text box), and the console output will indicate the class name that
+            needs to be whitelisted for the job dsl to be processed successfully.
+
+            <u>Example job dsl code:</u>(in this case, hudson.plugins.emailext.ExtendedEmailPublisher would need to be in the whitelist)
+            job() {
+                publish real thing... do email?
+            }
+        </li>
+        <li>
+            <b>Publish, Step, Wrapper, and scm job dsl blocks defined in an External Helper Class</b>
+            If you want to whitelist Publish, Step, Wrapper, and scm job dsl blocks, simply whitelist the class
+            <u>Example job dsl code:</u>(in this case, helper.MyStepHelperClass would need to be in the whitelist)
+            import helper.MyStepHelperClass
+
+            job() {
+                step myCustomStepDefinition()
+            }
+        </li>
+        <li>
+            <b>Configure Blocks defined in an External Helper Class</b>
+            If you want to whitelist configure job dsl blocks, you must pull these into an external class, and whitelist
+            that class name. For more information on how to pull a re-usable configure block into an external, helper
+            class, look at
+            <a href="https://github.com/jenkinsci/job-dsl-plugin/wiki/The-Configure-Block"> The Configure Block Wiki</a>
+            page
+            <u>Example job dsl code:</u>(in this case, helper.MyConfigHelperClass would need to be in the whitelist)
+            import helper.MyConfigHelperClass
+
+            job() {
+            configure myCustomConfigDefinition()
+            }
+        </li>
+    </ul>
+</div>

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-jobDslWhitelist.html
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-jobDslWhitelist.html
@@ -1,44 +1,66 @@
 <div>
-    Define a whitelist if you would like to restrict the type of job dsl that is allowed to be processed to create new
-    jobs.
-    <h3>There are three types of job dsl blocks that you can define using the whitelist</h3>
-    <ul>
+    Add classes to this whitelist if you would like to restrict the type of job dsl that is allowed to be processed to
+    create new jobs. Once one or more classes are added to the whitelist, whitelisting is "turned on" for this Process
+    Job DSLs" step and if any dsl blocks attempt to be processed that are not whitelisted, this step will fail, and
+    not create or update the job accordingly.<br/><br/>
+    Whitelisting only supports a subset of job dsl blocks at the moment. Namely any dsl defined under step, publish,
+    scm, or wrapper block can be whitelisted. In addition, you can whitelist config blocks if they are defined in an
+    external class. For more details on how to whitelist these, see below. <br/><br/>
+    If you want to use the whitelist feature, but need to allow dsl blocks outside of these types, you would need to
+    contribute back to the job-dsl plugin to add support.
+    <h3>The three types of job dsl blocks that can be whitelisted</h3>
+    <ol>
         <li>
-            <b>Publish, Step, Wrapper, and scm job dsl blocks</b>
-            If you want to whitelist Publish, Step, Wrapper, and scm job dsl blocks, simply whitelist the class that
-            defines the Perform method for that particular build, publish, wrapper, or scm plugin step. If you don't
-            know this, or can't find the class path, simply run the Process JobDsl Step with Whitelisting turned on
-            (just put a dummy class name in the text box), and the console output will indicate the class name that
-            needs to be whitelisted for the job dsl to be processed successfully.
+            <b>publish, step, wrapper, and scm job dsl blocks defined directly in the DSL script - </b>
+            If you want to whitelist publish, step, wrapper, or scm job dsl blocks, simply whitelist the class that
+            defines the Perform method for that particular step, publish, wrapper, or scm plugin. <br/>If you don't
+            know this, simply run the Process JobDsl Step with whitelisting turned on (just put a dummy class name in
+            the text box), and the console output will error and spit out the class name that needs to be whitelisted
+            for the job dsl to be processed successfully.<br/>
 
-            <u>Example job dsl code:</u>(in this case, hudson.plugins.emailext.ExtendedEmailPublisher would need to be in the whitelist)
-            job() {
-                publish real thing... do email?
+            <u>Example job dsl code:</u>(in this case, <i>hudson.plugins.emailext.ExtendedEmailPublisher</i> would need to be
+            in the whitelist)<br/><br/>
+            job() {<br/>
+            &ensp;extendedEmail {<br/>
+            &ensp;&ensp;recipientList('$DEFAULT_RECIPIENTS')<br/>
+            &ensp;&ensp;defaultSubject('$DEFAULT_SUBJECT')<br/>
+            &ensp;&ensp;defaultContent('$DEFAULT_CONTENT')<br/>
+            &ensp;&ensp;contentType('default')<br/>
+            &ensp;&ensp;triggers {<br/>
+            &ensp;&ensp;&ensp;...<br/>
+            &ensp;&ensp;}<br/>
+            &ensp;}<br/>
             }
         </li>
         <li>
-            <b>Publish, Step, Wrapper, and scm job dsl blocks defined in an External Helper Class</b>
-            If you want to whitelist Publish, Step, Wrapper, and scm job dsl blocks, simply whitelist the class
-            <u>Example job dsl code:</u>(in this case, helper.MyStepHelperClass would need to be in the whitelist)
-            import helper.MyStepHelperClass
+            <b>publish, step, wrapper, and scm job dsl blocks defined in an <i> External Helper Class</i> - </b>
+            If you want to whitelist publish, step, wrapper, and scm job dsl blocks defined in an external class,
+            simply whitelist the external class. For more information on how to put a re-usable dsl block into an
+            external, helper class, look at
+            <a href="https://github.com/jenkinsci/job-dsl-plugin/wiki/The-Configure-Block"> The Configure Block Wiki</a>
+            page. <br/>
+            <u>Example job dsl code:</u>(in this case, if closure myCustomStepDefinition() is defined in
+            helper.MyStepHelperClass, <i>helper.MyStepHelperClass</i> that would need to be in the whitelist)<br/><br/>
+            import helper.MyStepHelperClass<br/><br/>
 
-            job() {
-                step myCustomStepDefinition()
+            job() {<br/>
+            &ensp;step myCustomStepDefinition()<br/>
             }
         </li>
         <li>
-            <b>Configure Blocks defined in an External Helper Class</b>
+            <b>Configure Blocks defined in an External Helper Class - </b>
             If you want to whitelist configure job dsl blocks, you must pull these into an external class, and whitelist
             that class name. For more information on how to pull a re-usable configure block into an external, helper
             class, look at
             <a href="https://github.com/jenkinsci/job-dsl-plugin/wiki/The-Configure-Block"> The Configure Block Wiki</a>
-            page
-            <u>Example job dsl code:</u>(in this case, helper.MyConfigHelperClass would need to be in the whitelist)
-            import helper.MyConfigHelperClass
+            page<br/>
+            <u>Example job dsl code:</u>(in this case, if closure myCustomConfigDefinition is defined in the class
+            helper.MyConfigHelperClass, <i>helper.MyConfigHelperClass</i> would need to be in the whitelist)<br/><br/>
+            import helper.MyConfigHelperClass<br/><br/>
 
-            job() {
-            configure myCustomConfigDefinition()
+            job() {<br/>
+            &ensp;configure myCustomConfigDefinition()<br/>
             }
         </li>
-    </ul>
+    </ol>
 </div>


### PR DESCRIPTION
Whitelisting allows administers to only allow a subset of "approved" job dsl to be processed to create new jobs. We will use in our environment by allowing them to define the job dsl file in source control, and by adding these whitelisting options to all seed jobs to ensure they are using only supported build, publish, scm, config, and wrapper steps.
See the help-jobDslWhitelist.html for more detailed info.