### PR TITLE
Jenkins 52607 - Support categories and message filtering in compiler warnings plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1242,7 +1242,7 @@ class PublisherContext extends AbstractExtensibleContext {
      *
      * @since 1.17
      */
-    @RequiresPlugin(id = 'warnings', minimumVersion = '4.0')
+    @RequiresPlugin(id = 'warnings', minimumVersion = '4.63')
     void warnings(List consoleParsers, Map parserConfigurations = [:],
                   @DslContext(WarningsContext) Closure warningsClosure = null) {
         WarningsContext warningsContext = new WarningsContext()
@@ -1253,6 +1253,8 @@ class PublisherContext extends AbstractExtensibleContext {
             addStaticAnalysisContext(delegate, warningsContext)
             includePattern(warningsContext.includePattern)
             excludePattern(warningsContext.excludePattern)
+            messagesPattern(warningsContext.messagesPattern)
+            categoriesPattern(warningsContext.categoriesPattern)
             nodeBuilder.consoleParsers {
                 (consoleParsers ?: []).each { name ->
                     nodeBuilder.'hudson.plugins.warnings.ConsoleParser' {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WarningsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/WarningsContext.groovy
@@ -3,6 +3,8 @@ package javaposse.jobdsl.dsl.helpers.publisher
 class WarningsContext extends StaticAnalysisContext {
     String includePattern = ''
     String excludePattern = ''
+    String messagesPattern = ''
+    String categoriesPattern = ''
 
     /**
      * Determines if relative paths in warnings should be resolved. Defaults to {@code false}.
@@ -25,5 +27,21 @@ class WarningsContext extends StaticAnalysisContext {
      */
     void excludePattern(String excludePattern) {
         this.excludePattern = excludePattern
+    }
+
+    /**
+     * Sets a comma separated list of regular expressions that specifies the warning messages to exclude form the report
+     * (based on the warning messages).
+     */
+    void messagesPattern(String messagesPattern) {
+        this.messagesPattern = messagesPattern
+    }
+
+    /**
+     * Sets a comma separated list of regular expressions that specifies the warning categories to exclude form the
+     * report(based on the warning categories).
+     */
+    void categoriesPattern(String categoriesPattern) {
+        this.categoriesPattern = categoriesPattern
     }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/StaticAnalysisPublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/StaticAnalysisPublisherContextSpec.groovy
@@ -66,13 +66,15 @@ class StaticAnalysisPublisherContextSpec extends Specification {
                 thresholds: [],
                 parserConfigurations: [],
                 includePattern: '',
-                excludePattern: ''
+                excludePattern: '',
+                messagesPattern: '',
+                categoriesPattern: ''
         )
 
         def consoleParsers = warningsNode.consoleParsers.'hudson.plugins.warnings.ConsoleParser'
         assertValues(consoleParsers, parserName: 'Java Compiler (javac)')
 
-        1 * jobManagement.requireMinimumPluginVersion('warnings', '4.0')
+        1 * jobManagement.requireMinimumPluginVersion('warnings', '4.63')
     }
 
     @Unroll
@@ -142,6 +144,8 @@ class StaticAnalysisPublisherContextSpec extends Specification {
         context.warnings(['Java Compiler (javac)'], ['Java Compiler (javac)': '**/*.log']) {
             includePattern '.*include.*'
             excludePattern '.*exclude.*'
+            messagesPattern '.*exclude_msg.*'
+            categoriesPattern '.*exclude_cat.*'
             resolveRelativePaths true
             healthLimits 3, 20
             thresholdLimit 'high'
@@ -165,6 +169,8 @@ class StaticAnalysisPublisherContextSpec extends Specification {
         assertValues(analysisNode, ['consoleParsers', 'parserConfigurations', 'thresholds'],
                 includePattern: '.*include.*',
                 excludePattern: '.*exclude.*',
+                messagesPattern: '.*exclude_msg.*',
+                categoriesPattern: '.*exclude_cat.*',
                 healthy: 3, unHealthy: 20,
                 thresholdLimit: 'high',
                 defaultEncoding: 'UTF-8',
@@ -192,7 +198,7 @@ class StaticAnalysisPublisherContextSpec extends Specification {
                 parserName: 'Java Compiler (javac)'
         )
 
-        1 * jobManagement.requireMinimumPluginVersion('warnings', '4.0')
+        1 * jobManagement.requireMinimumPluginVersion('warnings', '4.63')
     }
 
     def 'add analysis collector with default values'() {


### PR DESCRIPTION
This adds support for the new filter for categories added in 4.63 of the Warnings Plugin ( https://wiki.jenkins.io/display/JENKINS/Warnings+Plugin ) and filtering of by message.

Issue: https://issues.jenkins-ci.org/browse/JENKINS-52607