### PR TITLE
Add bitbucketweb to git browser plugins

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitBrowserContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitBrowserContext.groovy
@@ -75,4 +75,15 @@ class GitBrowserContext extends AbstractContext {
             delegate.url(url)
         }
     }
+
+    /**
+     * Use BitbucketWeb as repository browser.
+     *
+     * @since 1.65
+     */
+    void bitbucketWeb(String url) {
+        browser = NodeBuilder.newInstance().browser(class: 'hudson.plugins.git.browser.BitbucketWeb') {
+            delegate.url(url)
+        }
+    }
 }


### PR DESCRIPTION
This adds support for bitbucketweb as a git repository browser. The result is:

```
<scm... >
    <browser class="hudson.plugins.git.browser.BitbucketWeb">
        <url>
            https://bitbucket.org/url-to-your-repository
        </url>
    </browser>
</scm>
```