### PR TITLE
Allow specify git clone depth

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitCloneOptionsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitCloneOptionsContext.groovy
@@ -9,6 +9,7 @@ class GitCloneOptionsContext extends AbstractContext {
     String reference
     Integer timeout
     boolean honorRefspec
+    Integer depth
 
     GitCloneOptionsContext(JobManagement jobManagement) {
         super(jobManagement)
@@ -51,5 +52,13 @@ class GitCloneOptionsContext extends AbstractContext {
      */
     void honorRefspec(boolean honorRefspec = true) {
         this.honorRefspec = honorRefspec
+    }
+
+    /**
+     * Set shallow clone depth, so that git will only download recent history of the project, saving time and
+     * disk space when you just want to access the latest version of a repository.
+     */
+    void depth(int depth = 0) {
+        this.depth = depth
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitExtensionContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/GitExtensionContext.groovy
@@ -70,6 +70,9 @@ class GitExtensionContext extends AbstractExtensibleContext {
                 timeout(context.timeout)
             }
             honorRefspec(context.honorRefspec)
+            if (context.depth != null) {
+                depth(context.depth)
+            }
         }
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
@@ -289,6 +289,7 @@ class ScmContextSpec extends Specification {
                     reference('/foo')
                     timeout(40)
                     honorRefspec()
+                    depth(1)
                 }
             }
         }
@@ -298,12 +299,13 @@ class ScmContextSpec extends Specification {
         with(context.scmNodes[0]) {
             extensions.size() == 1
             extensions[0].children().size() == 1
-            extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].children().size() == 5
+            extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].children().size() == 6
             extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].reference[0].value() == '/foo'
             extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].shallow[0].value() == true
             extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].noTags[0].value() == true
             extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].timeout[0].value() == 40
             extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].honorRefspec[0].value() == true
+            extensions[0].'hudson.plugins.git.extensions.impl.CloneOption'[0].depth[0].value() == 1
         }
         1 * mockJobManagement.requireMinimumPluginVersion('git', '2.5.3')
     }


### PR DESCRIPTION
Add `depth` parameter in git cloneOptions context.