### PR TITLE
Html publisher plugin report title on v1.13

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/HtmlReportTargetContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/HtmlReportTargetContext.groovy
@@ -33,7 +33,7 @@ class HtmlReportTargetContext extends AbstractContext {
     }
 
     /**
-     * Sets the path to the HTML report directory relative to the workspace.
+     * Sets the title for html files.
      */
     void reportTitles(String reportFiles) {
         this.reportTitles = reportFiles

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/HtmlReportTargetContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/HtmlReportTargetContext.groovy
@@ -8,6 +8,7 @@ class HtmlReportTargetContext extends AbstractContext {
 
     String reportName = ''
     String reportFiles = 'index.html'
+    String reportTitles = ''
     boolean keepAll
     boolean allowMissing
     boolean alwaysLinkToLastBuild
@@ -29,6 +30,13 @@ class HtmlReportTargetContext extends AbstractContext {
      */
     void reportFiles(String reportFiles) {
         this.reportFiles = reportFiles
+    }
+
+    /**
+     * Sets the path to the HTML report directory relative to the workspace.
+     */
+    void reportTitles(String reportFiles) {
+        this.reportTitles = reportFiles
     }
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -350,6 +350,7 @@ class PublisherContext extends AbstractExtensibleContext {
                         reportName(target.reportName)
                         reportDir(target.reportDir)
                         reportFiles(target.reportFiles)
+                        reportTitles(target.reportTitles)
                         keepAll(target.keepAll)
                         allowMissing(target.allowMissing)
                         alwaysLinkToLastBuild(target.alwaysLinkToLastBuild)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -894,10 +894,11 @@ class PublisherContextSpec extends Specification {
         publisherHtmlNode.name() == 'htmlpublisher.HtmlPublisher'
         !publisherHtmlNode.reportTargets.isEmpty()
         def target = publisherHtmlNode.reportTargets[0].'htmlpublisher.HtmlPublisherTarget'[0]
-        target.children().size() == 6
+        target.children().size() == 7
         target.reportName[0].value() == ''
         target.reportDir[0].value() == 'build/*'
         target.reportFiles[0].value() == 'index.html'
+        target.reportTitles[0].value() == ''
         target.keepAll[0].value() == false
         target.allowMissing[0].value() == false
         target.alwaysLinkToLastBuild[0].value() == false
@@ -910,6 +911,7 @@ class PublisherContextSpec extends Specification {
             report('build/*') {
                 reportName('foo')
                 reportFiles('test.html')
+                reportTitles('test')
                 allowMissing()
                 keepAll()
                 alwaysLinkToLastBuild()
@@ -921,10 +923,11 @@ class PublisherContextSpec extends Specification {
         publisherHtmlNode.name() == 'htmlpublisher.HtmlPublisher'
         !publisherHtmlNode.reportTargets.isEmpty()
         def target = publisherHtmlNode.reportTargets[0].'htmlpublisher.HtmlPublisherTarget'[0]
-        target.children().size() == 6
+        target.children().size() == 7
         target.reportName[0].value() == 'foo'
         target.reportDir[0].value() == 'build/*'
         target.reportFiles[0].value() == 'test.html'
+        target.reportTitles[0].value() == 'test'
         target.keepAll[0].value() == true
         target.allowMissing[0].value() == true
         target.alwaysLinkToLastBuild[0].value() == true


### PR DESCRIPTION
New feature has been added in html publisher plugin that allows user to specify title for html files shown in the build [html publisher doc](https://wiki.jenkins-ci.org/display/JENKINS/HTML+Publisher+Plugin). A new property called reportTitles added in the html publisher plugin. In this pull request, new property is added to dsl plugin, so that users uses html publisher can make use of new feature