### PR TITLE
JENKINS-63056: Fix casing issue with unreferenced items

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedJob.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/GeneratedJob.groovy
@@ -14,7 +14,7 @@ class GeneratedJob implements Comparable<GeneratedJob> {
 
     @Override
     int hashCode() {
-        jobName.hashCode()
+        jobName.toLowerCase().hashCode()
     }
 
     @Override
@@ -27,7 +27,7 @@ class GeneratedJob implements Comparable<GeneratedJob> {
         }
 
         GeneratedJob that = (GeneratedJob) o
-        jobName == that.jobName
+        jobName.toLowerCase() == that.jobName.toLowerCase()
     }
 
     @Override
@@ -37,6 +37,6 @@ class GeneratedJob implements Comparable<GeneratedJob> {
 
     @Override
     int compareTo(GeneratedJob o) {
-        jobName <=> o.jobName
+        jobName.toLowerCase() <=> o.jobName.toLowerCase()
     }
 }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
@@ -60,10 +60,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import static hudson.Util.fixEmptyAndTrim;
 import static java.lang.String.format;
@@ -445,19 +447,29 @@ public class ExecuteDslScripts extends Builder implements SimpleBuildStep {
         return freshTemplates;
     }
 
+    private Set<GeneratedJob> getUnreferencedJobs(Set<GeneratedJob> generatedJobs, Set<GeneratedJob> freshJobs) {
+        Set<GeneratedJob> unreferenced = new HashSet<>();
+        List<String> normalizedJobNames = freshJobs.stream().map(freshJob -> freshJob.getJobName().toLowerCase())
+                .collect(Collectors.toList());
+
+        Set<GeneratedJob> generatedJobsDiff = Sets.difference(generatedJobs, freshJobs);
+        for (GeneratedJob generatedJob : generatedJobsDiff) {
+            if (!normalizedJobNames.contains(generatedJob.getJobName().toLowerCase())) {
+                unreferenced.add(generatedJob);
+            }
+        }
+        return unreferenced;
+    }
+
     private void updateGeneratedJobs(final Job seedJob, TaskListener listener,
                                      Set<GeneratedJob> freshJobs) throws IOException, InterruptedException {
         // Update Project
         Set<GeneratedJob> generatedJobs = extractGeneratedObjects(seedJob, GeneratedJobsAction.class);
         Set<GeneratedJob> added = Sets.difference(freshJobs, generatedJobs);
         Set<GeneratedJob> existing = Sets.intersection(generatedJobs, freshJobs);
-        Set<GeneratedJob> unreferenced = Sets.difference(generatedJobs, freshJobs);
+        Set<GeneratedJob> unreferenced = getUnreferencedJobs(generatedJobs, freshJobs);
         Set<GeneratedJob> removed = new HashSet<>();
         Set<GeneratedJob> disabled = new HashSet<>();
-
-        logItems(listener, "Added items", added);
-        logItems(listener, "Existing items", existing);
-        logItems(listener, "Unreferenced items", unreferenced);
 
         // Update unreferenced jobs
         for (GeneratedJob unreferencedJob : unreferenced) {
@@ -477,7 +489,9 @@ public class ExecuteDslScripts extends Builder implements SimpleBuildStep {
             }
         }
 
-        // print what happened with unreferenced jobs
+        logItems(listener, "Added items", added);
+        logItems(listener, "Existing items", existing);
+        logItems(listener, "Unreferenced items", unreferenced);
         logItems(listener, "Disabled items", disabled);
         logItems(listener, "Removed items", removed);
 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-63056

Fixes an issue where removing the last folder of a specific casing will remove all jobs and history of that folder when the unreferenced action is marked to `DELETE`. This will actually just not add the item to the unreferenced list if it's still referenced under a different name.

Easiest way to reproduce this issue is to run the new test without the implementation, otherwise the information in the jira ticket above should have everything.