### PR TITLE
fix(JENKINS-56462): add trim option support in pipelinejob

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -221,8 +221,10 @@ class BuildParametersContext extends AbstractExtensibleContext {
     /**
      * Defines a simple text parameter, where users can enter a string value.
      */
-    void stringParam(String parameterName, String defaultValue = null, String description = null) {
+    void stringParam(String parameterName, String defaultValue = null, String description = null,
+                     boolean isTrim = false) {
         simpleParam('hudson.model.StringParameterDefinition', parameterName, defaultValue, description)
+        buildParameterNodes[parameterName].appendNode('trim', isTrim)
     }
 
     /**

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -531,7 +531,7 @@ class BuildParametersContextSpec extends Specification {
 
     def 'base stringParam usage'() {
         when:
-        context.stringParam('myParameterName', 'my default stringParam value', 'myStringParameterDescription')
+        context.stringParam('myParameterName', 'my default stringParam value', 'myStringParameterDescription', true)
 
         then:
         context.buildParameterNodes != null
@@ -540,6 +540,7 @@ class BuildParametersContextSpec extends Specification {
         context.buildParameterNodes['myParameterName'].name.text() == 'myParameterName'
         context.buildParameterNodes['myParameterName'].defaultValue.text() == 'my default stringParam value'
         context.buildParameterNodes['myParameterName'].description.text() == 'myStringParameterDescription'
+        context.buildParameterNodes['myParameterName'].trim.text() == 'true'
     }
 
     def 'simplified stringParam usage'() {


### PR DESCRIPTION
**Issue**

I am trying to define a string parameter with a trim option set to true in a pipelineJob (inspired from syntax of implementation done in JENKINS-47115). but the trim option is not define in the 
`BuildParametersContext.stringParam()` so the build failed.

** Solution**

To be consitent with existing StringParameterDefinition, I added a attribute to the node with the trim value.

link to issue : https://issues.jenkins-ci.org/browse/JENKINS-56462