### PR TITLE
Add unstableReturn support for shell build steps

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -35,9 +35,12 @@ class StepContext extends AbstractExtensibleContext {
      * Use {@link javaposse.jobdsl.dsl.DslFactory#readFileFromWorkspace(java.lang.String) readFileFromWorkspace} to read
      * the script from a file.
      */
-    void shell(String command) {
+    void shell(String command, String unstableReturn = null) {
         stepNodes << new NodeBuilder().'hudson.tasks.Shell' {
             delegate.command(command)
+            if (unstableReturn != null) {
+                delegate.unstableReturn(unstableReturn)
+            }
         }
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
@@ -24,6 +24,19 @@ class StepContextSpec extends Specification {
         shellStep.command[0].value() == 'echo "Hello"'
     }
 
+    def 'call shell method with unstableReturn'() {
+        when:
+        context.shell('echo "Hello"', '128')
+
+        then:
+        context.stepNodes != null
+        context.stepNodes.size() == 1
+        def shellStep = context.stepNodes[0]
+        shellStep.name() == 'hudson.tasks.Shell'
+        shellStep.command[0].value() == 'echo "Hello"'
+        shellStep.unstableReturn[0].value() == '128'
+    }
+
     def 'call remoteShell method with minimal options'() {
         when:
         context.remoteShell('root@example.com:22') {


### PR DESCRIPTION
This PR adds support for "Exit code to set build unstable" in Execute Shell build step:

<img width="957" alt="screen shot 2017-10-26 at 11 18 41" src="https://user-images.githubusercontent.com/346590/32045046-8b04d904-ba3f-11e7-8754-37cec373b87c.png">

This could also be set with something like:

```groovy
configure { project ->
  project / builders << 'hudson.tasks.Shell' {
    command "bundle exec fastlane deploy"
    unstableReturn "137"
  }
}
```

But doing:

```groovy
shell("bundle install", "137")
```

Is nicer I believe.

First time contributor so I'm not really familiar with the project 😊 

Things that might be missing:

* Check for the availability of the option. I'm not sure how this is done, I don't think this one is a plugin but I'm not sure. Also I don't know when this was introduced. Any hint of how should we handle this?