### PR TITLE
Ensure that passAsProperties also maps to project/system properties.

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -141,7 +141,11 @@ class StepContext extends AbstractExtensibleContext {
             makeExecutable gradleContext.makeExecutable
             fromRootBuildScriptDir gradleContext.fromRootBuildScriptDir
             useWorkspaceAsHome gradleContext.useWorkspaceAsHome
-            if (jobManagement.isMinimumPluginVersionInstalled('gradle', '1.25')) {
+
+            if (jobManagement.isMinimumPluginVersionInstalled('gradle', '1.27')) {
+                passAllAsProjectProperties gradleContext.passAsProperties
+                passAllAsSystemProperties gradleContext.passAsProperties
+            } else if (jobManagement.isMinimumPluginVersionInstalled('gradle', '1.25')) {
                 passAsProperties gradleContext.passAsProperties
             }
         }


### PR DESCRIPTION
Starting with the version 1.27 of the gradle plugin the passAsProperties
setting has been split into two settings: passAllAsProjectProperties
and passAllAsSystemProperties.

Now the passAsProperties settings forwards to both passAllAsProjectProperties
and passAllAsSystemProperties to ensure backwards compatibility.

Users can already pass project and system properties explicitly via switches.
Therefore I don't think that any further handling of system/project properties
is needed.