### PR TITLE
[JENKINS-49696] Option to delete views before re-creating them

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -29,6 +29,7 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
 
 ## Release Notes
 * 1.69 (unreleased)
+  * Added option to delete views before re-creating them
 * 1.68 (February 09 2018)
   * Increased the minimum supported Java version to JDK 8
   * Increased the minimum supported Jenkins version to 2.73

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractDslScriptLoader.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractDslScriptLoader.groovy
@@ -174,7 +174,9 @@ abstract class AbstractDslScriptLoader<S extends JobParent, G extends GeneratedI
                 extractGeneratedJobs(jobParent.referencedJobs, scriptRequest.ignoreExisting)
         )
         generatedItems.views.addAll(
-                extractGeneratedViews(jobParent.referencedViews, scriptRequest.ignoreExisting)
+                extractGeneratedViews(jobParent.referencedViews,
+                        scriptRequest.ignoreExisting,
+                        scriptRequest.deleteExistingViews)
         )
         generatedItems.userContents.addAll(
                 extractGeneratedUserContents(jobParent.referencedUserContents, scriptRequest.ignoreExisting)
@@ -198,12 +200,14 @@ abstract class AbstractDslScriptLoader<S extends JobParent, G extends GeneratedI
         generatedJobs
     }
 
-    protected Set<GeneratedView> extractGeneratedViews(Set<View> referencedViews, boolean ignoreExisting) {
+    protected Set<GeneratedView> extractGeneratedViews(Set<View> referencedViews,
+                                                       boolean ignoreExisting,
+                                                       boolean deleteExisting) {
         Set<GeneratedView> generatedViews = new LinkedHashSet<GeneratedView>()
         referencedViews.each { View view ->
             String xml = view.xml
             LOGGER.log(Level.FINE, "Saving view ${view.name} as ${xml}")
-            jobManagement.createOrUpdateView(view.name, xml, ignoreExisting)
+            jobManagement.createOrUpdateView(view.name, xml, ignoreExisting, deleteExisting)
             generatedViews << new GeneratedView(view.name)
         }
         generatedViews

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractJobManagement.groovy
@@ -38,6 +38,10 @@ abstract class AbstractJobManagement implements JobManagement {
         requireMinimumPluginVersion(pluginShortName, version, false)
     }
 
+    void createOrUpdateView(String viewName, String config, boolean ignoreExisting) {
+        createOrUpdateView(viewName, config, ignoreExisting, false)
+    }
+
     protected void logDeprecationWarning(String subject, String details) {
         logWarning("${subject} is deprecated", details)
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
@@ -47,7 +47,7 @@ class FileJobManagement extends MockJobManagement {
     }
 
     @Override
-    void createOrUpdateView(String viewName, String config, boolean ignoreExisting) {
+    void createOrUpdateView(String viewName, String config, boolean ignoreExisting, boolean deleteExistingViews) {
         validateUpdateArgs(viewName, config)
 
         File file = new File(root, viewName + ext)

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
@@ -38,11 +38,12 @@ interface JobManagement {
      * @param viewName the name of the new / updated view
      * @param config the new / updated view config
      * @param ignoreExisting do not update existing view
+     * @param deleteExistingViews delete and re-create existing views
      * @throws NameNotProvidedException if the viewName is null or blank
      * @throws ConfigurationMissingException if the config xml is null or blank
      * @since 1.21
      */
-    void createOrUpdateView(String viewName, String config, boolean ignoreExisting)
+    void createOrUpdateView(String viewName, String config, boolean ignoreExisting, boolean deleteExistingViews)
             throws NameNotProvidedException, ConfigurationMissingException
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/MemoryJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/MemoryJobManagement.groovy
@@ -38,7 +38,7 @@ class MemoryJobManagement extends MockJobManagement {
     }
 
     @Override
-    void createOrUpdateView(String viewName, String config, boolean ignoreExisting) {
+    void createOrUpdateView(String viewName, String config, boolean ignoreExisting, boolean deleteExisting) {
         validateUpdateArgs(viewName, config)
 
         savedViews[viewName] = config

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ScriptRequest.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ScriptRequest.groovy
@@ -13,6 +13,9 @@ class ScriptRequest {
     // Ignore existing jobs
     final boolean ignoreExisting
 
+    // Delete and re-create existing views
+    final boolean deleteExistingViews
+
     // Path to the script in the local filesystem, optional
     final String scriptPath
 
@@ -21,13 +24,15 @@ class ScriptRequest {
     }
 
     ScriptRequest(String body, URL urlRoot, boolean ignoreExisting = false, String scriptPath = null) {
-        this(body, [urlRoot] as URL[], ignoreExisting, scriptPath)
+        this(body, [urlRoot] as URL[], ignoreExisting, false,  scriptPath)
     }
 
-    ScriptRequest(String body, URL[] urlRoots, boolean ignoreExisting = false, String scriptPath = null) {
+    ScriptRequest(String body, URL[] urlRoots, boolean ignoreExisting = false,
+                  boolean deleteExistingViews = false, String scriptPath = null) {
         this.body = body
         this.urlRoots = urlRoots
         this.ignoreExisting = ignoreExisting
+        this.deleteExistingViews = deleteExistingViews
         this.scriptPath = scriptPath
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
@@ -137,7 +137,7 @@ class AbstractJobManagementSpec extends Specification {
         }
 
         @Override
-        void createOrUpdateView(String viewName, String config, boolean ignoreExisting) {
+        void createOrUpdateView(String viewName, String config, boolean ignoreExisting, boolean deleteExisting) {
             throw new UnsupportedOperationException()
         }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/ScriptRequestSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/ScriptRequestSpec.groovy
@@ -5,15 +5,15 @@ import spock.lang.Specification
 class ScriptRequestSpec extends Specification {
     def 'script name'() {
         expect:
-        new ScriptRequest('', [] as URL[], false, 'foo\\bar.txt').scriptName == 'bar.txt'
-        new ScriptRequest('', [] as URL[], false, 'foo/bar.txt').scriptName == 'bar.txt'
+        new ScriptRequest('', [] as URL[], false, false, 'foo\\bar.txt').scriptName == 'bar.txt'
+        new ScriptRequest('', [] as URL[], false, false, 'foo/bar.txt').scriptName == 'bar.txt'
         new ScriptRequest('script').scriptName == null
     }
 
     def 'script base name'() {
         expect:
-        new ScriptRequest('', [] as URL[], false, 'foo\\bar.txt').scriptBaseName == 'bar'
-        new ScriptRequest('', [] as URL[], false, 'foo/bar.txt').scriptBaseName == 'bar'
+        new ScriptRequest('', [] as URL[], false, false, 'foo\\bar.txt').scriptBaseName == 'bar'
+        new ScriptRequest('', [] as URL[], false, false, 'foo/bar.txt').scriptBaseName == 'bar'
         new ScriptRequest('script').scriptBaseName == null
     }
 }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
@@ -94,6 +94,8 @@ public class ExecuteDslScripts extends Builder implements SimpleBuildStep {
 
     private boolean ignoreMissingFiles;
 
+    private boolean deleteExistingViews;
+
     private boolean failOnMissingPlugin;
 
     private boolean unstableOnDeprecation;
@@ -182,6 +184,15 @@ public class ExecuteDslScripts extends Builder implements SimpleBuildStep {
 
     public boolean isIgnoreExisting() {
         return ignoreExisting;
+    }
+
+    @DataBoundSetter
+    public void setDeleteExistingViews(boolean deleteExistingViews) {
+        this.deleteExistingViews = deleteExistingViews;
+    }
+
+    public boolean isDeleteExistingViews() {
+        return !isIgnoreExisting() && deleteExistingViews;
     }
 
     @DataBoundSetter
@@ -306,7 +317,8 @@ public class ExecuteDslScripts extends Builder implements SimpleBuildStep {
 
             try (ScriptRequestGenerator generator = new ScriptRequestGenerator(workspace, env)) {
                 Set<ScriptRequest> scriptRequests = generator.getScriptRequests(
-                        getTargets(), isUsingScriptText(), getScriptText(), ignoreExisting, isIgnoreMissingFiles(), additionalClasspath
+                        getTargets(), isUsingScriptText(), getScriptText(), ignoreExisting,
+                        isDeleteExistingViews(), isIgnoreMissingFiles(), additionalClasspath
                 );
 
                 JenkinsDslScriptLoader dslScriptLoader;

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/InterruptibleJobManagement.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/InterruptibleJobManagement.groovy
@@ -36,9 +36,9 @@ class InterruptibleJobManagement implements JobManagement {
     }
 
     @Override
-    void createOrUpdateView(String viewName, String config, boolean ignoreExisting) throws NameNotProvidedException,
-            ConfigurationMissingException {
-        delegate.createOrUpdateView(viewName, config, ignoreExisting)
+    void createOrUpdateView(String viewName, String config, boolean ignoreExisting, boolean deleteExisting)
+            throws NameNotProvidedException, ConfigurationMissingException {
+        delegate.createOrUpdateView(viewName, config, ignoreExisting, deleteExisting)
     }
 
     @Override

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -142,7 +142,7 @@ public class JenkinsJobManagement extends AbstractJobManagement {
     }
 
     @Override
-    public void createOrUpdateView(String path, String config, boolean ignoreExisting) {
+    public void createOrUpdateView(String path, String config, boolean ignoreExisting, boolean deleteExisting) {
         validateUpdateArgs(path, config);
         String viewBaseName = FilenameUtils.getName(path);
         Jenkins.checkGoodName(viewBaseName);
@@ -151,7 +151,12 @@ public class JenkinsJobManagement extends AbstractJobManagement {
 
             ItemGroup parent = lookupStrategy.getParent(project, path);
             if (parent instanceof ViewGroup) {
-                View view = ((ViewGroup) parent).getView(viewBaseName);
+                ViewGroup parentViewGroup = (ViewGroup) parent;
+                View view = parentViewGroup.getView(viewBaseName);
+                if (deleteExisting && view != null) {
+                    parentViewGroup.deleteView(view);
+                    view = null;
+                }
                 if (view == null) {
                     if (parent instanceof ModifiableViewGroup) {
                         ((ModifiableViewGroup) parent).checkPermission(View.CREATE);
@@ -174,7 +179,7 @@ public class JenkinsJobManagement extends AbstractJobManagement {
         }
     }
 
-  @Override
+    @Override
     public void createOrUpdateUserContent(UserContent userContent, boolean ignoreExisting) {
         // As in git-userContent-plugin:
         Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/SandboxDslScriptLoader.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/SandboxDslScriptLoader.groovy
@@ -36,7 +36,8 @@ class SandboxDslScriptLoader extends SecureDslScriptLoader {
     protected Collection<ScriptRequest> createSecureScriptRequests(Collection<ScriptRequest> scriptRequests) {
         scriptRequests.collect {
             // it is not safe to use additional classpath entries
-            new ScriptRequest(it.body, it.urlRoots[0..0] as URL[], it.ignoreExisting, it.scriptPath)
+            new ScriptRequest(it.body, it.urlRoots[0..0] as URL[],
+                    it.ignoreExisting, it.deleteExistingViews, it.scriptPath)
         }
     }
 

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ScriptApprovalDslScriptLoader.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ScriptApprovalDslScriptLoader.groovy
@@ -43,7 +43,7 @@ class ScriptApprovalDslScriptLoader extends SecureDslScriptLoader {
             }
 
             // it is not safe to use additional classpath entries
-            new ScriptRequest(it.body, new URL[0], it.ignoreExisting, it.scriptPath)
+            new ScriptRequest(it.body, new URL[0], it.ignoreExisting, it.deleteExistingViews, it.scriptPath)
         }
     }
 }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ScriptRequestGenerator.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ScriptRequestGenerator.groovy
@@ -18,8 +18,9 @@ class ScriptRequestGenerator implements Closeable {
     }
 
     Set<ScriptRequest> getScriptRequests(String targets, boolean usingScriptText, String scriptText,
-                                         boolean ignoreExisting, boolean ignoreMissingFiles = false,
-                                         String additionalClasspath) throws IOException, InterruptedException {
+                                         boolean ignoreExisting, boolean deleteExistingViews,
+                                         boolean ignoreMissingFiles = false, String additionalClasspath)
+            throws IOException, InterruptedException {
         Set<ScriptRequest> scriptRequests = new LinkedHashSet<ScriptRequest>()
 
         List<URL> classpath = []
@@ -36,7 +37,7 @@ class ScriptRequestGenerator implements Closeable {
         }
         if (usingScriptText) {
             URL[] urlRoots = ([createWorkspaceUrl()] + classpath) as URL[]
-            ScriptRequest request = new ScriptRequest(scriptText, urlRoots, ignoreExisting)
+            ScriptRequest request = new ScriptRequest(scriptText, urlRoots, ignoreExisting, deleteExistingViews)
             scriptRequests.add(request)
         } else {
             targets.split('\n').each { String target ->
@@ -49,7 +50,7 @@ class ScriptRequestGenerator implements Closeable {
                 for (FilePath filePath : filePaths) {
                     URL[] urlRoots = ([createWorkspaceUrl(filePath.parent)] + classpath) as URL[]
                     ScriptRequest request = new ScriptRequest(
-                            readFile(filePath), urlRoots, ignoreExisting, getAbsolutePath(filePath)
+                            readFile(filePath), urlRoots, ignoreExisting, deleteExistingViews, getAbsolutePath(filePath)
                     )
                     scriptRequests.add(request)
                 }

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/config.jelly
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/config.jelly
@@ -27,6 +27,9 @@
         <f:checkbox name="ignoreExisting" title="Ignore changes" checked="${instance.ignoreExisting}"
                     description="What to do with previously generated jobs and views when generated config is not the same?"/>
     </f:entry>
+    <f:entry title="Delete and re-create existing views:" field="deleteExistingViews">
+        <f:checkbox name="deleteExistingViews" checked="${instance.deleteExistingViews}"/>
+    </f:entry>
     <f:entry title="Action for removed jobs:" field="removedJobAction">
         <f:select/>
     </f:entry>

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-deleteExistingViews.html
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-deleteExistingViews.html
@@ -1,0 +1,5 @@
+<div>
+    Delete and re-create existing views instead of updating them. This allows for view type to be changed. This also introduces the risk of losing
+    views in case they cannot be regenerated.
+    Note that this option is ignored when "Action for existing jobs and views" is set to "Ignore changes".
+</div>

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
@@ -547,6 +547,21 @@ class JenkinsJobManagementSpec extends Specification {
         e.message == 'Type of view "foo" does not match existing type, view type can not be changed'
     }
 
+    def 'createOrUpdateView should not fail on view type change if Delete existing views is checked'() {
+        setup:
+        jenkinsRule.jenkins.addView(new AllView('foo'))
+
+        when:
+        jobManagement.createOrUpdateView(
+                'foo',
+                JenkinsJobManagementSpec.getResourceAsStream('/javaposse/jobdsl/dsl/views/ListView-template.xml').text,
+                false, true
+        )
+
+        then:
+        noExceptionThrown()
+    }
+
     def isMinimumPluginVersionInstalled() {
         when:
         boolean result = jobManagement.isMinimumPluginVersionInstalled('script-security', '0.1')

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ScriptRequestGeneratorSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ScriptRequestGeneratorSpec.groovy
@@ -55,7 +55,8 @@ class ScriptRequestGeneratorSpec extends Specification {
         ScriptRequestGenerator generator = new ScriptRequestGenerator(build.workspace, env)
 
         when:
-        List<ScriptRequest> requests = generator.getScriptRequests(null, true, SCRIPT, false, null).toList()
+        List<ScriptRequest> requests = generator.getScriptRequests(null, true, SCRIPT, false, false, null)
+                .toList()
 
         then:
         requests.size() == 1
@@ -72,7 +73,8 @@ class ScriptRequestGeneratorSpec extends Specification {
         ScriptRequestGenerator generator = new ScriptRequestGenerator(build.workspace, env)
 
         when:
-        List<ScriptRequest> requests = generator.getScriptRequests(null, true, SCRIPT, true, null).toList()
+        List<ScriptRequest> requests = generator.getScriptRequests(null, true, SCRIPT, true, false, null)
+                .toList()
 
         then:
         requests.size() == 1
@@ -83,13 +85,32 @@ class ScriptRequestGeneratorSpec extends Specification {
         requests[0].scriptPath == null
     }
 
+    def 'script text delete existing views'() {
+        setup:
+        EnvVars env = new EnvVars()
+        ScriptRequestGenerator generator = new ScriptRequestGenerator(build.workspace, env)
+
+        when:
+        List<ScriptRequest> requests = generator.getScriptRequests(null, true, SCRIPT, false, true, null)
+                .toList()
+
+        then:
+        requests.size() == 1
+        requests[0].body == SCRIPT
+        requests[0].urlRoots.length == 1
+        requests[0].urlRoots[0].toString() == 'workspace:/'
+        requests[0].deleteExistingViews
+        requests[0].scriptPath == null
+    }
+
     def 'script text with additional classpath entry'() {
         setup:
         EnvVars env = new EnvVars()
         ScriptRequestGenerator generator = new ScriptRequestGenerator(build.workspace, env)
 
         when:
-        List<ScriptRequest> requests = generator.getScriptRequests(null, true, SCRIPT, false, 'classes').toList()
+        List<ScriptRequest> requests = generator.getScriptRequests(null, true, SCRIPT, false, false, 'classes')
+                .toList()
 
         then:
         requests.size() == 1
@@ -107,7 +128,8 @@ class ScriptRequestGeneratorSpec extends Specification {
         ScriptRequestGenerator generator = new ScriptRequestGenerator(build.workspace, env)
 
         when:
-        List<ScriptRequest> requests = generator.getScriptRequests(null, true, SCRIPT, false, '${FOO}/classes').toList()
+        List<ScriptRequest> requests = generator.getScriptRequests(null, true, SCRIPT, false, false, '${FOO}/classes')
+                .toList()
 
         then:
         requests.size() == 1
@@ -126,7 +148,7 @@ class ScriptRequestGeneratorSpec extends Specification {
 
         when:
         List<ScriptRequest> requests = generator.getScriptRequests(
-                null, true, SCRIPT, false, 'classes\noutput'
+                null, true, SCRIPT, false, false, 'classes\noutput'
         ).toList()
 
         then:
@@ -146,7 +168,8 @@ class ScriptRequestGeneratorSpec extends Specification {
         ScriptRequestGenerator generator = new ScriptRequestGenerator(build.workspace, env)
 
         when:
-        List<ScriptRequest> requests = generator.getScriptRequests('a.groovy', false, null, false, null).toList()
+        List<ScriptRequest> requests = generator.getScriptRequests('a.groovy', false, null, false, false, null)
+                .toList()
 
         then:
         requests.size() == 1
@@ -163,7 +186,8 @@ class ScriptRequestGeneratorSpec extends Specification {
         ScriptRequestGenerator generator = new ScriptRequestGenerator(build.workspace, env)
 
         when:
-        List<ScriptRequest> requests = generator.getScriptRequests('${FOO}.groovy', false, null, false, null).toList()
+        List<ScriptRequest> requests = generator.getScriptRequests('${FOO}.groovy', false, null, false, false, null)
+                .toList()
 
         then:
         requests.size() == 1
@@ -180,7 +204,8 @@ class ScriptRequestGeneratorSpec extends Specification {
         ScriptRequestGenerator generator = new ScriptRequestGenerator(build.workspace, env)
 
         when:
-        List<ScriptRequest> requests = generator.getScriptRequests('a.groovy', false, null, true, null).toList()
+        List<ScriptRequest> requests = generator.getScriptRequests('a.groovy', false, null, true, false, null)
+                .toList()
 
         then:
         requests.size() == 1
@@ -191,6 +216,24 @@ class ScriptRequestGeneratorSpec extends Specification {
         requests[0].scriptPath == getAbsolutePath(build.workspace.child('a.groovy'))
     }
 
+    def 'single target delete existing views'() {
+        setup:
+        EnvVars env = new EnvVars()
+        ScriptRequestGenerator generator = new ScriptRequestGenerator(build.workspace, env)
+
+        when:
+        List<ScriptRequest> requests = generator.getScriptRequests('a.groovy', false, null, false, true, null)
+                .toList()
+
+        then:
+        requests.size() == 1
+        requests[0].body == SCRIPT_A
+        requests[0].urlRoots.length == 1
+        requests[0].urlRoots[0].toString() == 'workspace:/'
+        requests[0].deleteExistingViews
+        requests[0].scriptPath == getAbsolutePath(build.workspace.child('a.groovy'))
+    }
+
     def 'multiple target'() {
         setup:
         EnvVars env = new EnvVars()
@@ -198,7 +241,7 @@ class ScriptRequestGeneratorSpec extends Specification {
 
         when:
         List<ScriptRequest> requests = generator.getScriptRequests(
-                'a.groovy\nb.groovy', false, null, false, null
+                'a.groovy\nb.groovy', false, null, false, false, null
         ).toList()
 
         then:
@@ -221,7 +264,8 @@ class ScriptRequestGeneratorSpec extends Specification {
         ScriptRequestGenerator generator = new ScriptRequestGenerator(build.workspace, env)
 
         when:
-        List<ScriptRequest> requests = generator.getScriptRequests('*.groovy', false, null, false, null).toList()
+        List<ScriptRequest> requests = generator.getScriptRequests('*.groovy', false, null, false, false, null)
+                .toList()
 
         then:
         requests.size() == 2
@@ -244,7 +288,7 @@ class ScriptRequestGeneratorSpec extends Specification {
 
         when:
         List<ScriptRequest> requests = generator.getScriptRequests(
-                'a.groovy\nb.groovy', false, null, false, 'classes\noutput'
+                'a.groovy\nb.groovy', false, null, false, false, 'classes\noutput'
         ).toList()
 
         then:
@@ -272,7 +316,7 @@ class ScriptRequestGeneratorSpec extends Specification {
 
         when:
         List<ScriptRequest> requests = generator.getScriptRequests(
-                'a.groovy', false, null, false, 'lib/*.jar'
+                'a.groovy', false, null, false, false, 'lib/*.jar'
         ).toList()
 
         then:
@@ -293,7 +337,7 @@ class ScriptRequestGeneratorSpec extends Specification {
 
         when:
         List<ScriptRequest> requests = generator.getScriptRequests(
-                'a.groovy', false, null, false, 'lib/*.jar'
+                'a.groovy', false, null, false, false, 'lib/*.jar'
         ).toList()
 
         then:
@@ -324,7 +368,7 @@ class ScriptRequestGeneratorSpec extends Specification {
 
         when:
         List<ScriptRequest> requests = generator.getScriptRequests(
-                null, true, SCRIPT, false, additionalClasspath
+                null, true, SCRIPT, false, false, additionalClasspath
         ).toList()
 
         then:
@@ -342,7 +386,7 @@ class ScriptRequestGeneratorSpec extends Specification {
         ScriptRequestGenerator generator = new ScriptRequestGenerator(build.workspace, env)
 
         when:
-        generator.getScriptRequests('x.groovy', false, null, false, null).toList()
+        generator.getScriptRequests('x.groovy', false, null, false, false, null).toList()
 
         then:
         Exception e = thrown(DslException)
@@ -355,7 +399,8 @@ class ScriptRequestGeneratorSpec extends Specification {
         ScriptRequestGenerator generator = new ScriptRequestGenerator(build.workspace, env)
 
         when:
-        List<ScriptRequest> requests = generator.getScriptRequests('x.groovy', false, null, false, true, null).toList()
+        List<ScriptRequest> requests = generator.getScriptRequests('x.groovy', false, null, false, false, true, null)
+                .toList()
 
         then:
         requests.empty
@@ -367,7 +412,7 @@ class ScriptRequestGeneratorSpec extends Specification {
         ScriptRequestGenerator generator = new ScriptRequestGenerator(build.workspace, env)
 
         when:
-        generator.getScriptRequests('*.foo', false, null, false, null).toList()
+        generator.getScriptRequests('*.foo', false, null, false, false, null).toList()
 
         then:
         Exception e = thrown(DslException)
@@ -380,7 +425,8 @@ class ScriptRequestGeneratorSpec extends Specification {
         ScriptRequestGenerator generator = new ScriptRequestGenerator(build.workspace, env)
 
         when:
-        List<ScriptRequest> requests = generator.getScriptRequests('*.foo', false, null, false, true, null).toList()
+        List<ScriptRequest> requests = generator.getScriptRequests('*.foo', false, null, false, false, true, null)
+                .toList()
 
         then:
         requests.empty


### PR DESCRIPTION
Add a checkbox called "Delete and re-create existing views". When checked, the deletion of existing views is forced.
This way the view xml is re-created instead of updated, allowing for view type to be changed.

Issue: JENKINS-49696