### PR TITLE
Update gitParam with missing options

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -230,6 +230,9 @@ class BuildParametersContext extends AbstractExtensibleContext {
                     tagFilter(context.tagFilter ?: '')
                     sortMode(context.sortMode)
                     defaultValue(context.defaultValue ?: '')
+                    branchFilter(context.branchFilter ?: '')
+                    quickFilterEnabled(context.quickFilterEnabled ?: false)
+                    useRepository(context.useRepository ?: '')
                 }
     }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/GitParamContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/GitParamContext.groovy
@@ -16,8 +16,11 @@ final class GitParamContext implements Context {
     String type = 'TAG'
     String branch
     String tagFilter
+    String branchFilter
     String sortMode = 'NONE'
     String defaultValue
+    Boolean quickFilterEnabled
+    String useRepository
 
     /**
      * Sets a description for the parameter.
@@ -59,6 +62,29 @@ final class GitParamContext implements Context {
     void sortMode(String sortMode) {
         checkArgument(VALID_SORT_MODES.contains(sortMode), "sortMode must be one of ${VALID_SORT_MODES.join(', ')}")
         this.sortMode = sortMode
+    }
+
+    /**
+     * Regex used to filter displayed branches. If blank, the filter will default to ".*".
+     * Remote branches will be listed with the remote name first. E.g., "origin/master"
+     */
+    void branchFilter(String branchFilter) {
+        this.branchFilter = branchFilter
+    }
+    /**
+     * When this option is enabled will show a text field.
+     * Parameter is filtered on the fly.
+     */
+    void quickFilterEnabled(boolean quickFilterEnabled) {
+        this.quickFilterEnabled = quickFilterEnabled
+    }
+    /**
+     *If in the task is defined multiple repositories parameter specifies which the repository is taken into account.
+     * If the parameter is not defined, is taken first defined repository.
+     * The parameter is a regular expression which is compared with a URL repository.
+     */
+    void useRepository(String useRepository) {
+        this.useRepository = useRepository
     }
 
     /**

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -923,7 +923,7 @@ class BuildParametersContextSpec extends Specification {
         context.buildParameterNodes.size() == 1
         with(context.buildParameterNodes['paramName']) {
             name() == 'net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition'
-            children().size() == 8
+            children().size() == 11
             name.text() == 'paramName'
             description[0].value() == ''
             UUID.fromString(uuid[0].value() as String)
@@ -932,6 +932,9 @@ class BuildParametersContextSpec extends Specification {
             tagFilter[0].value() == ''
             sortMode[0].value() == 'NONE'
             defaultValue[0].value() == ''
+            branchFilter[0].value() == ''
+            quickFilterEnabled[0].value() == false
+            useRepository[0].value() == ''
         }
         1 * jobManagement.requireMinimumPluginVersion('git-parameter', '0.4.0')
     }
@@ -945,6 +948,9 @@ class BuildParametersContextSpec extends Specification {
             tagFilter('*')
             sortMode('ASCENDING_SMART')
             defaultValue('foo')
+            branchFilter('*')
+            quickFilterEnabled(true)
+            useRepository('repository')
         }
 
         then:
@@ -952,7 +958,7 @@ class BuildParametersContextSpec extends Specification {
         context.buildParameterNodes.size() == 1
         with(context.buildParameterNodes['sha']) {
             name() == 'net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition'
-            children().size() == 8
+            children().size() == 11
             name.text() == 'sha'
             description[0].value() == 'Revision commit SHA'
             UUID.fromString(uuid[0].value() as String)
@@ -961,6 +967,9 @@ class BuildParametersContextSpec extends Specification {
             tagFilter[0].value() == '*'
             sortMode[0].value() == 'ASCENDING_SMART'
             defaultValue[0].value() == 'foo'
+            branchFilter[0].value() == '*'
+            quickFilterEnabled[0].value() == true
+            useRepository[0].value() == 'repository'
         }
         1 * jobManagement.requireMinimumPluginVersion('git-parameter', '0.4.0')
     }


### PR DESCRIPTION
The pull request adds three options that already exist in the git parameters plugin (since 0.4)