### PR TITLE
Patched wiki file as per [JENKINS-59506] issue

### DIFF
--- a/docs/JCasC.md.orig
+++ b/docs/JCasC.md.orig
@@ -39,30 +39,30 @@ You can reference multiple scripts, files, and URLs.
 ```yml
 jobs:
   - script: >
-      job('testJob1') {
-          scm {
-              git('git://github.com/quidryan/aws-sdk-test.git')
-          }
-          triggers {
-              scm('H/15 * * * *')
-          }
-          steps {
-              maven('-e clean test')
-          }
-      }
+    job('testJob1') {
+        scm {
+            git('git://github.com/quidryan/aws-sdk-test.git')
+        }
+        triggers {
+            scm('H/15 * * * *')
+        }
+        steps {
+            maven('-e clean test')
+        }
+    }
 
   - script: >
-      job('testJob2') {
-          scm {
-              git('git://github.com/quidryan/aws-sdk-test.git')
-          }
-          triggers {
-              scm('H/15 * * * *')
-          }
-          steps {
-              maven('-e clean test')
-          }
-      }
+    job('testJob2') {
+        scm {
+            git('git://github.com/quidryan/aws-sdk-test.git')
+        }
+        triggers {
+            scm('H/15 * * * *')
+        }
+        steps {
+            maven('-e clean test')
+        }
+    }
 
   - file: ./jobdsl/job1.groovy
   - file: ./jobdsl/job2.groovy


### PR DESCRIPTION
Patched the wiki file in the job-dsl-plugin repo of jenkinsci as per the unresolved issue [here.](https://issues.jenkins-ci.org/browse/JENKINS-59506). I used `patch -p3 < diff.patch` command to fix the patch. 