### PR TITLE
Add support for secret urls and retries

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/toplevel/NotificationContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/toplevel/NotificationContext.groovy
@@ -3,6 +3,7 @@ package javaposse.jobdsl.dsl.helpers.toplevel
 import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.DslContext
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.RequiresPlugin
 
 import static javaposse.jobdsl.dsl.ContextHelper.executeInContext
 import static javaposse.jobdsl.dsl.Preconditions.checkArgument
@@ -16,6 +17,46 @@ class NotificationContext extends AbstractContext {
 
     NotificationContext(JobManagement jobManagement) {
         super(jobManagement)
+    }
+
+    /**
+     * Adds an endpoint with a URL sourced from the Jenkins credential store
+     *
+     * @see #secretEndpoint(java.lang.String, java.lang.String, java.lang.String, groovy.lang.Closure)
+     */
+    @RequiresPlugin(id = 'notification', minimumVersion = '1.12')
+    void secretEndpoint(String credentialsId, String protocol = 'HTTP', String format = 'JSON') {
+        secretEndpoint(credentialsId, protocol, format, null)
+    }
+
+    /**
+     * Adds an endpoint with a URL sourced from the Jenkins credential store
+     *
+     * Possible values for the protocol argument are {@code 'HTTP'}, {@code 'TCP'}, and {@code 'UDP'}.
+     * Possible values for the format argument are {@code 'JSON'} and {@code 'XML'}.
+     */
+    @RequiresPlugin(id = 'notification', minimumVersion = '1.12')
+    void secretEndpoint(String credentialsId, String protocol = 'HTTP', String format = 'JSON',
+                  @DslContext(NotificationEndpointContext) Closure notificationEndpointClosure) {
+        checkNotNullOrEmpty(credentialsId, 'credentials id must be specified')
+        checkArgument(PROTOCOLS.contains(protocol), "protocol must be one of ${PROTOCOLS.join(', ')}")
+        checkArgument(FORMATS.contains(format), "format must be one of ${FORMATS.join(', ')}")
+
+        NotificationEndpointContext notificationEndpointContext = new NotificationEndpointContext(jobManagement)
+        executeInContext(notificationEndpointClosure, notificationEndpointContext)
+
+        endpoints << NodeBuilder.newInstance().'com.tikal.hudson.plugins.notification.Endpoint' {
+            urlInfo {
+                urlOrId(credentialsId)
+                urlType('SECRET')
+            }
+            delegate.protocol(protocol)
+            delegate.format(format)
+            event(notificationEndpointContext.event)
+            timeout(notificationEndpointContext.timeout)
+            loglines(notificationEndpointContext.logLines)
+            retries(notificationEndpointContext.retries)
+        }
     }
 
     /**
@@ -43,12 +84,24 @@ class NotificationContext extends AbstractContext {
         executeInContext(notificationEndpointClosure, notificationEndpointContext)
 
         endpoints << NodeBuilder.newInstance().'com.tikal.hudson.plugins.notification.Endpoint' {
-            delegate.url(url)
+            // Newer versions of this plugin use a different format for the URL
+            if (jobManagement.isMinimumPluginVersionInstalled('notification', '1.12')) {
+                urlInfo {
+                    urlOrId(url)
+                    urlType('PUBLIC')
+                }
+            }
+            else {
+                delegate.url(url)
+            }
             delegate.protocol(protocol)
             delegate.format(format)
             event(notificationEndpointContext.event)
             timeout(notificationEndpointContext.timeout)
             loglines(notificationEndpointContext.logLines)
+            if (jobManagement.isMinimumPluginVersionInstalled('notification', '1.12')) {
+                retries(notificationEndpointContext.retries)
+            }
         }
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/toplevel/NotificationEndpointContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/toplevel/NotificationEndpointContext.groovy
@@ -2,6 +2,7 @@ package javaposse.jobdsl.dsl.helpers.toplevel
 
 import javaposse.jobdsl.dsl.AbstractContext
 import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.RequiresPlugin
 
 import static javaposse.jobdsl.dsl.Preconditions.checkArgument
 
@@ -11,6 +12,7 @@ class NotificationEndpointContext extends AbstractContext {
     String event = 'all'
     int timeout = 30000
     int logLines
+    int retries
 
     NotificationEndpointContext(JobManagement jobManagement) {
         super(jobManagement)
@@ -41,5 +43,15 @@ class NotificationEndpointContext extends AbstractContext {
      */
     void logLines(int lines) {
         this.logLines = lines
+    }
+
+    /**
+     * Sets the number of times the endpoint should be retried
+     *
+     * @since 1.60
+     */
+    @RequiresPlugin(id = 'notification', minimumVersion = '1.12')
+    void retries(int retries) {
+        this.retries = retries
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobSpec.groovy
@@ -940,6 +940,30 @@ class JobSpec extends Specification {
         1 * jobManagement.requirePlugin('delivery-pipeline-plugin')
         1 * jobManagement.logPluginDeprecationWarning('delivery-pipeline-plugin', '0.10.0')
     }
+    
+    def 'set notification with default properties new url format'() {
+        when:
+        job.notifications {
+            endpoint('http://endpoint.com')
+        }
+
+        then:
+        with(job.node.properties[0].'com.tikal.hudson.plugins.notification.HudsonNotificationProperty') {
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'.size() == 1
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].children().size() == 7
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].urlInfo.children.size() == 2
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].urlInfo[0].urlOrId[0].text() == 
+                'http://endpoint.com'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].urlInfo[0].urlType[0].text() == 'PUBLIC'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].protocol[0].text() == 'HTTP'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].format[0].text() == 'JSON'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].event[0].text() == 'all'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].timeout[0].value() == 30000
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].loglines[0].value() == 0
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].retries[0].value() == 0
+        }
+        1 * jobManagement.requireMinimumPluginVersion('notification', '1.12')
+    }
 
     def 'set notification with default properties'() {
         when:
@@ -961,6 +985,30 @@ class JobSpec extends Specification {
         1 * jobManagement.requireMinimumPluginVersion('notification', '1.8')
     }
 
+    def 'set notification with all required properties new url format'() {
+        when:
+        job.notifications {
+            endpoint('http://endpoint.com', 'TCP', 'XML')
+        }
+
+        then:
+        with(job.node.properties[0].'com.tikal.hudson.plugins.notification.HudsonNotificationProperty') {
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'.size() == 1
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].children().size() == 7
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].urlInfo.children.size() == 2
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].urlInfo[0].urlOrId[0].text() == 
+                'http://endpoint.com'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].urlInfo[0].urlType[0].text() == 'PUBLIC'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].protocol[0].text() == 'TCP'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].format[0].text() == 'XML'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].event[0].text() == 'all'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].timeout[0].value() == 30000
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].loglines[0].value() == 0
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].retries[0].value() == 0
+        }
+        1 * jobManagement.requireMinimumPluginVersion('notification', '1.12')
+    }
+    
     def 'set notification with all required properties'() {
         when:
         job.notifications {
@@ -1082,5 +1130,72 @@ class JobSpec extends Specification {
             endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[1].loglines[0].value() == 0
         }
         1 * jobManagement.requireMinimumPluginVersion('notification', '1.8')
+    }
+    
+    def 'set notification with default properties new url format and secret endpoint'() {
+        when:
+        job.notifications {
+            secretEndpoint('http://endpoint.com')
+        }
+
+        then:
+        with(job.node.properties[0].'com.tikal.hudson.plugins.notification.HudsonNotificationProperty') {
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'.size() == 1
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].children().size() == 7
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].urlInfo.children.size() == 2
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].urlInfo[0].urlOrId[0].text() == 
+                'http://endpoint.com'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].urlInfo[0].urlType[0].text() == 'SECRET'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].protocol[0].text() == 'HTTP'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].format[0].text() == 'JSON'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].event[0].text() == 'all'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].timeout[0].value() == 30000
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].loglines[0].value() == 0
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].retries[0].value() == 0
+        }
+        1 * jobManagement.requireMinimumPluginVersion('notification', '1.12')
+    }
+    
+    def 'set notification with secret and public endpoint'() {
+        when:
+        job.notifications {
+            endpoint('http://endpoint1.com')
+            secretEndpoint('http://endpoint2.com', 'TCP', 'XML') {
+                event('started')
+                timeout(10000)
+                logLines(10)
+                retries(3)
+            }
+        }
+
+        then:
+        with(job.node.properties[0].'com.tikal.hudson.plugins.notification.HudsonNotificationProperty') {
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'.size() == 2
+
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].children().size() == 7
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].urlInfo.children.size() == 2
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].urlInfo[0].urlOrId[0].text() == 
+                'http://endpoint.com'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].urlInfo[0].urlType[0].text() == 'PUBLIC'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].protocol[0].text() == 'HTTP'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].format[0].text() == 'JSON'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].event[0].text() == 'all'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].timeout[0].value() == 30000
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].loglines[0].value() == 0
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].retries[0].value() == 0
+            
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[1].children().size() == 7
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[1].urlInfo.children.size() == 2
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[1].urlInfo[0].urlOrId[0].text() == 
+                'http://endpoint2.com'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[1].urlInfo[0].urlType[0].text() == 'SECRET'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[1].protocol[0].text() == 'TCP'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[1].format[0].text() == 'XML'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[1].event[0].text() == 'all'
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[1].timeout[0].value() == 30000
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[1].loglines[0].value() == 3
+            endpoints.'com.tikal.hudson.plugins.notification.Endpoint'[0].retries[0].value() == 0
+        }
+        1 * jobManagement.requireMinimumPluginVersion('notification', '1.12')
     }
 }


### PR DESCRIPTION
Adds support for the notification plugin's secretEndpoint and retry functionality.

Reviewers, I have a couple questions, since I'm not totally familiar with the update process.
- This depends on this PR being merged https://github.com/jenkinsci/notification-plugin/pull/29.  Before that the functionality is unavailable.  I assume I need to update minimum versions and such in the PR after that.
- I get TooManyInvocations and TooFewInvocations for the tests I added.  Is this because the plugin version is not yet available, or is the actual released plugin code independent of the job DSL code.  If it's independent, what is wrong with those tests?
