### PR TITLE
fix folder-related bugs in createOrUpdateConfig

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -143,15 +143,19 @@ public class JenkinsJobManagement extends AbstractJobManagement {
         } else if (!ignoreExisting) {
             if (failOnSeedCollision) {
                 // fail if the item being created is already managed by another seed job
-                String seedJobName = project.getName();
+                String seedJobName = project.getFullName();
                 if (seedJobName != null) {
                     DescriptorImpl descriptor = Jenkins.get().getDescriptorByType(DescriptorImpl.class);
-                    SeedReference seedReference = descriptor.getGeneratedJobMap().get(jobName);
+                    String getpath = path;
+                    // generatedJobMap keys look like 'folder/job' instead of '/folder/job'
+                    if (getpath.charAt(0) == '/')
+                        getpath = getpath.substring(1);
+                    SeedReference seedReference = descriptor.getGeneratedJobMap().get(getpath);
                     if (seedReference != null) {
                         String existingSeedJobName = seedReference.getSeedJobName();
                         if (!seedJobName.equals(existingSeedJobName) &&
                                 Jenkins.get().getItemByFullName(existingSeedJobName) != null) {
-                            throw new DslException(format(Messages.CreateOrUpdateConfigFile_SeedCollision(), jobName, existingSeedJobName));
+                            throw new DslException(format(Messages.CreateOrUpdateConfigFile_SeedCollision(), jobName, existingSeedJobName, path, seedJobName));
                         }
                     }
                 }

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/Messages.properties
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/Messages.properties
@@ -7,7 +7,7 @@ ReadFileFromWorkspace.JobNotFound=\
 CreateOrUpdateConfigFile.PluginNotInstalled=\
   Could not create or update config file, Config File Provider plugin not installed
 CreateOrUpdateConfigFile.SeedCollision=\
-  Could not create item %s, item is already managed by seed job %s
+  Could not create item %s, item is already managed by seed job %s.\n path=%s\n seedJobName=%s
 CreateOrUpdateConfigFile.ConfigProviderNotFound=\
   Could not create or update config file, config provider for config file type "%s" not found
 CreateOrUpdateConfigFile.UnknownConfigFileType=\

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/JenkinsJobManagementSpec.groovy
@@ -536,7 +536,50 @@ class JenkinsJobManagementSpec extends Specification {
 
         then:
         Exception e = thrown(DslException)
-        e.message == 'Could not create item project, item is already managed by seed job seed'
+        e.message.startsWith 'Could not create item project, item is already managed by seed job seed'
+    }
+
+    def 'JENKINS-59995 seed in folder can update jobs in and out of folder'() {
+        Folder folder = jenkinsRule.jenkins.createProject(Folder, 'folder')
+        FreeStyleProject seedJob = folder.createProject(FreeStyleProject, 'seed')
+        seedJob.buildersList.add(new ExecuteDslScripts('job("/project")'))
+        seedJob.buildersList.add(new ExecuteDslScripts('job("/folder/project")'))
+        jenkinsRule.buildAndAssertSuccess(seedJob)
+        AbstractBuild build = seedJob.scheduleBuild2(0).get()
+        JobManagement jobManagement = new JenkinsJobManagement(
+                new PrintStream(buffer), [:], build, build.workspace, LookupStrategy.JENKINS_ROOT
+        )
+        jobManagement.failOnSeedCollision = true
+
+        when:
+        jobManagement.createOrUpdateConfig(createItem('/project', '/config.xml'), false)
+        jobManagement.createOrUpdateConfig(createItem('/folder/project', '/config.xml'), false)
+
+        then:
+        jenkinsRule.jenkins.getItemByFullName('/project') != null
+        jenkinsRule.jenkins.getItemByFullName('/folder/project') != null
+    }
+
+    def 'JENKINS-59995 two seeds should have collision on updating job in folder'() {
+        setup:
+        jenkinsRule.jenkins.createProject(Folder, 'folder')
+        FreeStyleProject seedJob = jenkinsRule.createFreeStyleProject('seed')
+        seedJob.buildersList.add(new ExecuteDslScripts('job("folder/project")'))
+        jenkinsRule.buildAndAssertSuccess(seedJob)
+
+        FreeStyleProject seedJob2 = jenkinsRule.createFreeStyleProject('seed2')
+        AbstractBuild build = seedJob2.scheduleBuild2(0).get()
+        JobManagement jobManagement = new JenkinsJobManagement(
+                new PrintStream(buffer), [:], build, build.workspace, LookupStrategy.JENKINS_ROOT
+        )
+        jobManagement.failOnSeedCollision = true
+
+        when:
+        jobManagement.createOrUpdateConfig(createItem('folder/project', '/config.xml'), false)
+
+        then:
+        Exception e = thrown(DslException)
+        e.message.startsWith 'Could not create item project, item is already managed by seed job seed'
     }
 
     def 'createOrUpdateConfig should pass if item is managed by another seed and failOnSeedCollision is disabled'() {


### PR DESCRIPTION
Fixes [JENKINS-59995](https://issues.jenkins-ci.org/browse/JENKINS-59995):

1) Processing DSL failed at creating top-level (not in folder) items, if the seed job itself was located inside a folder.
2) Two seed jobs could override each other's results when creating item inside folder

The error message format can be left the way it was, but the lack of additional info cost us quite a few attempts at understanding what was going on :)