### PR TITLE
Syntax to set multiple ssh agent credentials

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext/sshAgent.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext/sshAgent.groovy
@@ -1,5 +1,5 @@
 job('example') {
     wrappers {
-        sshAgent('deployment-key')
+        sshAgent('deployment-key', 'another-deployment-key')
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -185,11 +185,13 @@ class WrapperContext extends AbstractExtensibleContext {
      * @param credentials name of the credentials to use
      */
     @RequiresPlugin(id = 'ssh-agent')
-    void sshAgent(String credentials) {
+    void sshAgent(String... credentials) {
         Preconditions.checkNotNull(credentials, 'credentials must not be null')
 
-        wrapperNodes << new NodeBuilder().'com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper' {
-            user(credentials)
+        credentials.each { credential ->
+            wrapperNodes << new NodeBuilder().'com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper' {
+                user(credential)
+            }
         }
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -401,6 +401,17 @@ class WrapperContextSpec extends Specification {
         1 * mockJobManagement.requirePlugin('ssh-agent')
     }
 
+    def 'sshAgent with multiple credentials'() {
+        when:
+        context.sshAgent('acme-1', 'acme-2')
+
+        then:
+        context.wrapperNodes[0].name() == 'com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper'
+        context.wrapperNodes[0].user[0].value() == 'acme-1'
+        context.wrapperNodes[1].user[0].value() == 'acme-2'
+        1 * mockJobManagement.requirePlugin('ssh-agent')
+    }
+
     def 'ansiColor with map'() {
         when:
         context.colorizeOutput('foo')


### PR DESCRIPTION
This is intended to turn DSL like this

```groovy
job('example') {
    wrappers {
        sshAgent('user-a', 'user-b')
    }
}
```

Into XML like this

```xml
<project>
    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
        <user>user-a</user>
    </com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
        <user>user-b</user>
    </com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
</project>
````