### PR TITLE
Gradle: Only use the maven-publish plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ configure(subprojects - project(':job-dsl-api-viewer')) {
     group = 'org.jenkins-ci.plugins'
 
     apply plugin: 'groovy'
-    apply plugin: 'maven' // for publishing
     apply plugin: 'codenarc'
 
     sourceCompatibility = 1.8


### PR DESCRIPTION
Previously, both the maven and the maven-publish plugin were used.
However, only either one should be used. As the used configuration
syntax is the one of the maven-publish plugin, remove the maven plugin.

/cc @mnonnenmacher