### PR TITLE
Deprecate support for concurrentBuild in Pipeline jobs

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -42,6 +42,8 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
     ([JENKINS-51202](https://issues.jenkins-ci.org/browse/JENKINS-51202))
   * Fixed [[Dynamic DSL]] problem
     ([JENKINS-57817](https://issues.jenkins-ci.org/browse/JENKINS-57817))
+  * Deprecated `concurrentBuild` method in `pipelineJob` context, see [Migration](Migration#migrating-to-175)
+    ([JENKINS-53775](https://issues.jenkins-ci.org/browse/JENKINS-53775))
 * 1.74 (May 01 2019)
   * Fixed [Configuration as Code](https://github.com/jenkinsci/configuration-as-code-plugin/) extension
     ([JENKINS-57218](https://issues.jenkins-ci.org/browse/JENKINS-57218))

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -24,6 +24,41 @@ multibranchPipelineJob('example') {
 }
 ```
 
+### Pipeline: Job Plugin
+
+The `concurrentBuild` field was deprecated and replaced by
+`DisableConcurrentBuildsJobProperty` in
+[jenkinsci/workflow-job-plugin#8](https://github.com/jenkinsci/workflow-job-plugin/pull/8),
+which was released in Pipeline: Job 2.4. Use of this deprecated field causes
+[JENKINS-53775](https://issues.jenkins-ci.org/browse/JENKINS-53775) and should
+be replaced with the [[Dynamic DSL]].
+
+#### Disabling concurrent Pipeline builds
+
+DSL prior to 1.75
+```groovy
+concurrentBuild false
+```
+
+DSL since 1.75
+```groovy
+properties {
+    disableConcurrentBuilds()
+}
+```
+
+#### Enabling concurrent Pipeline builds
+
+DSL prior to 1.75
+```groovy
+concurrentBuild true
+```
+
+DSL since 1.75
+
+Simply delete any usages of `concurrentBuild true`. Concurrent builds are
+enabled for Pipeline jobs by default.
+
 ## Migrating to 1.72
 
 ### CloudBees Folders Plugin

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Job.groovy
@@ -225,18 +225,6 @@ abstract class Job extends Item {
     }
 
     /**
-     * Allows Jenkins to schedule and execute multiple builds concurrently.
-     *
-     * @since 1.21
-     */
-    void concurrentBuild(boolean allowConcurrentBuild = true) {
-        configure { Node project ->
-            Node node = methodMissing('concurrentBuild', allowConcurrentBuild)
-            project / node
-        }
-    }
-
-    /**
      * Compresses the log file after build completion.
      *
      * @since 1.36

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Project.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/Project.groovy
@@ -143,6 +143,18 @@ abstract class Project extends Job {
     }
 
     /**
+     * Allows Jenkins to schedule and execute multiple builds concurrently.
+     *
+     * @since 1.21
+     */
+    void concurrentBuild(boolean allowConcurrentBuild = true) {
+        configure { Node project ->
+            Node node = methodMissing('concurrentBuild', allowConcurrentBuild)
+            project / node
+        }
+    }
+
+    /**
      * Adds batch tasks that are not regularly executed to projects, such as releases, integration, archiving.
      * Can be called multiple times to add more batch tasks.
      *

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/jobs/WorkflowJob.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/jobs/WorkflowJob.groovy
@@ -26,4 +26,12 @@ class WorkflowJob extends Job {
             project << context.definitionNode
         }
     }
+
+    @Deprecated
+    void concurrentBuild(boolean allowConcurrentBuild = true) {
+        configure { Node project ->
+            Node node = methodMissing('concurrentBuild', allowConcurrentBuild)
+            project / node
+        }
+    }
 }


### PR DESCRIPTION
## Problem

The `concurrentBuild` field was deprecated and replaced by [`DisableConcurrentBuildsJobProperty`](https://github.com/jenkinsci/workflow-job-plugin/blob/master/src/main/java/org/jenkinsci/plugins/workflow/job/properties/DisableConcurrentBuildsJobProperty.java) in jenkinsci/workflow-job-plugin#8, which was released in Pipeline: Job 2.4. Use of this deprecated field exposes [JENKINS-53775](https://issues.jenkins-ci.org/browse/JENKINS-53775).

## Solution

Encourage Job DSL users to move to the non-deprecated [`DisableConcurrentBuildsJobProperty`](https://github.com/jenkinsci/workflow-job-plugin/blob/master/src/main/java/org/jenkinsci/plugins/workflow/job/properties/DisableConcurrentBuildsJobProperty.java) (which avoids JENKINS-53775) by deprecating the `concurrentBuild` method in Pipeline jobs in Job DSL.

## Implementation

Moved the `concurrentBuild` method from `Job` (where it applies both to Pipeline and Freestyle jobs) to `Project` (where it applies only to Freestyle jobs) and `WorkflowJob` (where it applies only to Pipeline jobs). The version in `WorkflowJob` is marked deprecated and can be removed at some point in the future. The version in `Project` is not marked deprecated and will not be removed.

## Testing Done

- Used the new syntax to disable concurrent builds for a pipeline job and verified that the XML had  `DisableConcurrentBuildsJobProperty` as expected and that "Do not allow concurrent builds" was checked when I viewed the generated job in the Jenkins UI.
- Used the old syntax to disable concurrent builds for a pipeline job and verified that a deprecation warning was printed, the XML had `concurrentBuild` as expected, and "Do not allow concurrent builds" was checked when I viewed the generated job in the Jenkins UI.