### PR TITLE
Enhance Build Parameters with "validatingStringParam" 

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -194,6 +194,28 @@ class BuildParametersContext extends AbstractExtensibleContext {
     }
 
     /**
+     * Defines a parameter is validated using a regular expression.
+     *
+     * @since 1.31
+     */
+    @RequiresPlugin(id = 'validating-string-parameter', minimumVersion = '2.4')
+    void validatingStringParam(String parameterName, String defaultValue = null, String regex = null, String failedValidationMessage = null, String description = null) {
+        Node definitionNode = new Node(null, 'hudson.plugins.validating_string_parameter.ValidatingStringParameterDefinition')
+        definitionNode.appendNode('name', parameterName)
+        definitionNode.appendNode('defaultValue', defaultValue)
+        if (regex != null) {
+            definitionNode.appendNode('regex', regex)
+        }
+        if (failedValidationMessage != null) {
+            definitionNode.appendNode('failedValidationMessage', failedValidationMessage)
+        }
+        if (description != null) {
+            definitionNode.appendNode('description', description)
+        }
+        buildParameterNodes[parameterName] = definitionNode
+    }
+
+    /**
      * Defines a parameter that allows select a Git tag (or revision number).
      *
      * @since 1.31

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -195,12 +195,12 @@ class BuildParametersContext extends AbstractExtensibleContext {
 
     /**
      * Defines a parameter is validated using a regular expression.
-     *
-     * @since 1.31
      */
     @RequiresPlugin(id = 'validating-string-parameter', minimumVersion = '2.4')
-    void validatingStringParam(String parameterName, String defaultValue = null, String regex = null, String failedValidationMessage = null, String description = null) {
-        Node definitionNode = new Node(null, 'hudson.plugins.validating_string_parameter.ValidatingStringParameterDefinition')
+    void validatingStringParam(String parameterName, String defaultValue = null, String regex = null,
+                               String failedValidationMessage = null, String description = null) {
+        Node definitionNode = new Node(null,
+                'hudson.plugins.validating_string_parameter.ValidatingStringParameterDefinition')
         definitionNode.appendNode('name', parameterName)
         definitionNode.appendNode('defaultValue', defaultValue)
         if (regex != null) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -194,7 +194,7 @@ class BuildParametersContext extends AbstractExtensibleContext {
     }
 
     /**
-     * Defines a parameter is validated using a regular expression.
+     * Defines a parameter that is validated using a regular expression.
      */
     @RequiresPlugin(id = 'validating-string-parameter', minimumVersion = '2.4')
     void validatingStringParam(String parameterName, String defaultValue = null, String regex = null,

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -595,12 +595,15 @@ class BuildParametersContextSpec extends Specification {
 
     def 'base validatingStringParam usage'() {
         when:
-        context.validatingStringParam('myParameterName', 'my default validatingStringParam value', 'regex', 'failedValidationMessage', 'myValidatingStringParameterDescription')
+        context.validatingStringParam('myParameterName',
+                'my default validatingStringParam value', 'regex',
+                'failedValidationMessage', 'myValidatingStringParameterDescription')
 
         then:
         context.buildParameterNodes != null
         context.buildParameterNodes.size() == 1
-        context.buildParameterNodes['myParameterName'].name() == 'hudson.plugins.validating_string_parameter.ValidatingStringParameterDefinition'
+        context.buildParameterNodes['myParameterName'].name() ==
+                'hudson.plugins.validating_string_parameter.ValidatingStringParameterDefinition'
         context.buildParameterNodes['myParameterName'].name.text() == 'myParameterName'
         context.buildParameterNodes['myParameterName'].defaultValue.text() == 'my default validatingStringParam value'
         context.buildParameterNodes['myParameterName'].regex.text() == 'regex'

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -593,6 +593,21 @@ class BuildParametersContextSpec extends Specification {
         thrown(DslScriptException)
     }
 
+    def 'base validatingStringParam usage'() {
+        when:
+        context.validatingStringParam('myParameterName', 'my default validatingStringParam value', 'regex', 'failedValidationMessage', 'myValidatingStringParameterDescription')
+
+        then:
+        context.buildParameterNodes != null
+        context.buildParameterNodes.size() == 1
+        context.buildParameterNodes['myParameterName'].name() == 'hudson.plugins.validating_string_parameter.ValidatingStringParameterDefinition'
+        context.buildParameterNodes['myParameterName'].name.text() == 'myParameterName'
+        context.buildParameterNodes['myParameterName'].defaultValue.text() == 'my default validatingStringParam value'
+        context.buildParameterNodes['myParameterName'].regex.text() == 'regex'
+        context.buildParameterNodes['myParameterName'].failedValidationMessage.text() == 'failedValidationMessage'
+        context.buildParameterNodes['myParameterName'].description.text() == 'myValidatingStringParameterDescription'
+    }
+
     def 'base textParam usage'() {
         when:
         context.textParam('myParameterName', 'my default textParam value', 'myTextParameterDescription')


### PR DESCRIPTION
# What

Allow using "validatingStringParam" in Job DSL.

Plugin: https://plugins.jenkins.io/validating-string-parameter/

# Example usage

```
job('validation-job') {
  parameters {
    validatingStringParam('VALIDATION_STRING', '123', '\\d+', '', '')
  }

  steps {
    shell('echo ${VALIDATION_STRING}')
  }
}
```