### PR TITLE
Fix documentation for gerrit

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GerritContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GerritContext.groovy
@@ -92,9 +92,9 @@ class GerritContext implements Context {
     }
 
     /**
-     * Specifies on which Gerrit projects to trigger a build on. Use a {@code '<type>:<pattern>'} notation to specify
-     * a project or branch name pattern. Supported types are {@code plain} (default), {@code ant} (called "Path" in the
-     * UI) and {@code reg_exp}.
+     * Specifies on which Gerrit projects to trigger a build on. Use a {@code '&lt;type&gt;:&lt;pattern&gt;'} notation
+     * to specify a project or branch name pattern. Supported types are {@code plain} (default), {@code ant} (called
+     * "Path" in the UI) and {@code reg_exp}.
      */
     void project(String projectName, List<String> branches) {
         projects << [
@@ -104,9 +104,9 @@ class GerritContext implements Context {
     }
 
     /**
-     * Specifies on which Gerrit projects to trigger a build on. Use a {@code '<type>:<pattern>'} notation to specify
-     * a project or branch name pattern. Supported types are {@code plain} (default), {@code ant} (called "Path" in the
-     * UI) and {@code reg_exp}.
+     * Specifies on which Gerrit projects to trigger a build on. Use a {@code '&lt;type&gt;:&lt;pattern&gt;'} notation
+     * to specify a project or branch name pattern. Supported types are {@code plain} (default), {@code ant} (called
+     * "Path" in the UI) and {@code reg_exp}.
      */
     void project(String projectName, String branch) {
         project(projectName, [branch])


### PR DESCRIPTION
The keyword names in angle brackets in groovydoc were ommited when
rendering the documentation