### PR TITLE
Do not require workflow-aggregator

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
@@ -117,7 +117,7 @@ interface DslFactory extends ViewFactory {
      * @since 1.47
      * @see #pipelineJob(java.lang.String, groovy.lang.Closure)
      */
-    @RequiresPlugin(id = 'workflow-aggregator', failIfMissing = true)
+    @RequiresPlugin(id = 'workflow-job', failIfMissing = true)
     WorkflowJob pipelineJob(String name)
 
     /**
@@ -126,7 +126,7 @@ interface DslFactory extends ViewFactory {
      *
      * @since 1.47
      */
-    @RequiresPlugin(id = 'workflow-aggregator', failIfMissing = true)
+    @RequiresPlugin(id = 'workflow-job', failIfMissing = true)
     WorkflowJob pipelineJob(String name, @DslContext(WorkflowJob) Closure closure)
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/WorkflowDefinitionContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/WorkflowDefinitionContext.groovy
@@ -20,6 +20,7 @@ class WorkflowDefinitionContext extends AbstractExtensibleContext {
     /**
      * Defines a Groovy CPS DSL definition.
      */
+    @RequiresPlugin(id = 'workflow-cps')
     void cps(@DslContext(CpsContext) Closure cpsClosure) {
         CpsContext context = new CpsContext()
         ContextHelper.executeInContext(cpsClosure, context)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobParentSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobParentSpec.groovy
@@ -410,7 +410,7 @@ class JobParentSpec extends Specification {
         then:
         job.name == 'test'
         parent.referencedJobs.contains(job)
-        1 * jobManagement.requirePlugin('workflow-aggregator', true)
+        1 * jobManagement.requirePlugin('workflow-job', true)
     }
 
     def 'multibranchPipelineJob'() {


### PR DESCRIPTION
Nothing should be referring to `workflow-aggregator`, which was just a do-nothing plugin created to make it easier for Jenkins 1.x users to install a bunch of Pipeline plugins. Be more specific about the plugins actually required for certain elements.