### PR TITLE
Fix typo for default Jenkinsfile name

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/CpsScmContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/CpsScmContext.groovy
@@ -10,7 +10,7 @@ import javaposse.jobdsl.dsl.helpers.ScmContext
 class CpsScmContext extends AbstractContext {
     protected final Item item
 
-    String scriptPath = 'JenkinsFile'
+    String scriptPath = 'Jenkinsfile'
     ScmContext scmContext = new ScmContext(jobManagement, item)
 
     CpsScmContext(JobManagement jobManagement, Item item) {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/jobs/WorkflowJobSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/jobs/WorkflowJobSpec.groovy
@@ -67,7 +67,7 @@ class WorkflowJobSpec extends Specification {
             children().size() == 2
             scm[0].attribute('class') == 'hudson.plugins.git.GitSCM'
             scm[0].children().size() == 6
-            scriptPath[0].value() == 'JenkinsFile'
+            scriptPath[0].value() == 'Jenkinsfile'
         }
         1 * jobManagement.requireMinimumPluginVersion('workflow-cps', '1.2')
     }


### PR DESCRIPTION
Default Jenkinsfile name is `Jenkinsfile`, not `JenkinsFile`.