### PR TITLE
add support to git param branch filter

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -227,6 +227,7 @@ class BuildParametersContext extends AbstractExtensibleContext {
                     uuid(randomUUID().toString())
                     type("PT_$context.type")
                     branch(context.branch ?: '')
+                    branchFilter(context.branchFilter ?: '')
                     tagFilter(context.tagFilter ?: '')
                     sortMode(context.sortMode)
                     defaultValue(context.defaultValue ?: '')

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/GitParamContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/GitParamContext.groovy
@@ -15,6 +15,7 @@ final class GitParamContext implements Context {
     String description
     String type = 'TAG'
     String branch
+    String branchFilter
     String tagFilter
     String sortMode = 'NONE'
     String defaultValue
@@ -41,6 +42,13 @@ final class GitParamContext implements Context {
      */
     void branch(String branch) {
         this.branch = branch
+    }
+
+    /**
+     * Specifies a filter for branches.
+     */
+    void branchFilter(String branchFilter) {
+        this.branchFilter = branchFilter
     }
 
     /**

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -923,12 +923,13 @@ class BuildParametersContextSpec extends Specification {
         context.buildParameterNodes.size() == 1
         with(context.buildParameterNodes['paramName']) {
             name() == 'net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition'
-            children().size() == 8
+            children().size() == 9
             name.text() == 'paramName'
             description[0].value() == ''
             UUID.fromString(uuid[0].value() as String)
             type[0].value() == 'PT_TAG'
             branch[0].value() == ''
+            branchFilter[0].value() == ''
             tagFilter[0].value() == ''
             sortMode[0].value() == 'NONE'
             defaultValue[0].value() == ''
@@ -942,6 +943,7 @@ class BuildParametersContextSpec extends Specification {
             description('Revision commit SHA')
             type('REVISION')
             branch('master')
+            branchFilter('origin/.+')
             tagFilter('*')
             sortMode('ASCENDING_SMART')
             defaultValue('foo')
@@ -952,12 +954,13 @@ class BuildParametersContextSpec extends Specification {
         context.buildParameterNodes.size() == 1
         with(context.buildParameterNodes['sha']) {
             name() == 'net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition'
-            children().size() == 8
+            children().size() == 9
             name.text() == 'sha'
             description[0].value() == 'Revision commit SHA'
             UUID.fromString(uuid[0].value() as String)
             type[0].value() == 'PT_REVISION'
             branch[0].value() == 'master'
+            branchFilter[0].value() == 'origin/.+'
             tagFilter[0].value() == '*'
             sortMode[0].value() == 'ASCENDING_SMART'
             defaultValue[0].value() == 'foo'


### PR DESCRIPTION
It allows to use branch filter when using [git parameter plugin](https://wiki.jenkins.io/display/JENKINS/Git+Parameter+Plugin) 