### PR TITLE
 in job config history show only changes

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -500,6 +500,7 @@ public class JenkinsJobManagement extends AbstractJobManagement {
             String itemName = FilenameUtils.getName(path);
             if (parent instanceof ModifiableTopLevelItemGroup) {
                 Item project = ((ModifiableTopLevelItemGroup) parent).createProjectFromXML(itemName, is);
+                project.save();
                 notifyItemCreated(project, dslItem);
             } else if (parent == null) {
                 throw new DslException(format(Messages.CreateItem_UnknownParent(), path));

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
@@ -516,7 +516,7 @@ class JenkinsJobManagementSpec extends Specification {
         jobManagement.createOrUpdateConfig(createItem('project', '/config.xml'), false)
 
         then:
-        0 * saveableListener.onChange(job, _)
+        1 * saveableListener.onChange(job, _)
     }
 
     def 'createOrUpdateConfig should fail if item type does not match'() {


### PR DESCRIPTION
Jobs created via job-dsl-plugin have different formatting in job XML than jobs saved by Jenkins. This clutters job config history with unnecessary job config changes. See https://issues.jenkins-ci.org/browse/JENKINS-49787