### PR TITLE
Allow to specify paths in gerrit trigger definition

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GerritContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GerritContext.groovy
@@ -93,13 +93,14 @@ class GerritContext implements Context {
 
     /**
      * Specifies on which Gerrit projects to trigger a build on. Use a {@code '&lt;type&gt;:&lt;pattern&gt;'} notation
-     * to specify a project or branch name pattern. Supported types are {@code plain} (default), {@code ant} (called
-     * "Path" in the UI) and {@code reg_exp}.
+     * to specify a project, a branch name pattern or a file path. Supported types are {@code plain} (default),
+     * {@code ant} (called "Path" in the UI) and {@code reg_exp}.
      */
-    void project(String projectName, List<String> branches) {
+    void project(String projectName, List<String> branches, List<String> filePaths) {
         projects << [
                 new GerritSpec(projectName),
-                branches.collect { new GerritSpec(it) }
+                branches.collect { new GerritSpec(it) },
+                filePaths.collect { new GerritSpec(it) }
         ]
     }
 
@@ -108,8 +109,17 @@ class GerritContext implements Context {
      * to specify a project or branch name pattern. Supported types are {@code plain} (default), {@code ant} (called
      * "Path" in the UI) and {@code reg_exp}.
      */
+    void project(String projectName, List<String> branches) {
+        project(projectName, branches, [])
+    }
+
+    /**
+     * Specifies on which Gerrit projects to trigger a build on. Use a {@code '&lt;type&gt;:&lt;pattern&gt;'} notation
+     * to specify a project or branch name pattern. Supported types are {@code plain} (default), {@code ant} (called
+     * "Path" in the UI) and {@code reg_exp}.
+     */
     void project(String projectName, String branch) {
-        project(projectName, [branch])
+        project(projectName, [branch], [])
     }
 
     static class GerritSpec {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContext.groovy
@@ -59,7 +59,8 @@ class TriggerContext extends ItemTriggerContext {
             spec ''
             if (gerritContext.projects) {
                 gerritProjects {
-                    gerritContext.projects.each { GerritSpec project, List<GerritSpec> brancheSpecs ->
+                    gerritContext.projects.each {
+                        GerritSpec project, List<GerritSpec> brancheSpecs, List<GerritSpec> filePathSpecs ->
                         'com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject' {
                             compareType project.type
                             pattern project.pattern
@@ -68,6 +69,14 @@ class TriggerContext extends ItemTriggerContext {
                                     'com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.Branch' {
                                         compareType branch.type
                                         pattern branch.pattern
+                                    }
+                                }
+                            }
+                            filePaths {
+                                filePathSpecs.each { GerritSpec filePath ->
+                                    'com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.FilePath' {
+                                        compareType filePath.type
+                                        pattern filePath.pattern
                                     }
                                 }
                             }


### PR DESCRIPTION
- Implementation of JENKINS-49922
- When I specify on which Gerrit projects to trigger a build on,
I would like to be able to consider only some sub-directories.
