### PR TITLE
Feature/git no tags

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitCloneOptionsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitCloneOptionsContext.groovy
@@ -22,7 +22,7 @@ class GitCloneOptionsContext extends AbstractContext {
     }
 
     /**
-     * Do not check out tags.
+     * Do not check out tags. Defaults to {@code false}.
      */
     void noTags(boolean noTags = true) {
         this.noTags = noTags

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitCloneOptionsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitCloneOptionsContext.groovy
@@ -5,6 +5,7 @@ import javaposse.jobdsl.dsl.JobManagement
 
 class GitCloneOptionsContext extends AbstractContext {
     boolean shallow
+    boolean noTags
     String reference
     Integer timeout
     boolean honorRefspec
@@ -18,6 +19,13 @@ class GitCloneOptionsContext extends AbstractContext {
      */
     void shallow(boolean shallow = true) {
         this.shallow = shallow
+    }
+
+    /**
+     * Do not check out tags.
+     */
+    void noTags(boolean noTags = true) {
+        this.noTags = noTags
     }
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitExtensionContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitExtensionContext.groovy
@@ -64,6 +64,7 @@ class GitExtensionContext extends AbstractExtensibleContext {
 
         extensions << NodeBuilder.newInstance().'hudson.plugins.git.extensions.impl.CloneOption' {
             shallow(context.shallow)
+            noTags(context.noTags)
             reference(context.reference ?: '')
             if (context.timeout != null) {
                 timeout(context.timeout)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
@@ -267,9 +267,10 @@ class ScmContextSpec extends Specification {
         with(context.scmNodes[0]) {
             extensions.size() == 1
             extensions[0].children().size() == 1
-            extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].children().size() == 3
+            extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].children().size() == 4
             extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].reference[0].value() == ''
             extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].shallow[0].value() == false
+            extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].noTags[0].value() == false
             extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].honorRefspec[0].value() == false
         }
         1 * mockJobManagement.requireMinimumPluginVersion('git', '2.5.3')
@@ -284,6 +285,7 @@ class ScmContextSpec extends Specification {
             extensions {
                 cloneOptions {
                     shallow()
+                    noTags()
                     reference('/foo')
                     timeout(40)
                     honorRefspec()
@@ -296,9 +298,10 @@ class ScmContextSpec extends Specification {
         with(context.scmNodes[0]) {
             extensions.size() == 1
             extensions[0].children().size() == 1
-            extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].children().size() == 4
+            extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].children().size() == 5
             extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].reference[0].value() == '/foo'
             extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].shallow[0].value() == true
+            extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].noTags[0].value() == true
             extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].timeout[0].value() == 40
             extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].honorRefspec[0].value() == true
         }


### PR DESCRIPTION
The git plugin supports a [noTags](https://github.com/jenkinsci/git-plugin/blob/master/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java) option which is especially useful in combination with shallow. In fact without noTags shallow copies can get quite big.

In this PR I added the noTags option to the job dsl. The tests were extended and I tested the plugin on my local jenkins instance by creating a freestyle job with a "Process Job DSLs" task like this:

```job('DSL-Tutorial-1-Test') {
    scm {
      git {
        remote {
          name('origin')
          url('git://github.com/quidryan/aws-sdk-test.git')
        }
        extensions {
          cloneOptions {
            shallow()
            noTags()
          }
        }
      }
    }
    triggers {
        scm('H/15 * * * *')
    }
    steps {
        maven('-e clean test')
    }
}