### PR TITLE
Typo correction in The Configure Block wiki

### DIFF
--- a/docs/The-Configure-Block.md
+++ b/docs/The-Configure-Block.md
@@ -392,7 +392,7 @@ def emailTrigger = {
 
 job('example') {
     configure { project ->
-        project / publisher << 'hudson.plugins.emailext.ExtendedEmailPublisher' {
+        project / publishers << 'hudson.plugins.emailext.ExtendedEmailPublisher' {
               recipientList 'Engineering@company.com'
               configuredTriggers {
                   'hudson.plugins.emailext.plugins.trigger.FailureTrigger' emailTrigger
@@ -409,7 +409,7 @@ job('example') {
 Result:
 ```xml
 <project>
-    <publisher>
+    <publishers>
         <hudson.plugins.emailext.ExtendedEmailPublisher>
             <recipientList>Engineering@company.com</recipientList>
             <configuredTriggers>


### PR DESCRIPTION
Simple correction of a typo in The Configure Block wiki page.