### PR TITLE
allow import of Groovy code from the workspace 

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -29,6 +29,8 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
 
 ## Release Notes
 * 1.67 (unreleased)
+  * Allow import of Groovy code from the workspace when script security sandbox is enabled
+    ([#1078](https://github.com/jenkinsci/job-dsl-plugin/pull/1078))
   * Enhanced support for the [Groovy Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Groovy+plugin)
     ([JENKINS-44256](https://issues.jenkins-ci.org/browse/JENKINS-44256))
   * Support for the older versions of the [Groovy Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Groovy+plugin) is

--- a/docs/Real-World-Examples.md
+++ b/docs/Real-World-Examples.md
@@ -66,12 +66,6 @@ REST API calls
 Import other files (i.e. with class definitions) into your script
 -----------------------------------------------------------------
 
-> Importing Groovy classes from the workspace is not possible when script security is enabled since that would undermine
-> the script approval process. As an alternative it is possible to package the classes into a JAR file and add that JAR
-> to the classpath through the _Additional classpath_ option. Classpath entries are subject to the approval process. See
-> [Job DSL Gradle Example](https://github.com/sheehan/job-dsl-gradle-example) or
-> [Job DSL Sample](https://github.com/unguiculus/job-dsl-sample) as starting point for building and packaging classes.
-
 Make a directory at the same level as the DSL called `utilities` and create a file called `MyUtilities.groovy` in the
 `utilities` directory with the following contents:
 
@@ -92,4 +86,4 @@ Then from the DSL, add something like this:
     def myJob = job('example')
     MyUtilities.addMyFeature(myJob)
 
-Note that importing other files is not possible when [[Script Security]] is enabled.
+Note that importing other files is not possible when [[Script Security]] is enabled and not using Groovy Sandbox.

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ScriptApprovalDslScriptLoader.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ScriptApprovalDslScriptLoader.groovy
@@ -33,7 +33,7 @@ class ScriptApprovalDslScriptLoader extends SecureDslScriptLoader {
     }
 
     protected Collection<ScriptRequest> createSecureScriptRequests(Collection<ScriptRequest> scriptRequests) {
-        super.createSecureScriptRequests(scriptRequests).each {
+        scriptRequests.collect {
             if (it.body) {
                 ScriptApproval.get().configuring(
                         it.body,
@@ -41,6 +41,9 @@ class ScriptApprovalDslScriptLoader extends SecureDslScriptLoader {
                         ApprovalContext.create().withItem(seedJob)
                 )
             }
+
+            // it is not safe to use additional classpath entries
+            new ScriptRequest(it.body, new URL[0], it.ignoreExisting, it.scriptPath)
         }
     }
 }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/SecureDslScriptLoader.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/SecureDslScriptLoader.groovy
@@ -14,10 +14,10 @@ abstract class SecureDslScriptLoader extends JenkinsDslScriptLoader {
         super.runScripts(createSecureScriptRequests(scriptRequests))
     }
 
-    protected Collection<ScriptRequest> createSecureScriptRequests(Collection<ScriptRequest> scriptRequests) {
-        scriptRequests.collect {
-            // it is not safe to use additional classpath entries
-            new ScriptRequest(it.body, new URL[0], it.ignoreExisting, it.scriptPath)
-        }
+    @Override
+    protected ClassLoader prepareClassLoader(URL[] urlRoots, ClassLoader classLoader) {
+        new URLClassLoader([] as URL[], classLoader)
     }
+
+    protected abstract Collection<ScriptRequest> createSecureScriptRequests(Collection<ScriptRequest> scriptRequests)
 }

--- a/job-dsl-plugin/src/test/groovy/ScriptHelper.groovy
+++ b/job-dsl-plugin/src/test/groovy/ScriptHelper.groovy
@@ -1,0 +1,5 @@
+class ScriptHelper {
+    static foo() {
+        'foo'
+    }
+}


### PR DESCRIPTION
... when script security sandbox is enabled

The idea is to add an `URLClassLoader` as parent for the `SandboxResolvingClassLoader`. The `URLClassLoader` is created with a single URL, the directory of the DSL script to execute or the root of the workspace for inline scripts. And the `URLClassLoader` will not resolve compiles classes (`findClass` throws `ClassNotFoundException`), but allows to read resources when the `Item.WORKSPACE` has been granted. This allows the `GroovyClassLoader` from `GroovyShell` to pick up Groovy source files. And since the compiler configuration contains the `SandboxTransformer`, those source files are subject to the sandbox.