### PR TITLE
JENKINS-56427 Add workDir parameter to the Phabricator plugin DSL

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext/phabricator.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext/phabricator.groovy
@@ -4,6 +4,7 @@ job('example') {
             createCommit()
             applyToMaster()
             showBuildStartedMessage()
+            workDir('source')
         }
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/PhabricatorContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/PhabricatorContext.groovy
@@ -6,6 +6,7 @@ class PhabricatorContext implements Context {
     boolean createCommit
     boolean applyToMaster
     boolean showBuildStartedMessage = true
+    String workDir
 
     /**
      * Create a git commit with the patch. Defaults to {@code false}.
@@ -26,5 +27,12 @@ class PhabricatorContext implements Context {
      */
     void showBuildStartedMessage(boolean showBuildStartedMessage = true) {
         this.showBuildStartedMessage = showBuildStartedMessage
+    }
+
+    /**
+     * Sets the relative working directory in the workspace for arcanist commands.
+     */
+    void workDir(String workDir) {
+        this.workDir = workDir
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/PhabricatorContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/PhabricatorContext.groovy
@@ -6,7 +6,7 @@ class PhabricatorContext implements Context {
     boolean createCommit
     boolean applyToMaster
     boolean showBuildStartedMessage = true
-    String workDir
+    String workDir = ''
 
     /**
      * Create a git commit with the patch. Defaults to {@code false}.

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -340,6 +340,7 @@ class WrapperContext extends AbstractExtensibleContext {
             createCommit(context.createCommit)
             applyToMaster(context.applyToMaster)
             showBuildStartedMessage(context.showBuildStartedMessage)
+            workDir(context.workDir)
         }
     }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -655,6 +655,7 @@ class WrapperContextSpec extends Specification {
             createCommit[0].value() == false
             applyToMaster[0].value() == false
             showBuildStartedMessage[0].value() == true
+            workDir[0].value() == ''
         }
         1 * mockJobManagement.requireMinimumPluginVersion('phabricator-plugin', '1.8.1')
     }
@@ -665,6 +666,7 @@ class WrapperContextSpec extends Specification {
             createCommit()
             applyToMaster()
             showBuildStartedMessage(false)
+            workDir('source')
         }
 
         then:
@@ -674,6 +676,7 @@ class WrapperContextSpec extends Specification {
             createCommit[0].value() == true
             applyToMaster[0].value() == true
             showBuildStartedMessage[0].value() == false
+            workDir[0].value() == 'source'
         }
         1 * mockJobManagement.requireMinimumPluginVersion('phabricator-plugin', '1.8.1')
     }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -651,7 +651,7 @@ class WrapperContextSpec extends Specification {
         then:
         with(context.wrapperNodes[0]) {
             name() == 'com.uber.jenkins.phabricator.PhabricatorBuildWrapper'
-            children().size() == 3
+            children().size() == 4
             createCommit[0].value() == false
             applyToMaster[0].value() == false
             showBuildStartedMessage[0].value() == true
@@ -672,7 +672,7 @@ class WrapperContextSpec extends Specification {
         then:
         with(context.wrapperNodes[0]) {
             name() == 'com.uber.jenkins.phabricator.PhabricatorBuildWrapper'
-            children().size() == 3
+            children().size() == 4
             createCommit[0].value() == true
             applyToMaster[0].value() == true
             showBuildStartedMessage[0].value() == false


### PR DESCRIPTION
Fixes https://issues.jenkins-ci.org/browse/JENKINS-56427

The `workDir` parameter to the Phabricator Jenkins plugin has been added as of this commit: https://github.com/uber/phabricator-jenkins-plugin/commit/7ab34368869d82b8f49fa86b5d2628ef16880902