### PR TITLE
Allow setting runAtStart/End flags for the build-name-setter plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -390,14 +390,17 @@ class WrapperContext extends AbstractExtensibleContext {
      * Sets the display name of a build.
      *
      * @param nameTemplate template defining the build name
+     * @param runAtStart set build name before build starts. Defaults to {@code true}.
+     * @param runAtEnd set build name after build ends. Defaults to {@code true}.
      * @since 1.24
      */
     @RequiresPlugin(id = 'build-name-setter')
-    void buildName(String nameTemplate) {
+    void buildName(String nameTemplate, boolean atStart = true, boolean atEnd = true) {
         Preconditions.checkNotNull(nameTemplate, 'Name template must not be null')
-
         wrapperNodes << new NodeBuilder().'org.jenkinsci.plugins.buildnamesetter.BuildNameSetter' {
             template nameTemplate
+            runAtStart atStart
+            runAtEnd atEnd
         }
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -822,8 +822,12 @@ class WrapperContextSpec extends Specification {
         context.buildName('#${BUILD_NUMBER} && <test>')
 
         then:
-        context.wrapperNodes[0].name() == 'org.jenkinsci.plugins.buildnamesetter.BuildNameSetter'
-        context.wrapperNodes[0].template[0].value() == '#${BUILD_NUMBER} && <test>'
+        with(context.wrapperNodes[0]) {
+            name() == 'org.jenkinsci.plugins.buildnamesetter.BuildNameSetter'
+            template[0].value() == '#${BUILD_NUMBER} && <test>'
+            runAtStart[0].value() == true
+            runAtEnd[0].value() == true
+        }
         1 * mockJobManagement.requirePlugin('build-name-setter')
     }
 
@@ -833,6 +837,20 @@ class WrapperContextSpec extends Specification {
 
         then:
         thrown(DslScriptException)
+    }
+
+    def 'call buildName with all parameters'() {
+        when:
+        context.buildName('#${BUILD_NUMBER} && <test>', true, false)
+
+        then:
+        with(context.wrapperNodes[0]) {
+            name() == 'org.jenkinsci.plugins.buildnamesetter.BuildNameSetter'
+            template[0].value() == '#${BUILD_NUMBER} && <test>'
+            runAtStart[0].value() == true
+            runAtEnd[0].value() == false
+        }
+        1 * mockJobManagement.requirePlugin('build-name-setter')
     }
 
     def 'call codeSigning with no args'() {


### PR DESCRIPTION
The build-name-setter plugin allows setting runAtStart/runAtEnd flags:

```
  <buildWrappers>
    <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.6.3">
      <template>#${BUILD_NUMBER} custom name</template>
      <runAtStart>false</runAtStart>
      <runAtEnd>false</runAtEnd>
    </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
  </buildWrappers>
```

The default values are `true` and it was not possible to change this with the DSL.