### PR TITLE
Jenkins-ClassFilter-Whitelisted: true

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,7 @@ project(':job-dsl-core') {
         manifest {
             attributes 'Main-Class': project.mainClassName
             attributes 'Implementation-Version': version
+            attributes 'Jenkins-ClassFilter-Whitelisted': 'true'
         }
     }
 


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/pull/3120 for background. This plugin required a special whitelist entry in core for `javaposse.jobdsl.dsl.GeneratedJob`. Presumably the intent is that everything in the `job-dsl-core` JAR is treated as part of the plugin and will not be exposing anything dangerous for Java or XStream serialization.

@reviewbybees