### PR TITLE
Support 'net' parameter within the buildInDocker DSL step

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/BuildInDockerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/BuildInDockerContext.groovy
@@ -14,6 +14,7 @@ class BuildInDockerContext extends AbstractContext {
     boolean forcePull
     String userGroup
     String startCommand = '/bin/cat'
+    String net = 'bridge'
 
     BuildInDockerContext(JobManagement jobManagement) {
         super(jobManagement)
@@ -77,5 +78,12 @@ class BuildInDockerContext extends AbstractContext {
 
     void startCommand(String startCommand) {
         this.startCommand = startCommand
+    }
+
+    /**
+     * @since 1.72
+     */
+    void net(String net) {
+        this.net = net
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -605,6 +605,7 @@ class WrapperContext extends AbstractExtensibleContext {
             forcePull(context.forcePull)
             group(context.userGroup ?: '')
             command(context.startCommand ?: '')
+            net(context.net ?: '')
         }
         node.append(context.selector)
         wrapperNodes << node

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -1391,7 +1391,7 @@ class WrapperContextSpec extends Specification {
         then:
         with(context.wrapperNodes[0]) {
             name() == 'com.cloudbees.jenkins.plugins.okidocki.DockerBuildWrapper'
-            children().size() == 9
+            children().size() == 10
             selector[0].children().size() == 2
             selector[0].attribute('class') == 'com.cloudbees.jenkins.plugins.okidocki.DockerfileImageSelector'
             selector[0].contextPath[0].value() == '.'
@@ -1404,6 +1404,7 @@ class WrapperContextSpec extends Specification {
             forcePull[0].value() == false
             group[0].value().empty
             command[0].value() == '/bin/cat'
+            net[0].value() == 'bridge'
         }
         1 * mockJobManagement.requireMinimumPluginVersion('docker-custom-build-environment', '1.6.2')
     }
@@ -1422,12 +1423,13 @@ class WrapperContextSpec extends Specification {
             verbose()
             userGroup('test10')
             startCommand('test11')
+            net('test12')
         }
 
         then:
         with(context.wrapperNodes[0]) {
             name() == 'com.cloudbees.jenkins.plugins.okidocki.DockerBuildWrapper'
-            children().size() == 9
+            children().size() == 10
             selector[0].children().size() == 2
             selector[0].attribute('class') == 'com.cloudbees.jenkins.plugins.okidocki.DockerfileImageSelector'
             selector[0].contextPath[0].value() == 'test1'
@@ -1448,6 +1450,7 @@ class WrapperContextSpec extends Specification {
             forcePull[0].value() == true
             group[0].value() == 'test10'
             command[0].value() == 'test11'
+            net[0].value() == 'test12'
         }
         1 * mockJobManagement.requireMinimumPluginVersion('docker-custom-build-environment', '1.6.2')
     }
@@ -1466,12 +1469,13 @@ class WrapperContextSpec extends Specification {
             verbose()
             userGroup('test10')
             startCommand('test11')
+            net('test12')
         }
 
         then:
         with(context.wrapperNodes[0]) {
             name() == 'com.cloudbees.jenkins.plugins.okidocki.DockerBuildWrapper'
-            children().size() == 9
+            children().size() == 10
             selector[0].children().size() == 1
             selector[0].attribute('class') == 'com.cloudbees.jenkins.plugins.okidocki.PullDockerImageSelector'
             selector[0].image[0].value() == 'test1'
@@ -1491,6 +1495,7 @@ class WrapperContextSpec extends Specification {
             forcePull[0].value() == true
             group[0].value() == 'test10'
             command[0].value() == 'test11'
+            net[0].value() == 'test12'
         }
         1 * mockJobManagement.requireMinimumPluginVersion('docker-custom-build-environment', '1.6.2')
     }


### PR DESCRIPTION
Just seen the comment in the mailing list:
- https://groups.google.com/forum/#!topic/job-dsl-plugin/96tq8RT3NIo

So, I thought let's add it to remember my old days! Not sure if you'd like to track this requirement in a Jira ticket, if so I'm happy to do it. Or whether this is deprecated and it's worth to move to the `DataBoundConstructor` and `DataBoundSetter` annotations in the plugin itself.

Thanks