### PR TITLE
Support seed job creation in Configuration as Code

### DIFF
--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     }
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.15.4'
     optionalJenkinsPlugins 'org.jenkinsci.plugins:managed-scripts:1.3'
+    optionalJenkinsPlugins 'io.jenkins:configuration-as-code:1.0-20180516.160229-4'
     jenkinsTest 'org.jenkins-ci.plugins:cloudbees-folder:5.12'
     jenkinsTest 'org.jenkins-ci.plugins:matrix-auth:1.3'
     jenkinsTest 'org.jenkins-ci.plugins:nested-view:1.14'

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/SeedJobConfigurator.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/SeedJobConfigurator.java
@@ -1,0 +1,64 @@
+package javaposse.jobdsl.plugin.casc;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import javaposse.jobdsl.dsl.GeneratedItems;
+import javaposse.jobdsl.plugin.JenkinsDslScriptLoader;
+import javaposse.jobdsl.plugin.JenkinsJobManagement;
+import javaposse.jobdsl.plugin.LookupStrategy;
+import org.jenkinsci.plugins.casc.Attribute;
+import org.jenkinsci.plugins.casc.ConfiguratorException;
+import org.jenkinsci.plugins.casc.RootElementConfigurator;
+import org.jenkinsci.plugins.casc.model.CNode;
+import org.jenkinsci.plugins.casc.model.Sequence;
+
+import javax.annotation.CheckForNull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Extension
+public class SeedJobConfigurator implements RootElementConfigurator<List<GeneratedItems>> {
+
+    @Override
+    public String getName() {
+        return "jobs";
+    }
+
+    @Override
+    public Set<Attribute> describe() {
+        // no sub-attribute , "jobs" is a raw list
+        return Collections.EMPTY_SET;
+    }
+
+    @Override
+    public List<GeneratedItems> getTargetComponent() {
+        return Collections.EMPTY_LIST; // Doesn't really make sense
+    }
+
+    @Override
+    public List<GeneratedItems> configure(CNode config) throws ConfiguratorException {
+        JenkinsJobManagement mng = new JenkinsJobManagement(System.out, new EnvVars(), null, null, LookupStrategy.JENKINS_ROOT);
+        final Sequence scripts = config.asSequence();
+        List<GeneratedItems> generated = new ArrayList<>();
+        for (CNode script : scripts) {
+            try {
+                generated.add(new JenkinsDslScriptLoader(mng).runScript(script.asScalar().getValue()));
+            } catch (Exception ex) {
+                throw new ConfiguratorException(this, "Failed to execute script with hash " + script.hashCode(), ex);
+            }
+        }
+        return generated;
+    }
+
+    @CheckForNull
+    @Override
+    public CNode describe(List<GeneratedItems> instance) {
+        // We can't guess the seed job which was used to generate others on this instance
+        return null;
+    }
+}

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/casc/SeedJobConfigurator/documentation.jelly
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/casc/SeedJobConfigurator/documentation.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+
+  <div class='configurator'>
+    <div id="${it.extensionPoint.simpleName}-${it.name}" class='configurator__name'>${it.name}</div>
+    <div class='configurator__display-name'>JobDSL plugin scripts to generate initial seed jobs. ${it.displayName}</div>
+     <div class='attribute-type'>
+        <span class='attribute-type__list'>list of</span> <span class='attribute-type__class'>strings</span>
+     </div>
+  </div>
+
+</j:jelly>

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/casc/SeedJobConfigurator/schema.jelly
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/casc/SeedJobConfigurator/schema.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+    "${it.target.name}": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+</j:jelly>

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/casc/SeedJobTest.java
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/casc/SeedJobTest.java
@@ -1,0 +1,30 @@
+package javaposse.jobdsl.plugin.casc;
+
+import hudson.model.TopLevelItem;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.casc.ConfigurationAsCode;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class SeedJobTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void configure_seed_job() throws Exception {
+        final Jenkins jenkins = Jenkins.getInstance();
+        ConfigurationAsCode.get().configure(getClass().getResource("SeedJobTest.yml").toExternalForm());
+        final TopLevelItem test = jenkins.getItem("configuration-as-code");
+        assertNotNull(test);
+        assertTrue(test instanceof WorkflowMultiBranchProject);
+    }
+}

--- a/job-dsl-plugin/src/test/resources/javaposse/jobdsl/plugin/casc/SeedJobTest.yml
+++ b/job-dsl-plugin/src/test/resources/javaposse/jobdsl/plugin/casc/SeedJobTest.yml
@@ -1,0 +1,9 @@
+jobs:
+  - >
+      multibranchPipelineJob('configuration-as-code') {
+          branchSources {
+              git {
+                  remote('https://github.com/jenkinsci/configuration-as-code-plugin.git')
+              }
+          }
+      }


### PR DESCRIPTION
Move configuration-as-code seed job creation support in job-dsl plugin 

Configuration-as-Code [JEP-201](https://github.com/jenkinsci/jep/tree/master/jep/201) allow to configure a full jenkins master from a plain text definition. Creation for a set of initial jobs is better implemented by popular job-dsl plugin, so we'd like this feature hosted by the implementor.

see https://github.com/jenkinsci/configuration-as-code-plugin/issues/197

