### PR TITLE
[JENKINS-48877] war-for-test classifier is not supported from 2.64+

### DIFF
--- a/docs/Testing-DSL-Scripts.md
+++ b/docs/Testing-DSL-Scripts.md
@@ -49,9 +49,8 @@ when running the DSL scripts, e.g. for testing [[extensions|Extending the DSL]] 
         testCompile 'org.spockframework:spock-core:0.7-groovy-1.8'
 
         // Jenkins test harness dependencies
-        testCompile 'org.jenkins-ci.main:jenkins-test-harness:2.8'
+        testCompile 'org.jenkins-ci.main:jenkins-test-harness:2.33'
         testCompile "org.jenkins-ci.main:jenkins-war:${jenkinsVersion}"
-        testCompile "org.jenkins-ci.main:jenkins-war:${jenkinsVersion}:war-for-test@jar"
 
         // Job DSL plugin including plugin dependencies
         testCompile "org.jenkins-ci.plugins:job-dsl:${jobDslVersion}"


### PR DESCRIPTION
[JENKINS-48877](https://issues.jenkins-ci.org/browse/JENKINS-48877)

Wiki update: 
- Bumped jenkins-test-harness and also removed the war-for-test classifier as required since version 2.64 onwards

Further details:
- https://groups.google.com/forum/#!topic/job-dsl-plugin/oPjqGR6VTpU
  
@reviewbybees