### PR TITLE
[WIP] - [JENKINS-51856] Bump dependencies to pick up the new milestones

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=1.77-SNAPSHOT
 groovyVersion=2.4.11
-jenkinsVersion=2.138
+jenkinsVersion=2.218-rc29200.f79828ffaafc
 assetPipelineVersion=2.11.6
 githubUser=jenkinsci

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=1.77-SNAPSHOT
 groovyVersion=2.4.11
-jenkinsVersion=2.218-20200205.101217-1
+jenkinsVersion=2.220
 assetPipelineVersion=2.11.6
 githubUser=jenkinsci

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=1.77-SNAPSHOT
 groovyVersion=2.4.11
-jenkinsVersion=2.218-rc29200.f79828ffaafc
+jenkinsVersion=2.218-20200205.101217-1
 assetPipelineVersion=2.11.6
 githubUser=jenkinsci

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -79,6 +79,14 @@ war {
     dependsOn tasks.getByPath(':job-dsl-api-viewer:build')
 }
 
+configurations {
+    // see JENKINS-45512
+    testCompile {
+        exclude group: 'xalan'
+        exclude group: 'xerces'
+    }
+}
+
 dependencies {
     annotationProcessor 'net.java.sezpoz:sezpoz:1.13'
     annotationProcessor 'org.jenkins-ci:annotation-indexer:1.12'
@@ -88,6 +96,8 @@ dependencies {
     compile(project(':job-dsl-core'))  {
         exclude group: 'org.jvnet.hudson', module:'xstream'
     }
+    testCompile 'io.jenkins.configuration-as-code:test-harness:1.36-20200205.084914-2'
+    testCompile 'io.jenkins.configuration-as-code:test-harness:1.36-20200205.084914-2:tests'
     jenkinsPlugins 'org.jenkins-ci.plugins:structs:1.19'
     jenkinsPlugins 'org.jenkins-ci.plugins:script-security:1.54'
     optionalJenkinsPlugins('org.jenkins-ci.plugins:vsphere-cloud:1.1.11') {
@@ -95,9 +105,9 @@ dependencies {
     }
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.15.4'
     optionalJenkinsPlugins 'org.jenkinsci.plugins:managed-scripts:1.3'
-    optionalJenkinsPlugins 'io.jenkins:configuration-as-code:1.15'
-    jenkinsTest 'io.jenkins:configuration-as-code:1.15'
-    jenkinsTest 'io.jenkins:configuration-as-code:1.15:tests'
+    optionalJenkinsPlugins 'io.jenkins:configuration-as-code:1.36-20200205.084856-2'
+    jenkinsTest 'io.jenkins:configuration-as-code:1.36-20200205.084856-2'
+    jenkinsTest 'io.jenkins:configuration-as-code:1.36-20200205.084856-2-tests'
     jenkinsTest 'org.jenkins-ci.plugins:cloudbees-folder:5.14'
     jenkinsTest 'org.jenkins-ci.plugins:matrix-auth:1.3'
     jenkinsTest 'org.jenkins-ci.plugins:nested-view:1.14'

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -98,6 +98,7 @@ dependencies {
     }
     testCompile 'io.jenkins.configuration-as-code:test-harness:1.36-20200205.084914-2'
     testCompile 'io.jenkins.configuration-as-code:test-harness:1.36-20200205.084914-2:tests'
+    testCompile 'org.jenkins-ci.main:jenkins-war:2.218-20200205.101234-1'
     jenkinsPlugins 'org.jenkins-ci.plugins:structs:1.19'
     jenkinsPlugins 'org.jenkins-ci.plugins:script-security:1.54'
     optionalJenkinsPlugins('org.jenkins-ci.plugins:vsphere-cloud:1.1.11') {
@@ -106,6 +107,7 @@ dependencies {
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.15.4'
     optionalJenkinsPlugins 'org.jenkinsci.plugins:managed-scripts:1.3'
     optionalJenkinsPlugins 'io.jenkins:configuration-as-code:1.36-20200205.084856-2'
+    jenkinsTest 'org.jenkins-ci.main:jenkins-war:2.218-20200205.101234-1'
     jenkinsTest 'io.jenkins:configuration-as-code:1.36-20200205.084856-2'
     jenkinsTest 'io.jenkins:configuration-as-code:1.36-20200205.084856-2-tests'
     jenkinsTest 'org.jenkins-ci.plugins:cloudbees-folder:5.14'

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -98,7 +98,6 @@ dependencies {
     }
     testCompile 'io.jenkins.configuration-as-code:test-harness:1.36-20200205.084914-2'
     testCompile 'io.jenkins.configuration-as-code:test-harness:1.36-20200205.084914-2:tests'
-    testCompile 'org.jenkins-ci.main:jenkins-war:2.218-20200205.101234-1'
     jenkinsPlugins 'org.jenkins-ci.plugins:structs:1.19'
     jenkinsPlugins 'org.jenkins-ci.plugins:script-security:1.54'
     optionalJenkinsPlugins('org.jenkins-ci.plugins:vsphere-cloud:1.1.11') {
@@ -107,7 +106,6 @@ dependencies {
     optionalJenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.15.4'
     optionalJenkinsPlugins 'org.jenkinsci.plugins:managed-scripts:1.3'
     optionalJenkinsPlugins 'io.jenkins:configuration-as-code:1.36-20200205.084856-2'
-    jenkinsTest 'org.jenkins-ci.main:jenkins-war:2.218-20200205.101234-1'
     jenkinsTest 'io.jenkins:configuration-as-code:1.36-20200205.084856-2'
     jenkinsTest 'io.jenkins:configuration-as-code:1.36-20200205.084856-2-tests'
     jenkinsTest 'org.jenkins-ci.plugins:cloudbees-folder:5.14'


### PR DESCRIPTION
### General context
See [JENKINS-51856](https://issues.jenkins-ci.org/browse/JENKINS-51856) and [issue 280](https://github.com/jenkinsci/configuration-as-code-plugin/issues/280)

Before fixing [issue 280](https://github.com/jenkinsci/configuration-as-code-plugin/issues/280), it's needed to add new milestones to Jenkins Core. This is tried in https://github.com/jenkinsci/jenkins/pull/4450. Its downstream PR https://github.com/jenkinsci/configuration-as-code-plugin/pull/1262 is the proposed fix for the race condition. In the initial PR, @casz commented a possible impact in this plugin.
This PR pretends to be a downstream PR of those ones showing how `job-dsl-plugin` would be updated and demonstrating there is no impact.

### What is expected
I've marked the PR as WI since it's a downstream PR. At this point, when I update the dependencies with the new core and the JCasC fix everything seems to be working fine. I've manually tested and found nothing. @casz @timja @oleg-nenashev any help/review here would be more than welcome

CC @daspilker 

### This PR includes
* Update of the baseline to the incremental from https://github.com/jenkinsci/jenkins/pull/4450
   * I don't know why, but I don't see the incremental version for all the artifacts generated for CasC, so I've deployed a SNAPSHOT version (old-school approach). Since it's just a temporary patch, I don't think it's a real issue for now.