### PR TITLE
Undeprecate uno-choice support after security fixes

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -267,7 +267,6 @@ class BuildParametersContext extends AbstractExtensibleContext {
      * @since 1.36
      */
     @RequiresPlugin(id = 'uno-choice', minimumVersion = '1.2')
-    @Deprecated
     void activeChoiceParam(String parameterName, @DslContext(ActiveChoiceContext) Closure closure) {
         ActiveChoiceContext context = new ActiveChoiceContext()
         ContextHelper.executeInContext(closure, context)
@@ -285,7 +284,6 @@ class BuildParametersContext extends AbstractExtensibleContext {
      * @since 1.38
      */
     @RequiresPlugin(id = 'uno-choice', minimumVersion = '1.2')
-    @Deprecated
     void activeChoiceReactiveParam(String parameterName,
                                    @DslContext(ActiveChoiceReactiveContext) Closure closure = null) {
         ActiveChoiceReactiveContext context = new ActiveChoiceReactiveContext()
@@ -306,7 +304,6 @@ class BuildParametersContext extends AbstractExtensibleContext {
      * @since 1.38
      */
     @RequiresPlugin(id = 'uno-choice', minimumVersion = '1.2')
-    @Deprecated
     void activeChoiceReactiveReferenceParam(String parameterName,
                                             @DslContext(ActiveChoiceReactiveReferenceContext) Closure closure = null) {
         ActiveChoiceReactiveReferenceContext context = new ActiveChoiceReactiveReferenceContext()

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -1005,7 +1005,6 @@ class BuildParametersContextSpec extends Specification {
             filterable.text() == 'false'
         }
         1 * jobManagement.requireMinimumPluginVersion('uno-choice', '1.2')
-        1 * jobManagement.logDeprecationWarning()
     }
 
     def 'active choice param with all options and groovy script'() {
@@ -1038,7 +1037,6 @@ class BuildParametersContextSpec extends Specification {
             }
         }
         1 * jobManagement.requireMinimumPluginVersion('uno-choice', '1.2')
-        1 * jobManagement.logDeprecationWarning()
     }
 
     def 'active choice param with all options and scriptler script'() {
@@ -1077,7 +1075,6 @@ class BuildParametersContextSpec extends Specification {
             }
         }
         1 * jobManagement.requireMinimumPluginVersion('uno-choice', '1.2')
-        1 * jobManagement.logDeprecationWarning()
     }
 
     def 'active choice reactive param without options'() {
@@ -1099,7 +1096,6 @@ class BuildParametersContextSpec extends Specification {
             script.text() == ''
             referencedParameters.text() == ''
         }
-        1 * jobManagement.logDeprecationWarning()
     }
 
     def 'active choice reactive param with all options and groovy script'() {
@@ -1135,7 +1131,6 @@ class BuildParametersContextSpec extends Specification {
             }
             referencedParameters.text() == 'param1, param2'
         }
-        1 * jobManagement.logDeprecationWarning()
     }
 
     def 'active choice reactive reference param without options'() {
@@ -1157,7 +1152,6 @@ class BuildParametersContextSpec extends Specification {
             referencedParameters.text() == ''
             omitValueField.text() == 'false'
         }
-        1 * jobManagement.logDeprecationWarning()
     }
 
     def 'active choice reactive reference param with all options and scriptler script'() {
@@ -1195,7 +1189,6 @@ class BuildParametersContextSpec extends Specification {
             }
             referencedParameters.text() == 'param3, param4'
         }
-        1 * jobManagement.logDeprecationWarning()
     }
 
     def 'credentials parameter with minimal options'() {


### PR DESCRIPTION
Given that the Active Choices plugin has been reintegrated in the Update Center after it broke its
required dependency to Scriptler and made it optional, would it be possible to un-deprecate it, or maybe
deprecate only the Scriptler integration in that plugin ?