### PR TITLE
[JENKINS-45980] Adds password parameter to Job DSL

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -241,6 +241,13 @@ class BuildParametersContext extends AbstractExtensibleContext {
     }
 
     /**
+     * Defines a simple text parameter, where users can enter a masked password string value.
+     */
+    void passwordParam(String parameterName, String defaultValue = null, String description = null) {
+        simpleParam('hudson.model.PasswordParameterDefinition', parameterName, defaultValue, description)
+    }
+
+    /**
      * Defines a simple text parameter, where users can enter a multi-line string value.
      */
     void textParam(String parameterName, String defaultValue = null, String description = null) {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -529,6 +529,57 @@ class BuildParametersContextSpec extends Specification {
         thrown(DslScriptException)
     }
 
+    def 'base passwordParam usage'() {
+        when:
+        context.passwordParam('myParameterName', 'my default passwordParam value', 'myPasswordParameterDescription')
+
+        then:
+        context.buildParameterNodes != null
+        context.buildParameterNodes.size() == 1
+        context.buildParameterNodes['myParameterName'].name() == 'hudson.model.PasswordParameterDefinition'
+        context.buildParameterNodes['myParameterName'].name.text() == 'myParameterName'
+        context.buildParameterNodes['myParameterName'].defaultValue.text() == 'my default passwordParam value'
+        context.buildParameterNodes['myParameterName'].description.text() == 'myPasswordParameterDescription'
+    }
+
+    def 'simplified passwordParam usage'() {
+        when:
+        context.passwordParam('myParameterName', 'my default passwordParam value')
+
+        then:
+        context.buildParameterNodes != null
+        context.buildParameterNodes.size() == 1
+        context.buildParameterNodes['myParameterName'].name() == 'hudson.model.PasswordParameterDefinition'
+        context.buildParameterNodes['myParameterName'].name.text() == 'myParameterName'
+        context.buildParameterNodes['myParameterName'].defaultValue.text() == 'my default passwordParam value'
+        context.buildParameterNodes['myParameterName'].description.text() == ''
+    }
+
+    def 'passwordParam name argument cant be null'() {
+        when:
+        context.passwordParam(null)
+
+        then:
+        thrown(DslScriptException)
+    }
+
+    def 'passwordParam name argument cant be empty'() {
+        when:
+        context.passwordParam('')
+
+        then:
+        thrown(DslScriptException)
+    }
+
+    def 'passwordParam already defined'() {
+        when:
+        context.booleanParam('one')
+        context.passwordParam('one')
+
+        then:
+        thrown(DslScriptException)
+    }
+
     def 'base stringParam usage'() {
         when:
         context.stringParam('myParameterName', 'my default stringParam value', 'myStringParameterDescription')


### PR DESCRIPTION
See associated [feature request](https://issues.jenkins-ci.org/browse/JENKINS-45980).

Exactly as the ticket says, the password parameter is built into Jenkins/Hudson by default so why not have it as a default option in the DSL?