### PR TITLE
Fix: Don't destroy credentials when re-creating folders

### DIFF
--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -89,6 +89,7 @@ dependencies {
     compile(project(':job-dsl-core'))  {
         exclude group: 'org.jvnet.hudson', module:'xstream'
     }
+    jenkinsPlugins 'org.jenkins-ci.plugins:cloudbees-folder:5.14'
     jenkinsPlugins 'org.jenkins-ci.plugins:structs:1.19'
     jenkinsPlugins 'org.jenkins-ci.plugins:script-security:1.54'
     optionalJenkinsPlugins('org.jenkins-ci.plugins:vsphere-cloud:1.1.11') {
@@ -99,7 +100,6 @@ dependencies {
     optionalJenkinsPlugins 'io.jenkins:configuration-as-code:1.15'
     jenkinsTest 'io.jenkins:configuration-as-code:1.15'
     jenkinsTest 'io.jenkins:configuration-as-code:1.15:tests'
-    jenkinsTest 'org.jenkins-ci.plugins:cloudbees-folder:5.14'
     jenkinsTest 'org.jenkins-ci.plugins:matrix-auth:1.3'
     jenkinsTest 'org.jenkins-ci.plugins:nested-view:1.14'
     jenkinsTest 'org.jenkins-ci.plugins:credentials:2.1.10'

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/DslItemConfigurer.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/DslItemConfigurer.groovy
@@ -1,0 +1,21 @@
+package javaposse.jobdsl.plugin
+
+import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty
+import hudson.model.Items
+import javaposse.jobdsl.dsl.Item
+
+class DslItemConfigurer {
+    private static final String XML_HEADER = "<?xml version='1.1' encoding='UTF-8'?>"
+
+    /**
+     * Merge an {@link AbstractFolderProperty} into a new {@link Item}'s properties.
+     *
+     * @param item the property to merge
+     * @param dslItem the DSL item to merge the properties into
+     */
+    static void mergeCredentials(AbstractFolderProperty<?> property, Item dslItem) {
+        String xml = Items.XSTREAM2.toXML(property)
+        Node node = new XmlParser().parseText(XML_HEADER + xml)
+        dslItem.configure { p -> p / 'properties' << node }
+    }
+}

--- a/job-dsl-plugin/src/test/resources/folder.xml
+++ b/job-dsl-plugin/src/test/resources/folder.xml
@@ -1,0 +1,2 @@
+<com.cloudbees.hudson.plugins.folder.Folder>
+</com.cloudbees.hudson.plugins.folder.Folder>


### PR DESCRIPTION
As noted in JENKINS-44681, any credentials on folders are lost when
re-creating folders, as we don't merge the existing credentials with the
newly created folder.

To do this, we need to find any instances of
`FolderCredentialsProvider.FolderCredentialsProperty` in the `Folder`'s
and if present, merge the credentials.

We need to promote our dependency on `cloudbees-folder` to a runtime
dependency, as we now need to reference the `Folder` and any
`FolderCredentialsProperty`s.

Note that in `JenkinsJobManagementSpec`, we need to use
`getNodeTemplate` to ensure that the real implementation of `getXml` is
called, which will execute the `configuredBlocks`.

Because we need to call to the `configure` method, we need to call out
to a new Groovy file, `DslItemConfigurer`, which processes the new
`AbstractFolderProperty` and converts it to the correct XML
representation. When parsing it, we need to make sure we add a valid XML
header, otherwise `XmlParser` will reject it.

Closes JENKINS-44681.

---

Although this repo isn't participating in Hacktoberfest, I thought I'd contribute it over this month, as I'm a huge fan of the plugin, but have been bitten by this in the past!

This has been tested both under local tests, and as a manual test running against a Jenkins Docker image running `Jenkins 2.249.1`