### PR TITLE
JENKINS-49218 Using new PostBuildScript configuration format of v2.3.0

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1298,16 +1298,44 @@ class PublisherContext extends AbstractExtensibleContext {
      *
      * @since 1.31
      */
-    @RequiresPlugin(id = 'postbuildscript', minimumVersion = '0.17')
+    @RequiresPlugin(id = 'postbuildscript', minimumVersion = '2.3.0')
     void postBuildScripts(@DslContext(PostBuildScriptsContext) Closure closure) {
         PostBuildScriptsContext context = new PostBuildScriptsContext(jobManagement, item)
         ContextHelper.executeInContext(closure, context)
 
-        publisherNodes << new NodeBuilder().'org.jenkinsci.plugins.postbuildscript.PostBuildScript' {
-            buildSteps(context.stepContext.stepNodes)
-            scriptOnlyIfSuccess(context.onlyIfBuildSucceeds)
-            scriptOnlyIfFailure(context.onlyIfBuildFails)
-            markBuildUnstable(context.markBuildUnstable)
+        String nodeName
+        if (item instanceof MatrixJob) {
+            nodeName = 'org.jenkinsci.plugins.postbuildscript.MatrixPostBuildScript'
+        } else {
+            nodeName = 'org.jenkinsci.plugins.postbuildscript.PostBuildScript'
+        }
+
+        publisherNodes << new NodeBuilder()."${nodeName}" {
+            config {
+                scriptFiles {
+                    // not yet implemented
+                }
+                groovyScripts {
+                    // not yet implemented
+                }
+                buildSteps {
+                    if (!context.stepContext.stepNodes.empty) {
+                        'org.jenkinsci.plugins.postbuildscript.model.PostBuildStep' {
+                            results {
+                                if (context.onlyIfBuildSucceeds) {
+                                    string 'SUCCESS'
+                                }
+                                if (context.onlyIfBuildFails) {
+                                    string 'FAILURE'
+                                }
+                            }
+                            role 'BOTH'
+                            buildSteps(context.stepContext.stepNodes)
+                        }
+                    }
+                }
+                markBuildUnstable(context.markBuildUnstable)
+            }
             if (item instanceof MatrixJob) {
                 executeOn(context.executeOn)
             }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -3601,13 +3601,13 @@ class PublisherContextSpec extends Specification {
         then:
         with(context.publisherNodes[0]) {
             name() == 'org.jenkinsci.plugins.postbuildscript.PostBuildScript'
-            children().size() == 4
-            buildSteps[0].children().size == 0
-            scriptOnlyIfSuccess[0].value() == true
-            scriptOnlyIfFailure[0].value() == false
-            markBuildUnstable[0].value() == false
+            children().size() == 1
+            config[0].scriptFiles[0].children().size == 0
+            config[0].groovyScripts[0].children().size == 0
+            config[0].buildSteps[0].children().size == 0
+            config[0].markBuildUnstable[0].value() == false
         }
-        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '0.17')
+        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '2.3.0')
     }
 
     def 'call post build scripts with all options'() {
@@ -3624,14 +3624,21 @@ class PublisherContextSpec extends Specification {
         then:
         with(context.publisherNodes[0]) {
             name() == 'org.jenkinsci.plugins.postbuildscript.PostBuildScript'
-            children().size() == 4
-            buildSteps[0].children().size == 1
-            buildSteps[0].children()[0].name() == 'hudson.tasks.Shell'
-            scriptOnlyIfSuccess[0].value() == value
-            scriptOnlyIfFailure[0].value() == value
-            markBuildUnstable[0].value() == value
+            children().size() == 1
+            config[0].children().size() == 4
+            config[0].scriptFiles[0].children().size == 0
+            config[0].groovyScripts[0].children().size == 0
+            config[0].buildSteps[0].children().size == 1
+            if (value) {
+                config[0].buildSteps[0].children()[0].results[0].children()[0].value() == 'SUCCESS'
+                config[0].buildSteps[0].children()[0].results[0].children()[1].value() == 'FAILURE'
+            }
+            config[0].buildSteps[0].children()[0].role[0].value() == 'BOTH'
+            config[0].buildSteps[0].children()[0].name() == 'org.jenkinsci.plugins.postbuildscript.model.PostBuildStep'
+            config[0].buildSteps[0].children()[0].buildSteps[0].children()[0].name() == 'hudson.tasks.Shell'
+            config[0].markBuildUnstable[0].value() == value
         }
-        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '0.17')
+        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '2.3.0')
 
         where:
         value << [true, false]
@@ -3648,15 +3655,16 @@ class PublisherContextSpec extends Specification {
 
         then:
         with(context.publisherNodes[0]) {
-            name() == 'org.jenkinsci.plugins.postbuildscript.PostBuildScript'
-            children().size() == 5
-            buildSteps[0].children().size == 0
-            scriptOnlyIfSuccess[0].value() == true
-            scriptOnlyIfFailure[0].value() == false
-            markBuildUnstable[0].value() == false
+            name() == 'org.jenkinsci.plugins.postbuildscript.MatrixPostBuildScript'
+            children().size() == 2
+            config[0].children().size() == 4
+            config[0].scriptFiles[0].children().size == 0
+            config[0].groovyScripts[0].children().size == 0
+            config[0].buildSteps[0].children().size == 0
+            config[0].markBuildUnstable[0].value() == false
             executeOn[0].value() == 'BOTH'
         }
-        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '0.17')
+        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '2.3.0')
     }
 
     def 'call post build scripts with all options and matrix job'() {
@@ -3677,16 +3685,22 @@ class PublisherContextSpec extends Specification {
 
         then:
         with(context.publisherNodes[0]) {
-            name() == 'org.jenkinsci.plugins.postbuildscript.PostBuildScript'
-            children().size() == 5
-            buildSteps[0].children().size == 1
-            buildSteps[0].children()[0].name() == 'hudson.tasks.Shell'
-            scriptOnlyIfSuccess[0].value() == false
-            scriptOnlyIfFailure[0].value() == true
-            markBuildUnstable[0].value() == true
+            name() == 'org.jenkinsci.plugins.postbuildscript.MatrixPostBuildScript'
+            children().size() == 2
+            config[0].children().size() == 4
+            config[0].scriptFiles[0].children().size == 0
+            config[0].groovyScripts[0].children().size == 0
+            config[0].buildSteps[0].children().size == 1
+            if (value) {
+                config[0].buildSteps[0].children()[0].results[0].children()[0].value() == 'SUCCESS'
+                config[0].buildSteps[0].children()[0].results[0].children()[1].value() == 'FAILURE'
+            }
+            config[0].buildSteps[0].children()[0].role[0].value() == 'BOTH'
+            config[0].buildSteps[0].children()[0].buildSteps[0].children()[0].name() == 'hudson.tasks.Shell'
+            config[0].markBuildUnstable[0].value() == true
             executeOn[0].value() == mode
         }
-        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '0.17')
+        1 * jobManagement.requireMinimumPluginVersion('postbuildscript', '2.3.0')
 
         where:
         mode << ['MATRIX', 'AXES', 'BOTH']


### PR DESCRIPTION
Hi!

thanks for un-deprecating the PostBuildScript Jenkins plugin!

The PostBuildScript plugin configuration has changed since version 0.17. Currently the Job DSL creates a configuration, that needs to be merged to new format. Users complain about very long generation times: https://issues.jenkins-ci.org/browse/JENKINS-49180

I'm trying to implement the new features of the plugin into the Job DSL. This pull request is the first step towards the new configuration format. It is fully compatible with existing scripts, because nothing on the syntax itself changed. First step is to simply write the new format.

Tested manually with the build-in Jenkins server and the following job DSL:

```xml
<?xml version='1.0' encoding='UTF-8'?>
<project>
  <actions/>
  <description></description>
  <keepDependencies>false</keepDependencies>
  <properties/>
  <scm class="hudson.scm.NullSCM"/>
  <canRoam>true</canRoam>
  <disabled>false</disabled>
  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
  <triggers/>
  <concurrentBuild>false</concurrentBuild>
  <builders>
    <javaposse.jobdsl.plugin.ExecuteDslScripts plugin="job-dsl@1.68-SNAPSHOT">
      <scriptText>job(&apos;postbuildscript-project&apos;) {
  publishers {
    postBuildScripts {
            steps {
                shell(&apos;echo TEST&apos;)
            }
            onlyIfBuildSucceeds(true)
            onlyIfBuildFails(true)
            markBuildUnstable(true)
        }
  }
}</scriptText>
      <usingScriptText>true</usingScriptText>
      <sandbox>false</sandbox>
      <ignoreExisting>false</ignoreExisting>
      <ignoreMissingFiles>false</ignoreMissingFiles>
      <failOnMissingPlugin>false</failOnMissingPlugin>
      <unstableOnDeprecation>false</unstableOnDeprecation>
      <removedJobAction>IGNORE</removedJobAction>
      <removedViewAction>IGNORE</removedViewAction>
      <removedConfigFilesAction>IGNORE</removedConfigFilesAction>
      <lookupStrategy>JENKINS_ROOT</lookupStrategy>
    </javaposse.jobdsl.plugin.ExecuteDslScripts>
  </builders>
  <publishers/>
  <buildWrappers/>
</project>
```

It would be very kind, if you could merge this pull request. Thanks in advance!

Best wishes

Daniel