### PR TITLE
[INFRA-2243 ] - Switch CI to the new buildPluginWithGradle() step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,2 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+/* `buildPluginWithGradle` step provided by: https://github.com/jenkins-infra/pipeline-library */
+buildPluginWithGradle()


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/INFRA-2243
This change moves the plugin from the deprecated functionality to the new Pipeline Library step. There should be no differences in the behavior.
