### PR TITLE
Fix: Don't destroy credentials when re-creating organization folder

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=1.79-SNAPSHOT
 groovyVersion=2.4.12
-jenkinsVersion=2.176
+jenkinsVersion=2.264
 assetPipelineVersion=2.11.6
 githubUser=jenkinsci
 org.gradle.parallel=true

--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -110,18 +110,20 @@ dependencies {
         exclude group: 'org.jvnet.hudson', module:'xstream'
     }
     implementation 'org.jenkins-ci.plugins:cloudbees-folder:5.14'
+    implementation 'org.jenkins-ci.plugins:branch-api:2.6.3'
     implementation 'org.jenkins-ci.plugins:structs:1.19'
+    implementation 'org.jenkins-ci.plugins:scm-api:2.3.0'
     implementation 'org.jenkins-ci.plugins:script-security:1.54'
     vsphereCloudImplementation('org.jenkins-ci.plugins:vsphere-cloud:1.1.11') {
         exclude group: 'dom4j'
     }
     configFileProviderImplementation 'org.jenkins-ci.plugins:config-file-provider:2.15.4'
     managedScriptsImplementation 'org.jenkinsci.plugins:managed-scripts:1.3'
-    configurationAsCodeImplementation 'io.jenkins:configuration-as-code:1.15'
+    configurationAsCodeImplementation 'io.jenkins:configuration-as-code:1.35'
     testRuntimeOnly "org.jenkins-ci.main:jenkins-war:${project.properties['jenkinsVersion']}"
-    testImplementation 'io.jenkins:configuration-as-code:1.15'
-    testImplementation 'io.jenkins:configuration-as-code:1.15:tests'
+    testImplementation 'io.jenkins:configuration-as-code:1.35'
+    testImplementation 'io.jenkins.configuration-as-code:test-harness:1.35'
     testImplementation 'org.jenkins-ci.plugins:matrix-auth:1.3'
     testImplementation 'org.jenkins-ci.plugins:nested-view:1.14'
-    testImplementation 'org.jenkins-ci.plugins:credentials:2.1.10'
+    testImplementation 'org.jenkins-ci.plugins:credentials:2.3.11'
 }

--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -39,6 +39,7 @@ import javaposse.jobdsl.dsl.JobConfigurationNotFoundException;
 import javaposse.jobdsl.dsl.NameNotProvidedException;
 import javaposse.jobdsl.dsl.UserContent;
 import javaposse.jobdsl.plugin.ExtensionPointHelper.DslExtension;
+import jenkins.branch.OrganizationFolder;
 import jenkins.model.DirectlyModifiableTopLevelItemGroup;
 import jenkins.model.Jenkins;
 import jenkins.model.ModifiableTopLevelItemGroup;
@@ -587,17 +588,24 @@ public class JenkinsJobManagement extends AbstractJobManagement {
     }
 
     private void mergeCredentials(AbstractItem item, javaposse.jobdsl.dsl.Item dslItem) {
+        Optional<AbstractFolderProperty<?>> maybeProperty = Optional.empty();
         if (item instanceof Folder) {
             Folder folder = (Folder) item;
-            Optional<AbstractFolderProperty<?>> maybeProperty =
+            maybeProperty =
                 folder.getProperties().stream()
                 .filter(p -> p instanceof FolderCredentialsProperty)
                 .findFirst();
-
-            if (maybeProperty.isPresent()) {
-                LOGGER.log(Level.FINE, format("Merging credentials for %s", item.getName()));
-                DslItemConfigurer.mergeCredentials(maybeProperty.get(), dslItem);
-            }
+        }
+        if (item instanceof OrganizationFolder) {
+            OrganizationFolder folder = (OrganizationFolder) item;
+            maybeProperty =
+                folder.getProperties().stream()
+                .filter(p -> p instanceof FolderCredentialsProperty)
+                .findFirst();
+        }
+        if (maybeProperty.isPresent()) {
+            LOGGER.log(Level.FINE, format("Merging credentials for %s", item.getName()));
+            DslItemConfigurer.mergeCredentials(maybeProperty.get(), dslItem);
         }
     }
 


### PR DESCRIPTION
Extend the current code which does it for cloudbee Folder to Organization Folder.

refs JENKINS-44681
Previous fix for cloudbee Folder: https://github.com/jenkinsci/job-dsl-plugin/pull/1232