### PR TITLE
JENKINS-43637 Secured PostBuildScript plugin

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -141,8 +141,6 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
     see [Migration](Migration#migrating-to-162)
   * Support for the [Active Choices Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Active+Choices+Plugin) is
     deprecated, see [Migration](Migration#migrating-to-162)
-  * Support for the [PostBuildScript Plugin](https://wiki.jenkins-ci.org/display/JENKINS/PostBuildScript+Plugin) is
-    deprecated, see [Migration](Migration#migrating-to-162)
   * Support for the [ArtifactDeployer Plugin](https://wiki.jenkins-ci.org/display/JENKINS/ArtifactDeployer+Plugin) is
     deprecated, see [Migration](Migration#migrating-to-162)
   * Support for the [Subversion Tagging Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Subversion+Tagging+Plugin)

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -95,12 +95,6 @@ The [Active Choices Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Active+C
 Update Center due to [Security Vulnerabilities](https://jenkins.io/security/advisory/2017-04-10/). As a consequence the
 DSL support is [[deprecated|Deprecation-Policy]] and will be removed.
 
-### PostBuildScript Plugin
-
-The [PostBuildScript Plugin](https://wiki.jenkins-ci.org/display/JENKINS/PostBuildScript+Plugin) has been removed from
-the Update Center due to [Security Vulnerabilities](https://jenkins.io/security/advisory/2017-04-10/). As a consequence
-the DSL support is [[deprecated|Deprecation-Policy]] and will be removed.
-
 ### ArtifactDeployer Plugin
 
 The [ArtifactDeployer Plugin](https://wiki.jenkins-ci.org/display/JENKINS/ArtifactDeployer+Plugin) has been removed from

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1299,8 +1299,7 @@ class PublisherContext extends AbstractExtensibleContext {
      *
      * @since 1.31
      */
-    @RequiresPlugin(id = 'postbuildscript', minimumVersion = '0.17')
-    @Deprecated
+    @RequiresPlugin(id = 'postbuildscript', minimumVersion = '0.18')
     void postBuildScripts(@DslContext(PostBuildScriptsContext) Closure closure) {
         PostBuildScriptsContext context = new PostBuildScriptsContext(jobManagement, item)
         ContextHelper.executeInContext(closure, context)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -3607,8 +3607,7 @@ class PublisherContextSpec extends Specification {
             scriptOnlyIfFailure[0].value() == false
             markBuildUnstable[0].value() == false
         }
-        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '0.17')
-        1 * jobManagement.logDeprecationWarning()
+        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '0.18')
     }
 
     def 'call post build scripts with all options'() {
@@ -3632,8 +3631,7 @@ class PublisherContextSpec extends Specification {
             scriptOnlyIfFailure[0].value() == value
             markBuildUnstable[0].value() == value
         }
-        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '0.17')
-        1 * jobManagement.logDeprecationWarning()
+        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '0.18')
 
         where:
         value << [true, false]
@@ -3658,8 +3656,7 @@ class PublisherContextSpec extends Specification {
             markBuildUnstable[0].value() == false
             executeOn[0].value() == 'BOTH'
         }
-        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '0.17')
-        1 * jobManagement.logDeprecationWarning()
+        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '0.18')
     }
 
     def 'call post build scripts with all options and matrix job'() {
@@ -3689,8 +3686,7 @@ class PublisherContextSpec extends Specification {
             markBuildUnstable[0].value() == true
             executeOn[0].value() == mode
         }
-        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '0.17')
-        1 * jobManagement.logDeprecationWarning()
+        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '0.18')
 
         where:
         mode << ['MATRIX', 'AXES', 'BOTH']


### PR DESCRIPTION
Hi @daspilker !

I adopted the PostBuildScript plugin and removed the security vulnerability (see https://issues.jenkins-ci.org/browse/JENKINS-43637).

The version 0.18 does no longer contain the security problems. I hope you agree with this and allow me to remove the deprecation warning from the Job DSL plugin. 

I updated the the Publisher Context (including the tests) and the documenation.

Kind regards

Daniel