### PR TITLE
Jenkins 58575 - Add Noop SVN Checkout Strategy

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/SvnCheckoutStrategy.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/SvnCheckoutStrategy.groovy
@@ -8,7 +8,7 @@ enum SvnCheckoutStrategy {
      * Do not touch the working copy, it is updated by another script.
      */
     NOOP('hudson.scm.subversion.NoopUpdater'),
-        
+
     /**
      * Use <code>svn update</code> whenever possible, making the build faster. But this causes the artifacts from the
      * previous build to remain when a new build starts.

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/SvnCheckoutStrategy.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/scm/SvnCheckoutStrategy.groovy
@@ -5,6 +5,11 @@ package javaposse.jobdsl.dsl.helpers.scm
  */
 enum SvnCheckoutStrategy {
     /**
+     * Do not touch the working copy, it is updated by another script.
+     */
+    NOOP('hudson.scm.subversion.NoopUpdater'),
+        
+    /**
      * Use <code>svn update</code> whenever possible, making the build faster. But this causes the artifacts from the
      * previous build to remain when a new build starts.
      */

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/ScmContextSpec.groovy
@@ -1417,6 +1417,7 @@ class ScmContextSpec extends Specification {
 
         where:
         strategy                               | workspaceUpdaterClass
+        SvnCheckoutStrategy.NOOP               | 'hudson.scm.subversion.NoopUpdater'
         SvnCheckoutStrategy.UPDATE             | 'hudson.scm.subversion.UpdateUpdater'
         SvnCheckoutStrategy.CHECKOUT           | 'hudson.scm.subversion.CheckoutUpdater'
         SvnCheckoutStrategy.UPDATE_WITH_CLEAN  | 'hudson.scm.subversion.UpdateWithCleanUpdater'


### PR DESCRIPTION
The subversion plugin has the option to leave the working copy untouched with the [NoopUpdater](https://github.com/jenkinsci/subversion-plugin/blob/master/src/main/java/hudson/scm/subversion/NoopUpdater.java).
These changes make this strategy also available for the DSL.