### PR TITLE
Delete and re-create view if type changes

### DIFF
--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/Messages.properties
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/Messages.properties
@@ -34,8 +34,6 @@ UpdateExistingItem.ItemTypeDoesNotMatch=\
   Type of item "%s" does not match existing type, item type can not be changed
 UpdateExistingView.CouldNotParseConfig=\
   Could not parse generated configuration for view "%s"
-UpdateExistingView.ViewTypeDoesNotMatch=\
-  Type of view "%s" does not match existing type, view type can not be changed
 ScriptSecurity.ScriptApprovalWarning=\
   New or modified scripts must either be approved by an Jenkins administrator before they can be used or they must be \
   run in the restricted sandbox.

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
@@ -531,7 +531,7 @@ class JenkinsJobManagementSpec extends Specification {
         e.message == 'Type of item "my-job" does not match existing type, item type can not be changed'
     }
 
-    def 'createOrUpdateView should fail if view type does not match'() {
+    def 'createOrUpdateView should work if view type changes'() {
         setup:
         jenkinsRule.jenkins.addView(new AllView('foo'))
 
@@ -543,8 +543,9 @@ class JenkinsJobManagementSpec extends Specification {
         )
 
         then:
-        Exception e = thrown(DslException)
-        e.message == 'Type of view "foo" does not match existing type, view type can not be changed'
+        noExceptionThrown()
+        jenkinsRule.jenkins.getView('foo') != null
+        jenkinsRule.jenkins.getView('foo').class == ListView
     }
 
     def isMinimumPluginVersionInstalled() {


### PR DESCRIPTION
As discussed on [#1108](https://github.com/jenkinsci/job-dsl-plugin/pull/1108) let's always delete and re-create views when type changes.