### PR TITLE
Add issuesTotalColumn() for warnings-ng

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
@@ -283,6 +283,19 @@ class ColumnsContext extends AbstractExtensibleContext {
         columnNodes << new Node(null, 'jenkins.plugins.extracolumns.SCMTypeColumn')
     }
 
+    /**
+     * Adds a column showing issues that are in the project.
+     *
+     * @since 1.78
+     */
+    @RequiresPlugin(id = 'warnings-ng')
+    void issuesTotalColumn(String name = '# Issues', String type = 'TOTAL') {
+        columnNodes << new Node(null, 'io.jenkins.plugins.analysis.core.columns.IssuesTotalColumn') {
+            name(name)
+            type(type)
+        }
+    }
+
     @Override
     protected void addExtensionNode(Node node) {
         columnNodes << node

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/ListViewSpec.groovy
@@ -769,6 +769,20 @@ class ListViewSpec<T extends ListView> extends Specification {
         1 * jobManagement.requireMinimumPluginVersion('next-executions', '1.0.12')
     }
 
+    def 'issues total column'() {
+        when:
+        view.columns {
+            issuesTotalColumn()
+        }
+
+        then:
+        Node root = view.node
+        root.columns.size() == 1
+        root.columns[0].value().size() == 1
+        root.columns[0].value()[0].name() == 'io.jenkins.plugins.analysis.core.columns.IssuesTotalColumn'
+        1 * jobManagement.requireMinimumPluginVersion('warnings-ng', '1.0.0')
+    }
+
     protected String getDefaultXml() {
         '''<?xml version='1.0' encoding='UTF-8'?>
 <hudson.model.ListView>


### PR DESCRIPTION
So this;
```
listView('releases') {
	...
	columns {
		...
	}
	configure { view ->
		view / columns << 'io.jenkins.plugins.analysis.core.columns.IssuesTotalColumn' {
			name('# Issues')
			type('TOTAL')
		}
	}
}
```

Can change to this;
```
listView('releases') {
	...
	columns {
		...
		issuesTotalColumn()
	}
}
```