### PR TITLE
Add unstable return code to shell command

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -34,9 +34,10 @@ class StepContext extends AbstractExtensibleContext {
      * Use {@link javaposse.jobdsl.dsl.DslFactory#readFileFromWorkspace(java.lang.String) readFileFromWorkspace} to read
      * the script from a file.
      */
-    void shell(String command) {
+    void shell(String command, Integer returnCode = 0) {
         stepNodes << new NodeBuilder().'hudson.tasks.Shell' {
             delegate.command(command)
+            delegate.unstableReturn(returnCode)
         }
     }
 


### PR DESCRIPTION
Current dsl shell command missed unstableReturn option.
This changes was created by github web interface, so it should be tested.