### PR TITLE
JENKINS-44357 - add releaseEnvVar property to DeployArtifactsContext

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -38,6 +38,8 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
     ([#1028](https://github.com/jenkinsci/job-dsl-plugin/pull/1028))
   * Enhanced support for the [Gradle Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Gradle+Plugin)
     ([JENKINS-44217](https://issues.jenkins-ci.org/browse/JENKINS-44217))
+  * Enhanced support for the [Maven Project Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Maven+Project+Plugin)
+    ([JENKINS-44357](https://issues.jenkins-ci.org/browse/JENKINS-44357))
   * Support for older versions of the
     [HTML Publisher Plugin](https://wiki.jenkins-ci.org/display/JENKINS/HTML+Publisher+Plugin) is deprecated, see
     [Migration](Migration#migrating-to-164)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/DeployArtifactsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/DeployArtifactsContext.groovy
@@ -5,6 +5,7 @@ import javaposse.jobdsl.dsl.Context
 class DeployArtifactsContext implements Context {
     String repositoryUrl
     String repositoryId
+    String releaseEnvVar
     boolean uniqueVersion = true
     boolean evenIfUnstable
 
@@ -24,6 +25,16 @@ class DeployArtifactsContext implements Context {
      */
     void repositoryId(String repositoryId) {
         this.repositoryId = repositoryId
+    }
+
+    /**
+     * If the given environment variable is set to "true" the deploy step is skipped. Useful when using m2 release
+     * plugin.
+     *
+     * @since 1.64
+     */
+    void releaseEnvVar(String releaseEnvVar) {
+        this.releaseEnvVar = releaseEnvVar
     }
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/MavenPublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/MavenPublisherContext.groovy
@@ -24,6 +24,9 @@ class MavenPublisherContext extends PublisherContext {
             if (context.repositoryUrl) {
                 url(context.repositoryUrl)
             }
+            if (context.releaseEnvVar) {
+                releaseEnvVar(context.releaseEnvVar)
+            }
             uniqueVersion(context.uniqueVersion)
             evenIfUnstable(context.evenIfUnstable)
         }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/MavenPublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/MavenPublisherContextSpec.groovy
@@ -28,6 +28,7 @@ class MavenPublisherContextSpec extends Specification {
         context.deployArtifacts {
             repositoryUrl('foo')
             repositoryId('bar')
+            releaseEnvVar('var')
             uniqueVersion(false)
             evenIfUnstable()
         }
@@ -35,9 +36,10 @@ class MavenPublisherContextSpec extends Specification {
         then:
         with(context.publisherNodes[0]) {
             name() == 'hudson.maven.RedeployPublisher'
-            children().size() == 4
+            children().size() == 5
             url[0].value() == 'foo'
             id[0].value() == 'bar'
+            releaseEnvVar[0].value() == 'var'
             uniqueVersion[0].value() == false
             evenIfUnstable[0].value() == true
         }


### PR DESCRIPTION
Add support for the optional releaseEnvVar property in the maven plugin
RedeployPublisher.

This property controls if the publisher should be skipped when the
environment variable value is ‘true’.