### PR TITLE
Add build selector parameter

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -391,6 +391,26 @@ class BuildParametersContext extends AbstractExtensibleContext {
                 }
     }
 
+    /**
+     * Defines a parameter that allows to specify a build selector for the copy artifact plugin.
+     *
+     * @since 1.67
+     */
+    @RequiresPlugin(id = 'copyartifact', minimumVersion = '1.31')
+    void buildSelectorParam(String parameterName,
+                            @DslContext(BuildSelectorParameterContext) Closure buildSelectorParameterClosure) {
+        checkParameterName(parameterName)
+        BuildSelectorParameterContext selectorParameterContext = new BuildSelectorParameterContext(jobManagement, item)
+        ContextHelper.executeInContext(buildSelectorParameterClosure, selectorParameterContext)
+        Node selectorParameterNode = new Node(null, 'hudson.plugins.copyartifact.BuildSelectorParameter')
+        selectorParameterNode.appendNode('name', parameterName)
+        if (selectorParameterContext.description != null) {
+            selectorParameterNode.appendNode('description', selectorParameterContext.description)
+        }
+        selectorParameterNode.append(selectorParameterContext.defaultSelectorContext.selector)
+        buildParameterNodes[parameterName] = selectorParameterNode
+    }
+
     private void checkParameterName(String name) {
         checkNotNullOrEmpty(name, 'parameterName cannot be null')
         checkArgument(!buildParameterNodes.containsKey(name), "parameter ${name} already defined")

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildSelectorParameterContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildSelectorParameterContext.groovy
@@ -1,0 +1,36 @@
+package javaposse.jobdsl.dsl.helpers
+
+import javaposse.jobdsl.dsl.AbstractContext
+import javaposse.jobdsl.dsl.ContextHelper
+import javaposse.jobdsl.dsl.DslContext
+import javaposse.jobdsl.dsl.Item
+import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.helpers.step.CopyArtifactSelectorContext
+
+class BuildSelectorParameterContext extends AbstractContext {
+
+    private static final String DEFAULT_SELECTOR = 'defaultSelector'
+
+    String description
+    CopyArtifactSelectorContext defaultSelectorContext
+
+    protected BuildSelectorParameterContext(JobManagement jobManagement, Item item) {
+        super(jobManagement)
+        defaultSelectorContext = new CopyArtifactSelectorContext(jobManagement, item, DEFAULT_SELECTOR)
+    }
+
+    /**
+     * Specifies the parameter description.
+     * @param description String value of the description
+     */
+    void description(String description) {
+        this.description = description
+    }
+
+    /**
+     * Specifies the default build selector.
+     */
+    void defaultBuildSelector(@DslContext(CopyArtifactSelectorContext) Closure defaultSelectorClosure) {
+        ContextHelper.executeInContext(defaultSelectorClosure, defaultSelectorContext)
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/CopyArtifactSelectorContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/CopyArtifactSelectorContext.groovy
@@ -10,10 +10,13 @@ import javaposse.jobdsl.dsl.RequiresPlugin
 
 @ContextType('hudson.plugins.copyartifact.BuildSelector')
 class CopyArtifactSelectorContext extends AbstractExtensibleContext {
+
+    final String classifier
     Node selector
 
-    CopyArtifactSelectorContext(JobManagement jobManagement, Item item) {
+    CopyArtifactSelectorContext(JobManagement jobManagement, Item item, String classifier = 'selector') {
         super(jobManagement, item)
+        this.classifier = classifier
         latestSuccessful()
     }
 
@@ -122,10 +125,10 @@ class CopyArtifactSelectorContext extends AbstractExtensibleContext {
      */
     @RequiresPlugin(id = 'jenkins-multijob-plugin', minimumVersion = '1.22')
     void multiJobBuild() {
-        selector = new NodeBuilder().'selector'(class: 'com.tikal.jenkins.plugins.multijob.MultiJobBuildSelector')
+        selector = new NodeBuilder()."$classifier"(class: 'com.tikal.jenkins.plugins.multijob.MultiJobBuildSelector')
     }
 
     private void createSelectorNode(String type, Closure nodeBuilder = null) {
-        selector = new NodeBuilder().'selector'(class: "hudson.plugins.copyartifact.${type}Selector", nodeBuilder)
+        selector = new NodeBuilder()."$classifier"(class: "hudson.plugins.copyartifact.${type}Selector", nodeBuilder)
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -6,6 +6,8 @@ import javaposse.jobdsl.dsl.JobManagement
 import spock.lang.Specification
 
 class BuildParametersContextSpec extends Specification {
+
+    static final String DEFAULT_SELECTOR_CLASS = 'hudson.plugins.copyartifact.StatusBuildSelector'
     JobManagement jobManagement = Mock(JobManagement)
     Item item = Mock(Item)
     BuildParametersContext context = new BuildParametersContext(jobManagement, item)
@@ -1480,5 +1482,29 @@ class BuildParametersContextSpec extends Specification {
 
         then:
         thrown(DslScriptException)
+    }
+
+    def 'should add buildSelectorParameter node'() {
+        when:
+        context.buildSelectorParam('myParameterName') { description('myDescription') }
+        then:
+        context.buildParameterNodes
+        context.buildParameterNodes.size() == 1
+        context.buildParameterNodes['myParameterName'].name() == 'hudson.plugins.copyartifact.BuildSelectorParameter'
+        context.buildParameterNodes['myParameterName'].name.text() == 'myParameterName'
+        context.buildParameterNodes['myParameterName'].children().size() == 3
+        context.buildParameterNodes['myParameterName'].description.text() == 'myDescription'
+        context.buildParameterNodes['myParameterName'].defaultSelector.get(0).attributes().class ==
+                DEFAULT_SELECTOR_CLASS
+    }
+
+    def 'buildSelectorParameter name should not be null, empty or previously defined'() {
+        when:
+        context.stringParam('myParameterName')
+        context.buildSelectorParam(name) {}
+        then:
+        thrown(DslScriptException)
+        where:
+        name << [null, '', 'myParameterName']
     }
 }


### PR DESCRIPTION
This is a PR to allow using the Build Selector Parameter for the Copy Artifact Plugin (https://wiki.jenkins.io/display/JENKINS/Copy+Artifact+Plugin),

NOTE: I do know that an auto-generated method for that in theory exists, however, it does not work properly. Using it according to the API causes the following error:

> ERROR: Found multiple extensions which provide method upstream with arguments [devskiller.services.ServicesJobBuilder$_configureDeployJob_closure4$_closure20$_closure25$_closure26$_closure27@12fb813d]: [[com.tikal.jenkins.plugins.multijob.MultiJobBuildSelector, hudson.plugins.copyartifact.TriggeredBuildSelector]]
> Finished: FAILURE

The changes in this PR have been tested and they generate the parameter correctly.
