### PR TITLE
Add support for git notes in git publisher

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/GitPublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/GitPublisherContext.groovy
@@ -12,6 +12,7 @@ class GitPublisherContext extends AbstractContext {
     boolean pushMerge
     boolean forcePush
     List<Node> tags = []
+    List<Node> notes = []
     List<Node> branches = []
 
     GitPublisherContext(JobManagement jobManagement) {
@@ -57,6 +58,24 @@ class GitPublisherContext extends AbstractContext {
             tagMessage(context.message ?: '')
             createTag(context.create)
             updateTag(context.update)
+        }
+    }
+
+    /**
+     * Adds a note to push to a remote repository. Can be called multiple times to push more notes.
+     */
+    void note(String targetRepo, String message, @DslContext(NoteToPushContext) Closure closure = null) {
+        checkNotNullOrEmpty(targetRepo, 'targetRepo must be specified')
+        checkNotNullOrEmpty(message, 'message must be specified')
+
+        NoteToPushContext context = new NoteToPushContext()
+        ContextHelper.executeInContext(closure, context)
+
+        notes << NodeBuilder.newInstance().'hudson.plugins.git.GitPublisher_-NoteToPush' {
+            targetRepoName(targetRepo)
+            noteMsg(message)
+            noteNamespace(context.namespace ?: 'master')
+            noteReplace(context.replace)
         }
     }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/NoteToPushContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/NoteToPushContext.groovy
@@ -1,0 +1,30 @@
+package javaposse.jobdsl.dsl.helpers.publisher
+
+import javaposse.jobdsl.dsl.Context
+
+class NoteToPushContext implements Context {
+    String message
+    String namespace
+    boolean replace
+
+    /**
+     * Sets the content of the note.
+     */
+    void message(String message) {
+        this.message = message
+    }
+
+    /**
+     * If set, sets the namespace of the note.
+     */
+    void namespace(String namespace) {
+        this.namespace = namespace
+    }
+
+    /**
+     * If set, replaces an existing note. Defaults to {@code false}.
+     */
+    void replace(boolean replace = true) {
+        this.replace = replace
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -945,6 +945,7 @@ class PublisherContext extends AbstractExtensibleContext {
             pushOnlyIfSuccess(context.pushOnlyIfSuccess)
             forcePush(context.forcePush)
             tagsToPush(context.tags)
+            notesToPush(context.notes)
             branchesToPush(context.branches)
         }
     }


### PR DESCRIPTION
Added support for publishing git notes in the post-build gitpublisher.

This is more or less copy-paste from the implementation of the git tag
implementation.