### PR TITLE
Support for Gerrit multibranch pipeline

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/BranchSourcesContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/BranchSourcesContext.groovy
@@ -74,6 +74,30 @@ class BranchSourcesContext extends AbstractExtensibleContext {
         }
     }
 
+    /**
+     * Adds a GitHub branch source. Can be called multiple times to add more branch sources.
+     *
+     * @since 1.53
+     */
+    @RequiresPlugin(id = 'gerrit-code-review', minimumVersion = '0.3.2')
+    void gerrit(@DslContext(GerritBranchSourceContext) Closure branchSourceClosure) {
+        GerritBranchSourceContext context = new GerritBranchSourceContext()
+        ContextHelper.executeInContext(branchSourceClosure, context)
+
+        branchSourceNodes << new NodeBuilder().'jenkins.branch.BranchSource' {
+            source(class: 'jenkins.plugins.gerrit.GerritSCMSource') {
+                id(context.id)
+                remote(context.remote ?: '')
+                credentialsId(context.credentialsId ?: '')
+                includes(context.includes ?: '')
+                excludes(context.excludes ?: '')
+            }
+            strategy(class: 'jenkins.branch.DefaultBranchPropertyStrategy') {
+                properties(class: 'empty-list')
+            }
+        }
+    }
+
     @Override
     protected void addExtensionNode(Node node) {
         branchSourceNodes << node

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/GerritBranchSourceContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/workflow/GerritBranchSourceContext.groovy
@@ -1,0 +1,47 @@
+package javaposse.jobdsl.dsl.helpers.workflow
+
+import javaposse.jobdsl.dsl.Context
+
+class GerritBranchSourceContext implements Context {
+    String id = UUID.randomUUID()
+    String remote
+    String credentialsId
+    String includes = '*'
+    String excludes
+    boolean ignoreOnPushNotifications
+
+    /**
+     * Specifies a unique ID for this branch source.
+     */
+    void id(String id) {
+        this.id = id
+    }
+
+    /**
+     * Sets the Git remote repository URL.
+     */
+    void remote(String remote) {
+        this.remote = remote
+    }
+
+    /**
+     * Sets credentials for authentication with the remote repository.
+     */
+    void credentialsId(String credentialsId) {
+        this.credentialsId = credentialsId
+    }
+
+    /**
+     * Sets a pattern for branches to include.
+     */
+    void includes(String includes) {
+        this.includes = includes
+    }
+
+    /**
+     * Sets a pattern for branches to exclude.
+     */
+    void excludes(String excludes) {
+        this.excludes = excludes
+    }
+}


### PR DESCRIPTION
Introduce the gerrit type multibrancPipelineJob
for allowing the definition of Gerrit Code Review workflow
validation jobs inside the Jenkins Configuration-as-Code
definition.

Example:
      multibranchPipelineJob('gerrit-project') {
          branchSources {
              gerrit {
                  remote('http://gerrit:8080/gerrit-project')
              }
          }
      }