### PR TITLE
JENKINS-67594: support for item generation next to parent directory

### DIFF
--- a/docs/Job-DSL-Commands.md
+++ b/docs/Job-DSL-Commands.md
@@ -11,7 +11,8 @@ job('my-job')
 ```
 
 When defining jobs, views or folders the name is treated as absolute to the Jenkins root by default, but the seed job
-can be configured to interpret names relative to the seed job. (since 1.24)
+can be configured to interpret names relative to the seed job (since 1.24), or relative to the seed job's parent folder
+(since 1.79).
 
 In the closure provided to the job methods there are a few top level methods, like `label` and `description`. Others are nested
 deeper in blocks which represent their role in Jenkins, e.g. the `publishers` block contains all the publisher actions.

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/LookupStrategy.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/LookupStrategy.java
@@ -22,7 +22,21 @@ public enum LookupStrategy {
      * Using this naming strategy jobs with relative path names are created relative
      * to the seed job's parent folder.
      */
-    SEED_JOB("Seed Job", Item::getParent);
+    SEED_JOB("Seed Job", Item::getParent),
+
+    /**
+     * Using this naming strategy jobs with relative path names are created relative
+     * to the seed job's grandparent folder. This is most useful if you group several
+     * seed jobs together in a folder (e.g. called "seed-jobs") and the jobs shall be generated
+     * as siblings to that ("seed-jobs") folder.
+     */
+    SEED_JOB_PARENT("Seed Job Parent", (seedJob) -> {
+        ItemGroup<?> parent = seedJob.getParent();
+        if (parent instanceof Item) {
+            return ((Item) parent).getParent();
+        }
+        return Jenkins.get();
+    });
 
     LookupStrategy(String displayName, Function<Item, ItemGroup> context) {
         this.displayName = displayName;

--- a/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-lookupStrategy.html
+++ b/job-dsl-plugin/src/main/resources/javaposse/jobdsl/plugin/ExecuteDslScripts/help-lookupStrategy.html
@@ -15,5 +15,13 @@
             <em>subfolder2/job</em>. The job that is created by the seed job will be at the location
             <em>/seedJobFolder/subfolder2/job</em>.
         </li>
+        <li>
+            <b>Seed Job Parent</b>
+            If you choose this option relative job names in DSL scripts will be
+            interpreted relative to the parent folder in which the seed job is nested. Suppose you have multiple seed jobs which are
+            located in a folder named <em>/project/seedJobFolder</em> and a DSL script which creates a job named
+            <em>subfolder2/job</em>. The job that is created by the seed job will be at the location
+            <em>/project/subfolder2/job</em>.
+        </li>
     </ul>
 </div>

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/DescriptorImplSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/DescriptorImplSpec.groovy
@@ -14,10 +14,12 @@ class DescriptorImplSpec extends Specification {
         ListBoxModel listBoxModel = new DescriptorImpl().doFillLookupStrategyItems()
 
         then:
-        listBoxModel.size() == 2
+        listBoxModel.size() == 3
         listBoxModel.get(0).name == 'Jenkins Root'
         listBoxModel.get(0).value == 'JENKINS_ROOT'
         listBoxModel.get(1).name == 'Seed Job'
         listBoxModel.get(1).value == 'SEED_JOB'
+        listBoxModel.get(2).name == 'Seed Job Parent'
+        listBoxModel.get(2).value == 'SEED_JOB_PARENT'
     }
 }

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/LookupStrategySpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/LookupStrategySpec.groovy
@@ -13,6 +13,7 @@ import spock.lang.Unroll
 
 import static javaposse.jobdsl.plugin.LookupStrategy.JENKINS_ROOT
 import static javaposse.jobdsl.plugin.LookupStrategy.SEED_JOB
+import static javaposse.jobdsl.plugin.LookupStrategy.SEED_JOB_PARENT
 
 class LookupStrategySpec extends Specification {
     @Shared
@@ -43,9 +44,10 @@ class LookupStrategySpec extends Specification {
         name == expectedName
 
         where:
-        lookupStrategy | expectedName
-        JENKINS_ROOT   | 'Jenkins Root'
-        SEED_JOB       | 'Seed Job'
+        lookupStrategy  | expectedName
+        JENKINS_ROOT    | 'Jenkins Root'
+        SEED_JOB        | 'Seed Job'
+        SEED_JOB_PARENT | 'Seed Job Parent'
     }
 
     def 'getItem'(LookupStrategy lookupStrategy, String expectedFullName) {
@@ -56,9 +58,10 @@ class LookupStrategySpec extends Specification {
         result.fullName == expectedFullName
 
         where:
-        lookupStrategy | expectedFullName
-        JENKINS_ROOT   | 'job'
-        SEED_JOB       | 'folder/job'
+        lookupStrategy  | expectedFullName
+        JENKINS_ROOT    | 'job'
+        SEED_JOB        | 'folder/job'
+        SEED_JOB_PARENT | 'job'
     }
 
     def 'getItem not normalized'(LookupStrategy lookupStrategy, String expectedFullName) {
@@ -69,9 +72,10 @@ class LookupStrategySpec extends Specification {
         result?.fullName == expectedFullName
 
         where:
-        lookupStrategy | expectedFullName
-        JENKINS_ROOT   | null
-        SEED_JOB       | 'job'
+        lookupStrategy  | expectedFullName
+        JENKINS_ROOT    | null
+        SEED_JOB        | 'job'
+        SEED_JOB_PARENT | null
     }
 
     def 'getContext'(LookupStrategy lookupStrategy, String expectedFullName) {
@@ -82,9 +86,10 @@ class LookupStrategySpec extends Specification {
         result.fullName == expectedFullName
 
         where:
-        lookupStrategy | expectedFullName
-        JENKINS_ROOT   | ''
-        SEED_JOB       | 'folder'
+        lookupStrategy  | expectedFullName
+        JENKINS_ROOT    | ''
+        SEED_JOB        | 'folder'
+        SEED_JOB_PARENT | ''
     }
 
     @Unroll
@@ -96,15 +101,19 @@ class LookupStrategySpec extends Specification {
         result.fullName == expectedFullName
 
         where:
-        lookupStrategy | path          | expectedFullName
-        JENKINS_ROOT   | 'job'         | ''
-        SEED_JOB       | 'job'         | 'folder'
-        JENKINS_ROOT   | '/job'        | ''
-        SEED_JOB       | '/job'        | ''
-        JENKINS_ROOT   | 'folder/job'  | 'folder'
-        SEED_JOB       | 'folder/job'  | 'folder/folder'
-        JENKINS_ROOT   | '/folder/foo' | 'folder'
-        SEED_JOB       | '/folder/foo' | 'folder'
+        lookupStrategy  | path          | expectedFullName
+        JENKINS_ROOT    | 'job'         | ''
+        SEED_JOB        | 'job'         | 'folder'
+        SEED_JOB_PARENT | 'job'         | ''
+        JENKINS_ROOT    | '/job'        | ''
+        SEED_JOB        | '/job'        | ''
+        SEED_JOB_PARENT | '/job'        | ''
+        JENKINS_ROOT    | 'folder/job'  | 'folder'
+        SEED_JOB        | 'folder/job'  | 'folder/folder'
+        SEED_JOB_PARENT | 'folder/job'  | 'folder'
+        JENKINS_ROOT    | '/folder/foo' | 'folder'
+        SEED_JOB        | '/folder/foo' | 'folder'
+        SEED_JOB_PARENT | '/folder/foo' | 'folder'
     }
 
     @Unroll
@@ -116,14 +125,18 @@ class LookupStrategySpec extends Specification {
         result?.fullName == expected
 
         where:
-        strategy     | path                          | expected
-        JENKINS_ROOT | '../folder/job'               | null
-        SEED_JOB     | '../folder/job'               | 'folder'
-        JENKINS_ROOT | '/folder/../job'              | ''
-        SEED_JOB     | '/folder/../job'              | ''
-        JENKINS_ROOT | 'folder/../job'               | ''
-        SEED_JOB     | 'folder/../job'               | 'folder'
-        JENKINS_ROOT | 'folder/with space/../../job' | ''
-        SEED_JOB     | 'folder/with space/../../job' | 'folder'
+        strategy        | path                          | expected
+        JENKINS_ROOT    | '../folder/job'               | null
+        SEED_JOB        | '../folder/job'               | 'folder'
+        SEED_JOB_PARENT | '../folder/job'               | null
+        JENKINS_ROOT    | '/folder/../job'              | ''
+        SEED_JOB        | '/folder/../job'              | ''
+        SEED_JOB_PARENT | '/folder/../job'              | ''
+        JENKINS_ROOT    | 'folder/../job'               | ''
+        SEED_JOB        | 'folder/../job'               | 'folder'
+        SEED_JOB_PARENT | 'folder/../job'               | ''
+        JENKINS_ROOT    | 'folder/with space/../../job' | ''
+        SEED_JOB        | 'folder/with space/../../job' | 'folder'
+        SEED_JOB_PARENT | 'folder/with space/../../job' | ''
     }
 }


### PR DESCRIPTION
If you group several/many seed jobs together in a folder, you may want to get the items generated not next to their seed job, but next to their folder.

I.e. you would not clutter the project folders with all the seed jobs.

```
/projectA/foo/...
/projectA/bar/...
/projectA/seed-jobs/foo-seed
/projectA/seed-jobs/bar-seed
/projectB/baz
/projectB/seed-jobs/baz-seed
```

instead of

```
/projectA/foo/...
/projectA/foo-seed
/projectA/bar/...
/projectA/bar-seed
/projectB/baz
/projectB/baz-seed
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

