### PR TITLE
Added possibility to filter branches as it is already possible for tags.

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -228,6 +228,7 @@ class BuildParametersContext extends AbstractExtensibleContext {
                     type("PT_$context.type")
                     branch(context.branch ?: '')
                     tagFilter(context.tagFilter ?: '')
+                    branchFilter(context.branchFilter ?: '')
                     sortMode(context.sortMode)
                     defaultValue(context.defaultValue ?: '')
                 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/GitParamContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/GitParamContext.groovy
@@ -16,6 +16,7 @@ final class GitParamContext implements Context {
     String type = 'TAG'
     String branch
     String tagFilter
+    String branchFilter
     String sortMode = 'NONE'
     String defaultValue
 
@@ -48,6 +49,13 @@ final class GitParamContext implements Context {
      */
     void tagFilter(String tagFilter) {
         this.tagFilter = tagFilter
+    }
+    
+    /**
+     * Specifies a filter for branches.
+     */
+    void branchFilter(String branchFilter) {
+        this.branchFilter = branchFilter
     }
 
     /**

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -923,13 +923,14 @@ class BuildParametersContextSpec extends Specification {
         context.buildParameterNodes.size() == 1
         with(context.buildParameterNodes['paramName']) {
             name() == 'net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition'
-            children().size() == 8
+            children().size() == 9
             name.text() == 'paramName'
             description[0].value() == ''
             UUID.fromString(uuid[0].value() as String)
             type[0].value() == 'PT_TAG'
             branch[0].value() == ''
             tagFilter[0].value() == ''
+            branchFilter[0].value() == ''
             sortMode[0].value() == 'NONE'
             defaultValue[0].value() == ''
         }
@@ -943,6 +944,7 @@ class BuildParametersContextSpec extends Specification {
             type('REVISION')
             branch('master')
             tagFilter('*')
+            branchFilter('*')
             sortMode('ASCENDING_SMART')
             defaultValue('foo')
         }
@@ -952,13 +954,14 @@ class BuildParametersContextSpec extends Specification {
         context.buildParameterNodes.size() == 1
         with(context.buildParameterNodes['sha']) {
             name() == 'net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition'
-            children().size() == 8
+            children().size() == 9
             name.text() == 'sha'
             description[0].value() == 'Revision commit SHA'
             UUID.fromString(uuid[0].value() as String)
             type[0].value() == 'PT_REVISION'
             branch[0].value() == 'master'
             tagFilter[0].value() == '*'
+            branchFilter[0].value() == '*'
             sortMode[0].value() == 'ASCENDING_SMART'
             defaultValue[0].value() == 'foo'
         }


### PR DESCRIPTION
There was already the code to enable tag filters but no branch filters. With this change, branch filters should be enabled as well. This feature is supported by net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition.