### PR TITLE
JENKINS-55190 support missing parameters of Throttle Concurrent Builds Plugin

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/Job/throttleConcurrentBuilds.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/Job/throttleConcurrentBuilds.groovy
@@ -3,6 +3,8 @@ job('example-1') {
     throttleConcurrentBuilds {
         maxPerNode(1)
         maxTotal(2)
+        limitOneJobWithMatchingParams(true)
+        paramsToUseForLimit('PARAMETER_1 PARAMETER_2')
     }
 }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
@@ -103,6 +103,10 @@ abstract class Job extends Item {
                         throttleMatrixConfigurations(throttleContext.throttleMatrixConfigurations)
                     }
                 }
+                if (jobManagement.isMinimumPluginVersionInstalled('throttle-concurrents', '1.8.5')) {
+                    limitOneJobWithMatchingParams(throttleContext.limitOneJobWithMatchingParams)
+                    paramsToUseForLimit(throttleContext.paramsToUseForLimit)
+                }
             }
         }
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/toplevel/ThrottleConcurrentBuildsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/toplevel/ThrottleConcurrentBuildsContext.groovy
@@ -17,6 +17,8 @@ class ThrottleConcurrentBuildsContext extends AbstractContext {
     int maxConcurrentTotal
     boolean throttleMatrixBuilds = true
     boolean throttleMatrixConfigurations = true
+    boolean limitOneJobWithMatchingParams = false
+    String paramsToUseForLimit = ''
 
     ThrottleConcurrentBuildsContext(JobManagement jobManagement, Item item) {
         super(jobManagement)
@@ -75,4 +77,36 @@ class ThrottleConcurrentBuildsContext extends AbstractContext {
 
         this.throttleMatrixConfigurations = throttleMatrixConfigurations
     }
+
+    /**
+     * If this box is checked, only one instance of the job with matching parameter values will be allowed
+     * to run at a given time. Other instances of this job with different parameter values will be allowed
+     * to run concurrently.
+     *
+     * Optionally, provide a comma-separated list of parameters to use when comparing jobs. If blank,
+     * all parameters must match for a job to be limited to one running instance.
+     *
+     * Defaults to {@code false}.
+     *
+     * @since 1.72
+     */
+    @RequiresPlugin(id = 'throttle-concurrents', minimumVersion = '1.8.5')
+    void limitOneJobWithMatchingParams(boolean limitOneJobWithMatchingParams = false) {
+        this.limitOneJobWithMatchingParams = limitOneJobWithMatchingParams
+    }
+
+    /**
+     * List of parameters to check (using whitespace as the separator).
+     *
+     * Used if limitOneJobWithMatchingParams set to true.
+     *
+     * Defaults to {@code ''}.
+     *
+     * @since 1.72
+     */
+    @RequiresPlugin(id = 'throttle-concurrents', minimumVersion = '1.8.5')
+    void paramsToUseForLimit(String paramsToUseForLimit = '') {
+        this.paramsToUseForLimit = paramsToUseForLimit
+    }
+
 }


### PR DESCRIPTION
support limitOneJobWithMatchingParams and paramsToUseForLimit parameters of Throttle Concurrent Builds Plugin.

job-dsl-core should support limitOneJobWithMatchingParams and paramsToUseForLimit parameters of Throttle Concurrent Builds Plugin

See Ticket [JENKINS-55190](https://issues.jenkins-ci.org/browse/JENKINS-55190)