### PR TITLE
[JENKINS-59037] Allow passing values from casc yaml to job dsl.

### DIFF
--- a/docs/JCasC.md
+++ b/docs/JCasC.md
@@ -30,7 +30,7 @@ jobs:
   - url: https://raw.githubusercontent.com/jenkinsci/job-dsl-plugin/master/job-dsl-plugin/src/test/resources/javaposse/jobdsl/plugin/testjob.groovy
 ```
 
-you can reference multiple scripts, files, and urls
+You can reference multiple scripts, files, and urls
 
 ```yml
 jobs:
@@ -62,4 +62,20 @@ jobs:
 
   - file: ./jobdsl/job1.groovy
   - file: ./jobdsl/job2.groovy
+```
+
+You can pass values from the yaml file to the job dsl script
+
+```yml
+jobs:
+  - providedEnv:
+      SUPERHERO: 'Midnighter'
+  - file: ./jobdsl/job.groovy
+```
+
+```groovy
+//job.groovy
+job('awesome-job') {
+    description("favorite job of ${SUPERHERO}")
+}
 ```

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/SeedJobConfigurator.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/SeedJobConfigurator.java
@@ -10,7 +10,10 @@ import io.jenkins.plugins.casc.SecretSourceResolver;
 import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
-import java.util.Map;
+
+import java.util.*;
+import java.util.stream.Stream;
+
 import javaposse.jobdsl.dsl.GeneratedItems;
 import javaposse.jobdsl.plugin.JenkinsDslScriptLoader;
 import javaposse.jobdsl.plugin.JenkinsJobManagement;
@@ -20,9 +23,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import javax.annotation.CheckForNull;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 
 import static io.vavr.API.Try;
 import static io.vavr.API.unchecked;
@@ -59,9 +59,11 @@ public class SeedJobConfigurator implements RootElementConfigurator<GeneratedIte
     @Override
     @SuppressWarnings("unchecked")
     public GeneratedItems[] configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
-        JenkinsJobManagement management = new JenkinsJobManagement(System.out, System.getenv(), null, null, LookupStrategy.JENKINS_ROOT);
+        Map<String, String> env = new HashMap<>(System.getenv());
+        JenkinsJobManagement management = new JenkinsJobManagement(System.out, env, null, null, LookupStrategy.JENKINS_ROOT);
         Configurator<ScriptSource> configurator = context.lookupOrFail(ScriptSource.class);
         return config.asSequence().stream()
+            .flatMap(source -> processProvidedEnv(source, context, env))
             .map(source -> getActualValue(source, context))
             .map(source -> getScriptFromSource(source, context, configurator))
             .map(script -> generateFromScript(script, management))
@@ -83,6 +85,16 @@ public class SeedJobConfigurator implements RootElementConfigurator<GeneratedIte
     @Override
     public CNode describe(GeneratedItems[] instance, ConfigurationContext context) throws Exception {
         return null;
+    }
+
+    private Stream<CNode> processProvidedEnv(CNode source, ConfigurationContext context, Map<String, String> env) {
+        Map.Entry<String, CNode> entry = unchecked(() -> source.asMapping().entrySet().iterator().next()).apply();
+        if (entry.getKey().equals("providedEnv")) {
+            unchecked(entry.getValue()::asMapping).apply().entrySet().forEach(envEntry ->
+                env.put(envEntry.getKey(), revealSourceOrGetValue(envEntry, context)));
+            return Stream.empty();
+        }
+        return Stream.of(source);
     }
 
     private CNode getActualValue(CNode config, ConfigurationContext context) {

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/SeedJobConfigurator.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/casc/SeedJobConfigurator.java
@@ -10,9 +10,8 @@ import io.jenkins.plugins.casc.SecretSourceResolver;
 import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
-
-import java.util.*;
-import java.util.stream.Stream;
+import java.util.Map;
+import java.util.HashMap;
 
 import javaposse.jobdsl.dsl.GeneratedItems;
 import javaposse.jobdsl.plugin.JenkinsDslScriptLoader;
@@ -23,6 +22,10 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import javax.annotation.CheckForNull;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import static io.vavr.API.Try;
 import static io.vavr.API.unchecked;

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.java
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.java
@@ -17,5 +17,6 @@ public class ConfigurationAsCodeTest {
     public void configure_seed_job() {
         assertNotNull(j.jenkins.getItem("testJob1"));
         assertNotNull(j.jenkins.getItem("testJob2"));
+        assertNotNull(j.jenkins.getItem("testJob3"));
     }
 }

--- a/job-dsl-plugin/src/test/resources/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.yaml
+++ b/job-dsl-plugin/src/test/resources/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.yaml
@@ -13,3 +13,13 @@ jobs:
       }
 
   - file: ./src/test/resources/javaposse/jobdsl/plugin/testjob.groovy
+
+  - providedEnv:
+      JOB_NAME_FROM_ENV: testJob3
+
+  - script: >
+      job(JOB_NAME_FROM_ENV) {
+          steps {
+              shell('echo hello world')
+          }
+      }


### PR DESCRIPTION
An implementation of the improvement proposed in [JENKINS-59037](https://issues.jenkins-ci.org/browse/JENKINS-59037).