### PR TITLE
Support seed job creation in Configuration as Code, updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ gradle-app.setting
 /local*
 build
 generated
-/out
+*/out/
 /classes
 .DS_Store
 

--- a/docs/JCasC-Job-DSL.md
+++ b/docs/JCasC-Job-DSL.md
@@ -1,0 +1,65 @@
+Via [configuratin-as-code-plugin](https://plugins.jenkins.io/configuration-as-code) also known as JCasC
+
+It is possible to configure initial seed jobs through a yaml config file.  
+The basics for job dsl is you have a root element called `jobs` that will be parsed to configure via job dsl
+
+Examples of config file
+
+```yml
+jobs:
+  - script: >
+      multibranchPipelineJob('configuration-as-code') {
+          branchSources {
+              git {
+                  id = 'configuration-as-code'
+                  remote('https://github.com/jenkinsci/configuration-as-code-plugin.git')
+              }
+          }
+      }
+```
+
+You can also fetch your job dsl from a file or URL
+
+```yml
+jobs:
+  - file: ./jobdsl/job.groovy
+```
+
+```yml
+jobs:
+  - url: https://raw.githubusercontent.com/jenkinsci/job-dsl-plugin/master/job-dsl-plugin/src/test/resources/javaposse/jobdsl/plugin/testjob.groovy
+```
+
+you can reference multiple scripts, files, and urls
+
+```yml
+jobs:
+  - script: >
+    job('testJob1') {
+        scm {
+            git('git://github.com/quidryan/aws-sdk-test.git')
+        }
+        triggers {
+            scm('H/15 * * * *')
+        }
+        steps {
+            maven('-e clean test')
+        }
+    }
+
+  - script: >
+    job('testJob2') {
+        scm {
+            git('git://github.com/quidryan/aws-sdk-test.git')
+        }
+        triggers {
+            scm('H/15 * * * *')
+        }
+        steps {
+            maven('-e clean test')
+        }
+    }
+
+  - file: ./jobdsl/job1.groovy
+  - file: ./jobdsl/job2.groovy
+```

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -95,7 +95,8 @@ dependencies {
     }
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.15.4'
     optionalJenkinsPlugins 'org.jenkinsci.plugins:managed-scripts:1.3'
-    optionalJenkinsPlugins 'io.jenkins:configuration-as-code:1.1-20180926.061808-1'
+    optionalJenkinsPlugins 'io.jenkins:configuration-as-code:1.13'
+    jenkinsTest 'io.jenkins:configuration-as-code:1.13:tests'
     jenkinsTest 'org.jenkins-ci.plugins:cloudbees-folder:5.14'
     jenkinsTest 'org.jenkins-ci.plugins:matrix-auth:1.3'
     jenkinsTest 'org.jenkins-ci.plugins:nested-view:1.14'

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     }
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.15.4'
     optionalJenkinsPlugins 'org.jenkinsci.plugins:managed-scripts:1.3'
+    optionalJenkinsPlugins 'io.jenkins:configuration-as-code:1.1-20180926.061808-1'
     jenkinsTest 'org.jenkins-ci.plugins:cloudbees-folder:5.14'
     jenkinsTest 'org.jenkins-ci.plugins:matrix-auth:1.3'
     jenkinsTest 'org.jenkins-ci.plugins:nested-view:1.14'

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -96,6 +96,7 @@ dependencies {
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.15.4'
     optionalJenkinsPlugins 'org.jenkinsci.plugins:managed-scripts:1.3'
     optionalJenkinsPlugins 'io.jenkins:configuration-as-code:1.13'
+    jenkinsTest 'io.jenkins:configuration-as-code:1.13'
     jenkinsTest 'io.jenkins:configuration-as-code:1.13:tests'
     jenkinsTest 'org.jenkins-ci.plugins:cloudbees-folder:5.14'
     jenkinsTest 'org.jenkins-ci.plugins:matrix-auth:1.3'

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/ConfigurableScriptSource.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/ConfigurableScriptSource.java
@@ -1,0 +1,29 @@
+package javaposse.jobdsl.plugin.casc;
+
+import io.jenkins.plugins.casc.Configurable;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.model.CNode;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public abstract class ConfigurableScriptSource extends ScriptSource implements Configurable {
+
+    @Override
+    public void configure(CNode node) throws ConfiguratorException {
+        configure(node.asScalar().getValue());
+    }
+
+    protected abstract void configure(String value);
+
+    @Override
+    public void check(CNode node) throws ConfiguratorException {
+        node.asScalar();
+    }
+
+    @Override
+    public CNode describe() throws Exception {
+        return null; // Not relevant here
+    }
+
+}

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/ConfigurableScriptSource.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/ConfigurableScriptSource.java
@@ -4,9 +4,6 @@ import io.jenkins.plugins.casc.Configurable;
 import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.model.CNode;
 
-/**
- * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
- */
 public abstract class ConfigurableScriptSource extends ScriptSource implements Configurable {
 
     @Override

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/FromFileScriptSource.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/FromFileScriptSource.java
@@ -9,9 +9,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-/**
- * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
- */
 public class FromFileScriptSource extends ConfigurableScriptSource {
 
     public String path;

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/FromFileScriptSource.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/FromFileScriptSource.java
@@ -1,0 +1,34 @@
+package javaposse.jobdsl.plugin.casc;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import org.apache.commons.io.FileUtils;
+import org.jenkinsci.Symbol;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class FromFileScriptSource extends ConfigurableScriptSource {
+
+    public String path;
+
+    @Override
+    public void configure(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public String getScript() throws IOException {
+        return FileUtils.readFileToString(new File(path), StandardCharsets.UTF_8);
+    }
+
+    @Extension
+    @Symbol("file")
+    public static class DescriptorImpl extends Descriptor<ScriptSource> {
+
+    }
+}

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/FromUrlScriptSource.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/FromUrlScriptSource.java
@@ -1,0 +1,34 @@
+package javaposse.jobdsl.plugin.casc;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.jenkins.plugins.casc.Configurable;
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.Symbol;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class FromUrlScriptSource extends ConfigurableScriptSource implements Configurable {
+
+    public String url;
+
+    @Override
+    public void configure(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public String getScript() throws IOException {
+        return IOUtils.toString(URI.create(url));
+    }
+
+    @Extension
+    @Symbol("url")
+    public static class DescriptorImpl extends Descriptor<ScriptSource> {
+
+    }
+}

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/FromUrlScriptSource.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/FromUrlScriptSource.java
@@ -9,9 +9,6 @@ import org.jenkinsci.Symbol;
 import java.io.IOException;
 import java.net.URI;
 
-/**
- * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
- */
 public class FromUrlScriptSource extends ConfigurableScriptSource implements Configurable {
 
     public String url;

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/InlineGroovyScriptSource.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/InlineGroovyScriptSource.java
@@ -7,9 +7,6 @@ import org.jenkinsci.Symbol;
 
 import java.io.IOException;
 
-/**
- * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
- */
 public class InlineGroovyScriptSource extends ConfigurableScriptSource implements Configurable {
 
     public String script;

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/InlineGroovyScriptSource.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/InlineGroovyScriptSource.java
@@ -1,0 +1,32 @@
+package javaposse.jobdsl.plugin.casc;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.jenkins.plugins.casc.Configurable;
+import org.jenkinsci.Symbol;
+
+import java.io.IOException;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class InlineGroovyScriptSource extends ConfigurableScriptSource implements Configurable {
+
+    public String script;
+
+    @Override
+    public void configure(String script) {
+        this.script = script;
+    }
+
+    @Override
+    public String getScript() throws IOException {
+        return script;
+    }
+
+    @Extension
+    @Symbol("script")
+    public static class DescriptorImpl extends Descriptor<ScriptSource> {
+
+    }
+}

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/ScriptSource.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/ScriptSource.java
@@ -5,9 +5,6 @@ import hudson.model.AbstractDescribableImpl;
 
 import java.io.IOException;
 
-/**
- * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
- */
 public abstract class ScriptSource extends AbstractDescribableImpl<ScriptSource> implements ExtensionPoint {
 
     public abstract String getScript() throws IOException;

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/ScriptSource.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/ScriptSource.java
@@ -1,0 +1,14 @@
+package javaposse.jobdsl.plugin.casc;
+
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+
+import java.io.IOException;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public abstract class ScriptSource extends AbstractDescribableImpl<ScriptSource> implements ExtensionPoint {
+
+    public abstract String getScript() throws IOException;
+}

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/SeedJobConfigurator.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/SeedJobConfigurator.java
@@ -1,16 +1,16 @@
 package javaposse.jobdsl.plugin.casc;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.EnvVars;
 import hudson.Extension;
 import io.jenkins.plugins.casc.Attribute;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.Configurator;
 import io.jenkins.plugins.casc.RootElementConfigurator;
+import io.jenkins.plugins.casc.SecretSourceResolver;
 import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
 import io.jenkins.plugins.casc.model.CNode;
-import io.jenkins.plugins.casc.model.Sequence;
+import io.jenkins.plugins.casc.model.Mapping;
+import java.util.Map;
 import javaposse.jobdsl.dsl.GeneratedItems;
 import javaposse.jobdsl.plugin.JenkinsDslScriptLoader;
 import javaposse.jobdsl.plugin.JenkinsJobManagement;
@@ -18,33 +18,38 @@ import javaposse.jobdsl.plugin.LookupStrategy;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.util.ArrayList;
+import javax.annotation.CheckForNull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static io.vavr.API.Try;
+import static io.vavr.API.unchecked;
+
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-@Extension(optional = true)
+@Extension(optional = true, ordinal = -50) // Ordinal -50 Ensure it is loaded after GlobalJobDslSecurityConfiguration
 @Restricted(NoExternalUse.class)
 public class SeedJobConfigurator implements RootElementConfigurator<GeneratedItems[]> {
 
+    @Nonnull
     @Override
     public String getName() {
         return "jobs";
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Class getTarget() {
         return GeneratedItems[].class;
     }
 
+    @Nonnull
     @Override
-    public Set<Attribute<GeneratedItems[],?>> describe() {
+    @SuppressWarnings("unchecked")
+    public Set<Attribute<GeneratedItems[], ?>> describe() {
         return Collections.singleton(new MultivaluedAttribute("", ScriptSource.class));
     }
 
@@ -53,26 +58,17 @@ public class SeedJobConfigurator implements RootElementConfigurator<GeneratedIte
         return new GeneratedItems[0]; // Doesn't really make sense
     }
 
+    @Nonnull
     @Override
+    @SuppressWarnings("unchecked")
     public GeneratedItems[] configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
-        JenkinsJobManagement mng = new JenkinsJobManagement(System.out, new EnvVars(), null, null, LookupStrategy.JENKINS_ROOT);
-        final Sequence sources = config.asSequence();
-        final Configurator<ScriptSource> con = context.lookup(ScriptSource.class);
-        List<GeneratedItems> generated = new ArrayList<>();
-        for (CNode source : sources) {
-            final String script;
-            try {
-                script = con.configure(source, context).getScript();
-            } catch (IOException e) {
-                throw new ConfiguratorException(this, "Failed to retrieve job-dsl script", e);
-            }
-            try {
-                generated.add(new JenkinsDslScriptLoader(mng).runScript(script));
-            } catch (Exception ex) {
-                throw new ConfiguratorException(this, "Failed to execute script with hash " + script.hashCode(), ex);
-            }
-        }
-        return generated.toArray(new GeneratedItems[generated.size()]);
+        JenkinsJobManagement management = new JenkinsJobManagement(System.out, System.getenv(), null, null, LookupStrategy.JENKINS_ROOT);
+        Configurator<ScriptSource> configurator = context.lookupOrFail(ScriptSource.class);
+        return config.asSequence().stream()
+            .map(source -> getActualValue(source, context))
+            .map(source -> getScriptFromSource(source, context, configurator))
+            .map(script -> generateFromScript(script, management))
+            .toArray(GeneratedItems[]::new);
     }
 
     @Override
@@ -83,7 +79,7 @@ public class SeedJobConfigurator implements RootElementConfigurator<GeneratedIte
 
     @Nonnull
     @Override
-    public List<Configurator> getConfigurators(ConfigurationContext context) {
+    public List<Configurator<GeneratedItems[]>> getConfigurators(ConfigurationContext context) {
         return Collections.singletonList(context.lookup(ScriptSource.class));
     }
 
@@ -91,5 +87,32 @@ public class SeedJobConfigurator implements RootElementConfigurator<GeneratedIte
     @Override
     public CNode describe(GeneratedItems[] instance, ConfigurationContext context) throws Exception {
         return null;
+    }
+
+    private CNode getActualValue(CNode config, ConfigurationContext context) {
+        return unchecked(() -> config.asMapping().entrySet().stream().findFirst()).apply()
+            .map(entry -> {
+                Mapping mapping = new Mapping();
+                mapping.put(entry.getKey(), revealSourceOrGetValue(entry, context));
+                return (CNode) mapping;
+            }).orElse(config);
+    }
+
+    private String revealSourceOrGetValue(Map.Entry<String, CNode> entry, ConfigurationContext context) {
+        String value = unchecked(() -> entry.getValue().asScalar().getValue()).apply();
+        return SecretSourceResolver.resolve(context, value);
+    }
+
+    private GeneratedItems generateFromScript(String script, JenkinsJobManagement management) {
+        return unchecked(() ->
+            Try(() -> new JenkinsDslScriptLoader(management).runScript(script))
+                .getOrElseThrow(t -> new ConfiguratorException(this, "Failed to execute script with hash " + script.hashCode(), t))).apply();
+    }
+
+    private String getScriptFromSource(CNode source, ConfigurationContext context, Configurator<ScriptSource> configurator) {
+        return unchecked(() ->
+            Try(() -> configurator.configure(source, context))
+                .getOrElseThrow(t -> new ConfiguratorException(this, "Failed to retrieve job-dsl script", t))
+                .getScript()).apply();
     }
 }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/SeedJobConfigurator.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/SeedJobConfigurator.java
@@ -1,0 +1,95 @@
+package javaposse.jobdsl.plugin.casc;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.EnvVars;
+import hudson.Extension;
+import io.jenkins.plugins.casc.Attribute;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.Configurator;
+import io.jenkins.plugins.casc.RootElementConfigurator;
+import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Sequence;
+import javaposse.jobdsl.dsl.GeneratedItems;
+import javaposse.jobdsl.plugin.JenkinsDslScriptLoader;
+import javaposse.jobdsl.plugin.JenkinsJobManagement;
+import javaposse.jobdsl.plugin.LookupStrategy;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Extension(optional = true)
+@Restricted(NoExternalUse.class)
+public class SeedJobConfigurator implements RootElementConfigurator<GeneratedItems[]> {
+
+    @Override
+    public String getName() {
+        return "jobs";
+    }
+
+    @Override
+    public Class getTarget() {
+        return GeneratedItems[].class;
+    }
+
+    @Override
+    public Set<Attribute<GeneratedItems[],?>> describe() {
+        return Collections.singleton(new MultivaluedAttribute("", ScriptSource.class));
+    }
+
+    @Override
+    public GeneratedItems[] getTargetComponent(ConfigurationContext context) {
+        return new GeneratedItems[0]; // Doesn't really make sense
+    }
+
+    @Override
+    public GeneratedItems[] configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
+        JenkinsJobManagement mng = new JenkinsJobManagement(System.out, new EnvVars(), null, null, LookupStrategy.JENKINS_ROOT);
+        final Sequence sources = config.asSequence();
+        final Configurator<ScriptSource> con = context.lookup(ScriptSource.class);
+        List<GeneratedItems> generated = new ArrayList<>();
+        for (CNode source : sources) {
+            final String script;
+            try {
+                script = con.configure(source, context).getScript();
+            } catch (IOException e) {
+                throw new ConfiguratorException(this, "Failed to retrieve job-dsl script", e);
+            }
+            try {
+                generated.add(new JenkinsDslScriptLoader(mng).runScript(script));
+            } catch (Exception ex) {
+                throw new ConfiguratorException(this, "Failed to execute script with hash " + script.hashCode(), ex);
+            }
+        }
+        return generated.toArray(new GeneratedItems[generated.size()]);
+    }
+
+    @Override
+    public GeneratedItems[] check(CNode config, ConfigurationContext context) throws ConfiguratorException {
+        // Any way to dry-run a job-dsl script ?
+        return new GeneratedItems[0];
+    }
+
+    @Nonnull
+    @Override
+    public List<Configurator> getConfigurators(ConfigurationContext context) {
+        return Collections.singletonList(context.lookup(ScriptSource.class));
+    }
+
+    @CheckForNull
+    @Override
+    public CNode describe(GeneratedItems[] instance, ConfigurationContext context) throws Exception {
+        return null;
+    }
+}

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/SeedJobConfigurator.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/SeedJobConfigurator.java
@@ -27,9 +27,6 @@ import java.util.Set;
 import static io.vavr.API.Try;
 import static io.vavr.API.unchecked;
 
-/**
- * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
- */
 @Extension(optional = true, ordinal = -50) // Ordinal -50 Ensure it is loaded after GlobalJobDslSecurityConfiguration
 @Restricted(NoExternalUse.class)
 public class SeedJobConfigurator implements RootElementConfigurator<GeneratedItems[]> {
@@ -73,7 +70,6 @@ public class SeedJobConfigurator implements RootElementConfigurator<GeneratedIte
 
     @Override
     public GeneratedItems[] check(CNode config, ConfigurationContext context) throws ConfiguratorException {
-        // Any way to dry-run a job-dsl script ?
         return new GeneratedItems[0];
     }
 

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/casc/FromFileScriptSource/schema.jelly
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/casc/FromFileScriptSource/schema.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+    "io.jenkins.plugins.casc.support.jobdsl.FromFileScriptSource": { "type": "string" }
+</j:jelly>

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/casc/FromUrlScriptSource/schema.jelly
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/casc/FromUrlScriptSource/schema.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+    "io.jenkins.plugins.casc.support.jobdsl.FromUrlScriptSource": { "type": "string" }
+</j:jelly>

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/casc/InlineGroovyScriptSource/schema.jelly
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/casc/InlineGroovyScriptSource/schema.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+    "io.jenkins.plugins.casc.support.jobdsl.InlineGroovyScriptSource": { "type": "string" }
+</j:jelly>

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/casc/SeedJobConfigurator/schema.jelly
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/casc/SeedJobConfigurator/schema.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+    "[javaposse.jobdsl.dsl.GeneratedItems;": {
+      "type": "array",
+      "items": {
+        "type": "#/definitions/io.jenkins.plugins.casc.support.jobdsl.ScriptSource"
+      }
+    }
+</j:jelly>

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.java
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.java
@@ -1,10 +1,9 @@
 package javaposse.jobdsl.plugin;
 
-import io.jenkins.plugins.casc.ConfigurationAsCode;
-import io.jenkins.plugins.casc.yaml.YamlSource;
-import org.junit.Rule;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -13,12 +12,12 @@ import static org.junit.Assert.assertNotNull;
  */
 public class ConfigurationAsCodeTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    @ClassRule
+    @ConfiguredWithCode("ConfigurationAsCodeTest.yaml")
+    public static JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
 
     @Test
-    public void configure_seed_job() throws Exception {
-        ConfigurationAsCode.get().configureWith(new YamlSource(getClass().getResourceAsStream("ConfigurationAsCodeTest.yaml"), YamlSource.READ_FROM_INPUTSTREAM));
+    public void configure_seed_job() {
         assertNotNull(j.jenkins.getItem("testJob1"));
         assertNotNull(j.jenkins.getItem("testJob2"));
     }

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.java
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.java
@@ -7,9 +7,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
 
-/**
- * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
- */
 public class ConfigurationAsCodeTest {
 
     @ClassRule

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.java
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.java
@@ -1,0 +1,25 @@
+package javaposse.jobdsl.plugin;
+
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.yaml.YamlSource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class ConfigurationAsCodeTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void configure_seed_job() throws Exception {
+        ConfigurationAsCode.get().configureWith(new YamlSource(getClass().getResourceAsStream("ConfigurationAsCodeTest.yaml"), YamlSource.READ_FROM_INPUTSTREAM));
+        assertNotNull(j.jenkins.getItem("testJob1"));
+        assertNotNull(j.jenkins.getItem("testJob2"));
+    }
+}

--- a/job-dsl-plugin/src/test/resources/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.yaml
+++ b/job-dsl-plugin/src/test/resources/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.yaml
@@ -1,0 +1,15 @@
+jobs:
+  - script: >
+      job('testJob1') {
+          scm {
+              git('git://github.com/quidryan/aws-sdk-test.git')
+          }
+          triggers {
+              scm('H/15 * * * *')
+          }
+          steps {
+              maven('-e clean test')
+          }
+      }
+
+  - file: ./src/test/resources/javaposse/jobdsl/plugin/testjob.groovy

--- a/job-dsl-plugin/src/test/resources/javaposse/jobdsl/plugin/testjob.groovy
+++ b/job-dsl-plugin/src/test/resources/javaposse/jobdsl/plugin/testjob.groovy
@@ -1,0 +1,11 @@
+job('testJob2') {
+    scm {
+        git('git://github.com/quidryan/aws-sdk-test.git')
+    }
+    triggers {
+        scm('H/15 * * * *')
+    }
+    steps {
+        maven('-e clean test')
+    }
+}


### PR DESCRIPTION
It is using a released version and the changes that have happened to the configurator in the meantime.
SeedJob configurator now has access to JCasC secrets.