### PR TITLE
JobDsl should respect Job post-construction initialization

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -515,6 +515,7 @@ public class JenkinsJobManagement extends AbstractJobManagement {
             String itemName = FilenameUtils.getName(path);
             if (parent instanceof ModifiableTopLevelItemGroup) {
                 Item project = ((ModifiableTopLevelItemGroup) parent).createProjectFromXML(itemName, is);
+                project.onCreatedFromScratch();
                 notifyItemCreated(project, dslItem);
             } else if (parent == null) {
                 throw new DslException(format(Messages.CreateItem_UnknownParent(), path));


### PR DESCRIPTION


Hello!
 
This is a fix for issue https://issues.jenkins-ci.org/browse/JENKINS-59402
 
**Problem**:
If we run the creation of job via jobDsl pipeline step (https://jenkins.io/doc/pipeline/steps/job-dsl/) with any parameters, we are getting a folder on our filesystem without "legacyIds" file in builds directory.
examples are in the bottom of this post.
The problem is that if there is no legacyIds file in builds directory, after restarting of jenkins server, we are facing long migrations for all jobs created after the previous reboot
 
 
**Examples**:
job created via jobDsl:

```
[root@server]# ls -lah builds/jobDsl_job
total 2.5K
drwxr-xr-x 1 centos centos 808K Sep 12 07:23 .
drwxr-xr-x 1 centos centos 3.1G Sep 12 07:21 ..
drwxr-xr-x 1 centos centos 808K Sep 12 07:23 1
lrwxrwxrwx 1 centos centos    2 Sep 12 07:19 lastFailedBuild -> -1
lrwxrwxrwx 1 centos centos    1 Sep 12 07:23 lastStableBuild -> 1
lrwxrwxrwx 1 centos centos    1 Sep 12 07:23 lastSuccessfulBuild -> 1
lrwxrwxrwx 1 centos centos    2 Sep 12 07:19 lastUnstableBuild -> -1
lrwxrwxrwx 1 centos centos    2 Sep 12 07:19 lastUnsuccessfulBuild -> -1

```
job created via manual creation:

```
[root@server]# ls -lah builds/manual_job
total 0
drwxr-xr-x 1 centos centos    0 Sep 12 07:21 .
drwxr-xr-x 1 centos centos 3.1G Sep 12 07:21 ..
-rw-r--r-- 1 centos centos    0 Sep 12 07:21 legacyIds
```

