### PR TITLE
JENKINS-44217 fixes incompatibility with the gradle plugin version 1.26

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/GradleContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/GradleContext.groovy
@@ -46,6 +46,7 @@ class GradleContext extends AbstractContext {
     /**
      * Sets a description for the build step.
      */
+    @Deprecated
     void description(String description) {
         this.description = description
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -128,7 +128,9 @@ class StepContext extends AbstractExtensibleContext {
         ContextHelper.executeInContext(gradleClosure, gradleContext)
 
         Node gradleNode = new NodeBuilder().'hudson.plugins.gradle.Gradle' {
-            description gradleContext.description
+            if (!jobManagement.isMinimumPluginVersionInstalled('gradle', '1.26')) {
+                description gradleContext.description
+            }
             switches gradleContext.switches.join(' ')
             tasks gradleContext.tasks.join(' ')
             rootBuildScriptDir gradleContext.rootBuildScriptDir


### PR DESCRIPTION
Issue
-----
With gradle plugin version 1.26 the description field was removed.
This leads to exceptions like the following:

hudson.model.FreeStyleProject	SomeJob	MissingFieldException: No field 'description' found in class 'hudson.plugins.gradle.Gradle'

The faulty commit is
https://github.com/jenkinsci/gradle-plugin/commit/ffddd0b33e7c820b16d97b5e60a330fe81917556

Solution
--------
* The description field is only written when old (< 1.26) gradle versions are installed.
* The description field is marked deprecated.

[FIXES JENKINS-44217]