### PR TITLE
[JENKINS-47560] fixed support for Automatically Generated DSL

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -31,6 +31,8 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
 * 1.67 (unreleased)
   * Allow import of Groovy code from the workspace when script security sandbox is enabled
     ([#1078](https://github.com/jenkinsci/job-dsl-plugin/pull/1078))
+  * Fixed support for [[Automatically Generated DSL]] when using script security sandbox
+    ([JENKINS-47560](https://issues.jenkins-ci.org/browse/JENKINS-47560))
   * Enhanced support for the [Groovy Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Groovy+plugin)
     ([JENKINS-44256](https://issues.jenkins-ci.org/browse/JENKINS-44256))
   * Enhanced support for the

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JobDslWhitelist.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JobDslWhitelist.groovy
@@ -1,6 +1,9 @@
 package javaposse.jobdsl.plugin
 
+import javaposse.jobdsl.dsl.AbstractExtensibleContext
 import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.plugin.structs.DescribableContext
+import javaposse.jobdsl.plugin.structs.DescribableListContext
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.AbstractWhitelist
 
 import java.lang.reflect.Method
@@ -9,8 +12,15 @@ import java.lang.reflect.Method
  * Allows methods defined in {@link Context}.
  */
 class JobDslWhitelist extends AbstractWhitelist {
+    private static final Method INVOKE_METHOD = GroovyObject.getDeclaredMethod('invokeMethod', String, Object)
+    private static final Set<Class> DYNAMIC_CONTEXTS = [
+            AbstractExtensibleContext, DescribableContext, DescribableListContext
+    ]
+
     @Override
     boolean permitsMethod(Method method, Object receiver, Object[] args) {
-        Context.isAssignableFrom(method.declaringClass)
+        Context.isAssignableFrom(method.declaringClass) ||
+                (method == INVOKE_METHOD && receiver.class.classLoader == JobDslWhitelist.classLoader &&
+                        DYNAMIC_CONTEXTS.any { context -> context.isInstance(receiver) })
     }
 }


### PR DESCRIPTION
… when using script security sandbox.

The idea is to allow dynamic calls to instances of the three `Context` classes used to implement the Automatically Generated DSL (`AbstractExtensibleContext`, `DescribableContext`, `DescribableListContext`) when the receiver is part of the Job DSL plugin (it's classloader is the same as the classloader of `JobDslWhitelist`).