### PR TITLE
JENKINS-29784: DSL Job View shows many copies of Generated Items

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedObjectsAction.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedObjectsAction.groovy
@@ -19,6 +19,9 @@ abstract class GeneratedObjectsAction<T, B extends GeneratedObjectsRunAction<T>>
 
     Set<T> findLastGeneratedObjects() {
         for (Run run = job.lastBuild; run != null; run = run.previousBuild) {
+            if (run.isBuilding()) {
+                continue
+            }
             B action = run.getAction(buildActionClass)
             if (action != null && action.modifiedObjects != null) {
                 return action.modifiedObjects

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedObjectsRunAction.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedObjectsRunAction.java
@@ -48,7 +48,11 @@ public abstract class GeneratedObjectsRunAction<T> implements RunAction2, Simple
     }
 
     public void addModifiedObjects(Collection<T> modifiedObjects) {
-        this.modifiedObjects.addAll(modifiedObjects);
+        if (this.modifiedObjects == null) {
+            this.modifiedObjects = new LinkedHashSet<>(modifiedObjects);
+        } else {
+            this.modifiedObjects.addAll(modifiedObjects);
+        }
     }
 
 }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedObjectsRunAction.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedObjectsRunAction.java
@@ -46,4 +46,9 @@ public abstract class GeneratedObjectsRunAction<T> implements RunAction2, Simple
     public Collection<T> getModifiedObjects() {
         return modifiedObjects == null ? null : new TreeSet<>(modifiedObjects);
     }
+
+    public void addModifiedObjects(Collection<T> modifiedObjects) {
+        this.modifiedObjects.addAll(modifiedObjects);
+    }
+
 }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedObjectsRunAction.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/actions/GeneratedObjectsRunAction.java
@@ -49,7 +49,7 @@ public abstract class GeneratedObjectsRunAction<T> implements RunAction2, Simple
 
     public void addModifiedObjects(Collection<T> modifiedObjects) {
         if (this.modifiedObjects == null) {
-            this.modifiedObjects = new LinkedHashSet<>(modifiedObjects);
+            throw new IllegalStateException("Modified object should not be null. Probably wrong state after serialization/deserialization");
         } else {
             this.modifiedObjects.addAll(modifiedObjects);
         }


### PR DESCRIPTION
This should fix JENKINS-44142 too.

Basically every job dsl build step creates a new build action with its generated items. Multiply build step creates the same amount of actions. But for comparing which items were generated during the build it use the first one which jenkins returns. So with settings RemovedJobAction.DELETE it always deletes actions which were not created by the particular step (even those which were created in the same build by previous job dsl build steps. 