### PR TITLE
Fix documentation regarding old *workflow* job methods

### DIFF
--- a/docs/Job-DSL-Commands.md
+++ b/docs/Job-DSL-Commands.md
@@ -51,9 +51,9 @@ mavenJob(String name, Closure closure = null)     // since 1.30
 
 multiJob(String name, Closure closure = null)     // since 1.30
 
-workflowJob(String name, Closure closure = null)  // since 1.30
+pipelineJob(String name, Closure closure = null)  // since 1.47
 
-multibranchWorkflowJob(String name, Closure closure = null) // since 1.42
+multibranchPipelineJob(String name, Closure closure = null) // since 1.47
 ```
 
 These methods will return a job object that can be re-used and passed around. E.g.

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
@@ -112,7 +112,6 @@ interface DslFactory extends ViewFactory {
 
     /**
      * Create or updates a pipeline job.
-     * Alias for #workflowJob(java.lang.String).
      *
      * @since 1.47
      * @see #pipelineJob(java.lang.String, groovy.lang.Closure)
@@ -122,7 +121,6 @@ interface DslFactory extends ViewFactory {
 
     /**
      * Create or updates a pipeline job.
-     * Alias for #workflowJob(java.lang.String, groovy.lang.Closure)
      *
      * @since 1.47
      */


### PR DESCRIPTION
There still have been some traces of `workflowJob` and `multibranchWorkflowJob`.