### PR TITLE
fixed ClassFormatError

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractDslScriptLoader.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractDslScriptLoader.groovy
@@ -122,7 +122,7 @@ abstract class AbstractDslScriptLoader<S extends JobParent, G extends GeneratedI
 
     protected GroovyCodeSource createGroovyCodeSource(ScriptRequest scriptRequest) {
         if (scriptRequest.body != null) {
-            new GroovyCodeSource(scriptRequest.body, scriptRequest.scriptPath ?: 'script', DEFAULT_CODE_BASE)
+            new GroovyCodeSource(scriptRequest.body, scriptRequest.scriptName ?: 'script', DEFAULT_CODE_BASE)
         } else {
             new GroovyCodeSource(new URL(scriptRequest.urlRoots[0], scriptRequest.location))
         }


### PR DESCRIPTION
not sure why it's suddenly broken, but it's probably a good idea to use only the file name instead of the path for the generated class name