### PR TITLE
Add support for Naginator checkRegex and regexpForRerun

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=1.72-SNAPSHOT
 groovyVersion=2.4.11
-jenkinsVersion=2.121
+jenkinsVersion=2.121.1
 assetPipelineVersion=2.11.6
 githubUser=jenkinsci

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/NaginatorContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/NaginatorContext.groovy
@@ -3,7 +3,9 @@ package javaposse.jobdsl.dsl.helpers.publisher
 import javaposse.jobdsl.dsl.Context
 
 class NaginatorContext implements Context {
+    String regexpForRerun = ''
     boolean rerunIfUnstable
+    boolean checkRegexp
     int retryLimit
     Node delay
 
@@ -42,5 +44,19 @@ class NaginatorContext implements Context {
         this.delay = new NodeBuilder().delay(class: 'com.chikli.hudson.plugin.naginator.FixedDelay') {
             delegate.delay(delay)
         }
+    }
+
+    /**
+     * Specifies if we should evaluate the regex for re-run
+     */
+    void checkRegexp(boolean checkRegexp = true) {
+        this.checkRegexp = checkRegexp
+    }
+
+    /**
+     * Specifies the regexp to evaluate
+     */
+    void regexpForRerun(String regexpForRerun) {
+        this.regexpForRerun = regexpForRerun
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -1354,10 +1354,10 @@ class PublisherContext extends AbstractExtensibleContext {
         ContextHelper.executeInContext(naginatorClosure, naginatorContext)
 
         Node naginatorNode = new NodeBuilder().'com.chikli.hudson.plugin.naginator.NaginatorPublisher' {
-            regexpForRerun()
+            regexpForRerun(naginatorContext.regexpForRerun)
             rerunIfUnstable(naginatorContext.rerunIfUnstable)
             rerunMatrixPart(false)
-            checkRegexp(false)
+            checkRegexp(naginatorContext.checkRegexp)
             maxSchedule(naginatorContext.retryLimit)
         }
         naginatorNode.append(naginatorContext.delay)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -4538,7 +4538,7 @@ class PublisherContextSpec extends Specification {
         with(context.publisherNodes[0]) {
             name() == 'com.chikli.hudson.plugin.naginator.NaginatorPublisher'
             children().size() == 6
-            regexpForRerun[0].value() == []
+            regexpForRerun[0].value() == ''
             rerunIfUnstable[0].value() == false
             rerunMatrixPart[0].value() == false
             checkRegexp[0].value() == false
@@ -4557,16 +4557,18 @@ class PublisherContextSpec extends Specification {
             rerunIfUnstable()
             retryLimit(3)
             fixedDelay(30)
+            checkRegexp()
+            regexpForRerun('.*')
         }
 
         then:
         with(context.publisherNodes[0]) {
             name() == 'com.chikli.hudson.plugin.naginator.NaginatorPublisher'
             children().size() == 6
-            regexpForRerun[0].value() == []
+            regexpForRerun[0].value() == '.*'
             rerunIfUnstable[0].value() == true
             rerunMatrixPart[0].value() == false
-            checkRegexp[0].value() == false
+            checkRegexp[0].value() == true
             maxSchedule[0].value() == 3
             delay[0].@class == 'com.chikli.hudson.plugin.naginator.FixedDelay'
             delay[0].children().size() == 1


### PR DESCRIPTION
The Naginator support is incomplete at the moment... The last checkbox and the regex field of the below image are not supported

https://cdn-images-1.medium.com/max/2000/1*f9Sq_tP2EHm-2UZjV0F-7Q.png

This pull request adds the possibility to define them using jobdsl

Let me know if something is missing