### PR TITLE
JENKINS-41308 add possibility to set sandbox in activeChoiceParam script

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/BuildParametersContext/activeChoiceParam.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/BuildParametersContext/activeChoiceParam.groovy
@@ -5,8 +5,12 @@ job('example') {
             filterable()
             choiceType('SINGLE_SELECT')
             groovyScript {
-                script('["choice1", "choice2"]')
-                fallbackScript('"fallback choice"')
+                script('["choice1", "choice2"]') {
+                    sandbox(true)
+                }
+                fallbackScript('"fallback choice"') {
+                    sandbox()
+                }
             }
         }
     }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/AbstractActiveChoiceContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/AbstractActiveChoiceContext.groovy
@@ -23,9 +23,10 @@ abstract class AbstractActiveChoiceContext implements Context {
         ActiveChoiceGroovyScriptContext context = new ActiveChoiceGroovyScriptContext()
         executeInContext(closure, context)
 
-        script = new NodeBuilder().script(class: 'org.biouno.unochoice.model.GroovyScript') {
-            delegate.script(context.script ?: '')
-            delegate.fallbackScript(context.fallbackScript ?: '')
+        script = new NodeBuilder().script(class: 'org.biouno.unochoice.model.GroovyScript').with {
+            append(context.script)
+            append(context.fallbackScript)
+            it
         }
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/ActiveChoiceGroovyScriptContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/ActiveChoiceGroovyScriptContext.groovy
@@ -1,22 +1,50 @@
 package javaposse.jobdsl.dsl.helpers.parameter
 
 import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.DslContext
+
+import static javaposse.jobdsl.dsl.ContextHelper.executeInContext
 
 class ActiveChoiceGroovyScriptContext implements Context {
-    String script
-    String fallbackScript
+    Node script = new NodeBuilder().createNode('script', '')
+    Node fallbackScript = new NodeBuilder().createNode('fallbackScript', '')
 
     /**
      * Sets the script that will dynamically generate the parameter value options.
      */
-    void script(String script) {
-        this.script = script
+    void script(String script, @DslContext(ActiveChoiceSecureScriptContext) Closure closure = null) {
+        this.script = createNode('script', script, closure)
     }
 
     /**
      * Provides alternate parameter value options in case the main script fails.
      */
-    void fallbackScript(String fallbackScript) {
-        this.fallbackScript = fallbackScript
+    void fallbackScript(String fallbackScript, @DslContext(ActiveChoiceSecureScriptContext) Closure closure = null) {
+        this.fallbackScript = createNode('fallbackScript', fallbackScript, closure)
+    }
+
+    /**
+     * Creates a node to be attached to a Groovy script.
+     */
+    private Node createNode(String name, String script, Closure closure) {
+        if (!closure) {
+            return new NodeBuilder().createNode(name, script)
+        }
+
+        ActiveChoiceSecureScriptContext context = new ActiveChoiceSecureScriptContext()
+        executeInContext(closure, context)
+
+        new NodeBuilder().createNode(secureName(name)).with {
+            appendNode('script', script)
+            appendNode('sandbox', context.sandbox)
+            it
+        }
+    }
+
+    /*
+     * Appends 'secure' to parameter 'name' and makes it camelCase.
+     */
+    private String secureName(String name) {
+        "secure${name.capitalize()}"
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/ActiveChoiceSecureScriptContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/ActiveChoiceSecureScriptContext.groovy
@@ -1,0 +1,17 @@
+package javaposse.jobdsl.dsl.helpers.parameter
+
+import javaposse.jobdsl.dsl.Context
+
+class ActiveChoiceSecureScriptContext implements Context {
+    boolean sandbox
+
+    /**
+     * Sets the sandbox field for secure scripts.
+     * Defaults to {@code false}.
+     *
+     * @since 1.77
+     */
+    void sandbox(boolean sandbox = true) {
+        this.sandbox = sandbox
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -328,7 +328,10 @@ class BuildParametersContextSpec extends Specification {
 
     def 'base choiceParam usage'() {
         when:
-        context.choiceParam('myParameterName', ['option 1 (default)', 'option 2'], 'myChoiceParamDescription')
+        context.choiceParam('myParameterName', [
+            'option 1 (default)',
+            'option 2'
+        ], 'myChoiceParamDescription')
 
         then:
         context.buildParameterNodes != null
@@ -347,7 +350,11 @@ class BuildParametersContextSpec extends Specification {
 
     def 'simplified choiceParam usage'() {
         when:
-        context.choiceParam('myParameterName', ['option 1 (default)', 'option 2', 'option 3'])
+        context.choiceParam('myParameterName', [
+            'option 1 (default)',
+            'option 2',
+            'option 3'
+        ])
 
         then:
         context.buildParameterNodes != null
@@ -713,7 +720,7 @@ class BuildParametersContextSpec extends Specification {
             description[0].value() == 'myRunParamDescription'
             triggerIfResult[0].value() == 'multiSelectionDisallowed'
             nodeEligibility[0].attribute('class') ==
-                 'org.jvnet.jenkins.plugins.nodelabelparameter.node.IgnoreOfflineNodeEligibility'
+                    'org.jvnet.jenkins.plugins.nodelabelparameter.node.IgnoreOfflineNodeEligibility'
             allowMultiNodeSelection[0].value() == false
             triggerConcurrentBuilds[0].value() == false
             ignoreOfflineNodes[0].value() == false
@@ -1041,6 +1048,137 @@ class BuildParametersContextSpec extends Specification {
                 children().size() == 2
                 script.text() == 'x1'
                 fallbackScript.text() == 'x2'
+            }
+        }
+        1 * jobManagement.requireMinimumPluginVersion('uno-choice', '1.2')
+    }
+
+    def 'active choice param with all options and groovy script with sandbox'() {
+        when:
+        context.activeChoiceParam('activeChoiceGroovyParam') {
+            description('Active choice param test/groovy script')
+            filterable()
+            choiceType('MULTI_SELECT')
+            groovyScript {
+                script('x1') {
+                    sandbox(true)
+                }
+                fallbackScript('x2') {
+                    sandbox()
+                }
+            }
+        }
+
+        then:
+        with(context.buildParameterNodes['activeChoiceGroovyParam']) {
+            name() == 'org.biouno.unochoice.ChoiceParameter'
+            children().size() == 7
+            name.text() == 'activeChoiceGroovyParam'
+            description.text() == 'Active choice param test/groovy script'
+            randomName.text() =~ /choice-parameter-\d+/
+            visibleItemCount.text() == '1'
+            choiceType.text() == 'PT_MULTI_SELECT'
+            filterable.text() == 'true'
+            with(script[0]) {
+                attributes()['class'] == 'org.biouno.unochoice.model.GroovyScript'
+                children().size() == 2
+                with(secureScript) {
+                    children().size() == 2
+                    script.text() == 'x1'
+                    sandbox.text() == 'true'
+                }
+                with(secureFallbackScript) {
+                    children().size() == 2
+                    script.text() == 'x2'
+                    sandbox.text() == 'true'
+                }
+            }
+        }
+        1 * jobManagement.requireMinimumPluginVersion('uno-choice', '1.2')
+    }
+
+    def 'active choice param with all options and groovy script with empty closure'() {
+        when:
+        context.activeChoiceParam('activeChoiceGroovyParam') {
+            description('Active choice param test/groovy script')
+            filterable()
+            choiceType('MULTI_SELECT')
+            groovyScript {
+                script('x1') {
+                    sandbox(true)
+                }
+                fallbackScript('x2') {
+                }
+            }
+        }
+
+        then:
+        with(context.buildParameterNodes['activeChoiceGroovyParam']) {
+            name() == 'org.biouno.unochoice.ChoiceParameter'
+            children().size() == 7
+            name.text() == 'activeChoiceGroovyParam'
+            description.text() == 'Active choice param test/groovy script'
+            randomName.text() =~ /choice-parameter-\d+/
+            visibleItemCount.text() == '1'
+            choiceType.text() == 'PT_MULTI_SELECT'
+            filterable.text() == 'true'
+            with(script[0]) {
+                attributes()['class'] == 'org.biouno.unochoice.model.GroovyScript'
+                children().size() == 2
+                with(secureScript) {
+                    children().size() == 2
+                    script.text() == 'x1'
+                    sandbox.text() == 'true'
+                }
+                with(secureFallbackScript) {
+                    children().size() == 2
+                    script.text() == 'x2'
+                    sandbox.text() == 'false'
+                }
+            }
+        }
+        1 * jobManagement.requireMinimumPluginVersion('uno-choice', '1.2')
+    }
+
+    def 'active choice param with all options and groovy script with sandbox false'() {
+        when:
+        context.activeChoiceParam('activeChoiceGroovyParam') {
+            description('Active choice param test/groovy script')
+            filterable()
+            choiceType('MULTI_SELECT')
+            groovyScript {
+                script('x1') {
+                    sandbox(false)
+                }
+                fallbackScript('x2') {
+                    sandbox(true)
+                }
+            }
+        }
+
+        then:
+        with(context.buildParameterNodes['activeChoiceGroovyParam']) {
+            name() == 'org.biouno.unochoice.ChoiceParameter'
+            children().size() == 7
+            name.text() == 'activeChoiceGroovyParam'
+            description.text() == 'Active choice param test/groovy script'
+            randomName.text() =~ /choice-parameter-\d+/
+            visibleItemCount.text() == '1'
+            choiceType.text() == 'PT_MULTI_SELECT'
+            filterable.text() == 'true'
+            with(script[0]) {
+                attributes()['class'] == 'org.biouno.unochoice.model.GroovyScript'
+                children().size() == 2
+                with(secureScript) {
+                    children().size() == 2
+                    script.text() == 'x1'
+                    sandbox.text() == 'false'
+                }
+                with(secureFallbackScript) {
+                    children().size() == 2
+                    script.text() == 'x2'
+                    sandbox.text() == 'true'
+                }
             }
         }
         1 * jobManagement.requireMinimumPluginVersion('uno-choice', '1.2')


### PR DESCRIPTION
The ActiveChoiceParameter plugin already allows the setting of `scripts` and `fallbackScripts` to be run in a `sandbox` via the UI. With this commit, the ability to set sandboxing via the Job-DSL is introduced.

If the `sandbox` property is not present, it defaults to the old mechanism. In case an empty closure is added to either `script` or `fallbackScript`, sandboxing is also disabled. Only if `sandbox` is explicetly set to `true` or if the `sandbox` property is set without explicitly mentioning the state (e.g. `sandbox()`), sandboxing is enabled.

All previous tests and ways of functioning are unaffected by this chagne.