### PR TITLE
feat: expose http timeout options

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/ParameterizedRemoteTriggerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/ParameterizedRemoteTriggerContext.groovy
@@ -11,6 +11,8 @@ class ParameterizedRemoteTriggerContext extends AbstractContext {
     boolean blockBuildUntilComplete = false
     String token
     String credentialsIds
+    int httpGetReadTimeout = 10000
+    int httpPostReadTimeout = 30000
 
     ParameterizedRemoteTriggerContext(JobManagement jobManagement) {
         super(jobManagement)
@@ -84,5 +86,23 @@ class ParameterizedRemoteTriggerContext extends AbstractContext {
      */
     void overrideCredentials(String credentialsIds) {
         this.credentialsIds = credentialsIds
+    }
+
+    /**
+     * HTTP GET read timeout (milliseconds)
+     *
+     * @since 1.78
+     */
+    void httpGetReadTimeout(int value) {
+        this.httpGetReadTimeout = value
+    }
+
+    /**
+     * HTTP POST read timeout (milliseconds)
+     *
+     * @since 1.78
+     */
+    void httpPostReadTimeout(int value) {
+        this.httpPostReadTimeout = value
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/step/StepContext.groovy
@@ -625,6 +625,8 @@ class StepContext extends AbstractExtensibleContext {
             loadParamsFromFile(false)
             parameterFile()
             queryString()
+            httpGetReadTimeout(context.httpGetReadTimeout)
+            httpPostReadTimeout(context.httpPostReadTimeout)
         }
     }
 


### PR DESCRIPTION
recently added in https://github.com/jenkinsci/parameterized-remote-trigger-plugin/pull/66/files

alternatively exposing the autogenerated DSL would solve this too, I'm not sure how to do it though