### PR TITLE
add sourceInclusionPattern, sourceExclusionPattern and skipCopyOfSrcFiles for JaCoCo Plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/JacocoContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/JacocoContext.groovy
@@ -22,6 +22,9 @@ class JacocoContext extends AbstractContext {
     String maximumLineCoverage = '0'
     String maximumMethodCoverage = '0'
     String maximumClassCoverage = '0'
+    String sourceInclusionPattern = '**/*.java'
+    String sourceExclusionPattern = ''
+    Boolean skipCopyOfSrcFiles = false
     Boolean changeBuildStatus = null
 
     protected JacocoContext(JobManagement jobManagement) {
@@ -145,6 +148,28 @@ class JacocoContext extends AbstractContext {
      */
     void maximumClassCoverage(String maximumClassCoverage) {
         this.maximumClassCoverage = maximumClassCoverage
+    }
+
+    /**
+     * If set, changes the build status according to the thresholds. Defaults to {@code false}.
+     * Allows to include certain source files. Defaults to {@code '**&#47;*.java'}.
+     */
+    void sourceInclusionPattern(String sourceInclusionPattern) {
+      this.sourceInclusionPattern = sourceInclusionPattern
+    }
+
+    /**
+     * Allows to exclude certain source files. Defaults to {@code ''}.
+     */
+    void sourceExclusionPattern(String sourceExclusionPattern) {
+      this.sourceExclusionPattern = sourceExclusionPattern
+    }
+
+    /**
+     * If set, disables display of source files for coverage. Defaults to {@code false}.
+     */
+    void skipCopyOfSrcFiles(Boolean skipCopyOfSrcFiles = false) {
+      this.skipCopyOfSrcFiles = skipCopyOfSrcFiles
     }
 
     /**

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContext.groovy
@@ -254,6 +254,9 @@ class PublisherContext extends AbstractExtensibleContext {
             maximumLineCoverage jacocoContext.maximumLineCoverage
             maximumMethodCoverage jacocoContext.maximumMethodCoverage
             maximumClassCoverage jacocoContext.maximumClassCoverage
+            sourceInclusionPattern jacocoContext.sourceInclusionPattern
+            sourceExclusionPattern jacocoContext.sourceExclusionPattern
+            skipCopyOfSrcFiles jacocoContext.skipCopyOfSrcFiles
             if (jacocoContext.changeBuildStatus != null) {
                 changeBuildStatus jacocoContext.changeBuildStatus
             }


### PR DESCRIPTION
After my first pull request headed against the wrong fork maybe now all is right.

While creating a job with Job DSL I got an exception during runtime on unix system that sourceInclusionPattern and sourceExclusionPattern are null. When I edited the job eveything works fine.
So it was a problem that Job DSL wrotes null to this values.