### PR TITLE
Support lightweight checkout for pipeline jobs

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/CpsScmContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/CpsScmContext.groovy
@@ -11,6 +11,7 @@ class CpsScmContext extends AbstractContext {
     protected final Item item
 
     String scriptPath = 'JenkinsFile'
+    boolean lightweight = false
     ScmContext scmContext = new ScmContext(jobManagement, item)
 
     CpsScmContext(JobManagement jobManagement, Item item) {
@@ -31,5 +32,13 @@ class CpsScmContext extends AbstractContext {
      */
     void scriptPath(String scriptPath) {
         this.scriptPath = scriptPath
+    }
+
+    /**
+     * If selected, try to obtain the Pipeline script contents directly from the SCM without performing
+     * a full checkout.
+     */
+    void lightweight(boolean lightweight) {
+        this.lightweight = lightweight
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/WorkflowDefinitionContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/WorkflowDefinitionContext.groovy
@@ -51,6 +51,7 @@ class WorkflowDefinitionContext extends AbstractExtensibleContext {
         definitionNode = new NodeBuilder().
                 definition(class: 'org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition') {
             scriptPath(context.scriptPath)
+            lightweight(context.lightweight)
         }
         definitionNode.children().add(context.scmContext.scmNodes[0])
     }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/jobs/WorkflowJobSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/jobs/WorkflowJobSpec.groovy
@@ -64,10 +64,11 @@ class WorkflowJobSpec extends Specification {
         then:
         with(job.node.definition[0]) {
             attribute('class') == 'org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition'
-            children().size() == 2
+            children().size() == 3
             scm[0].attribute('class') == 'hudson.plugins.git.GitSCM'
             scm[0].children().size() == 6
             scriptPath[0].value() == 'JenkinsFile'
+            lightweight[0].value() == false
         }
         1 * jobManagement.requireMinimumPluginVersion('workflow-cps', '1.2')
     }
@@ -80,16 +81,18 @@ class WorkflowJobSpec extends Specification {
                     git('https://github.com/jenkinsci/job-dsl-plugin.git')
                 }
                 scriptPath('.jenkins/Jenkinsfile')
+                lightweight(true)
             }
         }
 
         then:
         with(job.node.definition[0]) {
             attribute('class') == 'org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition'
-            children().size() == 2
+            children().size() == 3
             scm[0].attribute('class') == 'hudson.plugins.git.GitSCM'
             scm[0].children().size() == 6
             scriptPath[0].value() == '.jenkins/Jenkinsfile'
+            lightweight[0].value() == true
         }
         1 * jobManagement.requireMinimumPluginVersion('workflow-cps', '1.2')
     }


### PR DESCRIPTION
Add the `lightweight` property to cpsScm, to allow lightweight checkout
to retrieve the pipeline script.