### PR TITLE
Fix typo in `removedJobAction` documentation

### DIFF
--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-removedJobAction.html
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-removedJobAction.html
@@ -4,7 +4,7 @@
     <p>
         <b>Note:</b> when using multiple Job DSL build steps in a single job, set this to "Delete" or "Disable" only for
         the last Job DSL build step. Otherwise jobs will be deleted and re-created or disabled and re-enabled and you
-        may loose the job history of generated jobs. See
+        may lose the job history of generated jobs. See
         <a href="https://issues.jenkins-ci.org/browse/JENKINS-44142">JENKINS-44142</a> for details.
     </p>
 </div>


### PR DESCRIPTION
In the `removedJobAction` documentation, this should read 'lose', not 'loose'.