### PR TITLE
DescriptionSetter: Omit description when empty

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -106,7 +106,9 @@ class StepContext extends AbstractExtensibleContext {
     void buildDescription(String regexp, String description = null) {
         stepNodes << new NodeBuilder().'hudson.plugins.descriptionsetter.DescriptionSetterBuilder' {
             delegate.regexp(regexp ?: '')
-            delegate.description(description ?: '')
+            if (description) {
+                delegate.description(description)
+            }
         }
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/step/StepContextSpec.groovy
@@ -139,9 +139,8 @@ class StepContextSpec extends Specification {
         then:
         with(context.stepNodes[0]) {
             name() == 'hudson.plugins.descriptionsetter.DescriptionSetterBuilder'
-            children().size() == 2
+            children().size() == 1
             regexp[0].value() == '[version] (.*)'
-            description[0].value() == ''
         }
         1 * jobManagement.requireMinimumPluginVersion('description-setter', '1.9')
     }


### PR DESCRIPTION
Previously, there was no invocation of the buildDescription step that
would set the description from a regex: the plugin would see the empty
string `description` and faithfully set that ignoring the other
configuration parameter.