### PR TITLE
[JENKINS-56505] Fix for JENKINS-38606 related log spam

### DIFF
--- a/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/Folder-template.xml
+++ b/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/Folder-template.xml
@@ -7,14 +7,14 @@
         <views>
             <hudson.model.AllView>
                 <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../../.."/>
-                <name>All</name>
+                <name>all</name>
                 <filterExecutors>false</filterExecutors>
                 <filterQueue>false</filterQueue>
                 <properties class="hudson.model.View$PropertyList"/>
             </hudson.model.AllView>
         </views>
         <tabBar class="hudson.views.DefaultViewsTabBar"/>
-        <primaryView>All</primaryView>
+        <primaryView>all</primaryView>
     </folderViews>
     <healthMetrics>
         <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric/>

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/FolderSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/FolderSpec.groovy
@@ -17,7 +17,7 @@ class FolderSpec extends Specification {
         <views>
             <hudson.model.AllView>
                 <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../../.."/>
-                <name>All</name>
+                <name>all</name>
                 <filterExecutors>false</filterExecutors>
                 <filterQueue>false</filterQueue>
                 <properties class="hudson.model.View$PropertyList"/>


### PR DESCRIPTION
All view should have the (unlocalized) name "all". Otherwise, every start of Jenkins, all names are converted, taking a couple (15 in our case) minutes.

See: https://issues.jenkins-ci.org/browse/JENKINS-38606