### PR TITLE
Bump minimum Jenkins version to v2.332.3

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -30,7 +30,7 @@ jobs:
           git config --global user.name "wiki[bot]"
 
           cd wiki
-          cp ../docs/* -r .
+          cp ../repo/docs/* -r .
           git add .
           git commit -m "Automagic update"
           git push

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -32,6 +32,9 @@ scripts, including [[tests for DSL scripts|Testing DSL Scripts]] and [[IDE Suppo
 Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins-ci.org/issues/?filter=15140).
 
 ## Release Notes
+* 1.82.0 (unreleased)
+  * Internal dependency management updates
+  * Fix concurrent modification exception in ExecuteDslScripts ([GH-1253](https://github.com/jenkinsci/job-dsl-plugin/pull/1253) [JENKINS-69064](https://issues.jenkins.io/browse/JENKINS-69064)).
 * 1.81.0 (July 18 2022)
   * Add missing options for Parameterized Remote Trigger Plugin ([GH-1250](https://github.com/jenkinsci/job-dsl-plugin/pull/1250) [JENKINS-68781](https://issues.jenkins.io/browse/JENKINS-68781)).
 * 1.80.0 (July 1 2022)

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -33,6 +33,7 @@ Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins
 
 ## Release Notes
 * 1.82.0 (unreleased)
+  * Bump minimum Jenkins version to 2.332.3 TODTODTODTODTODOOOOOTODO ([JENKINS-68275](https://issues.jenkins.io/browse/JENKINS-68275))
   * Internal dependency management updates
   * Fix concurrent modification exception in ExecuteDslScripts ([GH-1253](https://github.com/jenkinsci/job-dsl-plugin/pull/1253) [JENKINS-69064](https://issues.jenkins.io/browse/JENKINS-69064)).
 * 1.81.0 (July 18 2022)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=1.82-SNAPSHOT
 groovyVersion=2.4.12
-jenkinsVersion=2.200
+jenkinsVersion=2.332.4
 jenkinsPluginBomVersion=4.47
 assetPipelineVersion=2.11.6
 githubUser=jenkinsci

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=1.82-SNAPSHOT
 groovyVersion=2.4.12
-jenkinsVersion=2.240
+jenkinsVersion=2.200
 jenkinsPluginBomVersion=4.47
 assetPipelineVersion=2.11.6
 githubUser=jenkinsci

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version=1.82-SNAPSHOT
 groovyVersion=2.4.12
-jenkinsVersion=2.176
-jenkinsPluginBomVersion=3.57
+jenkinsVersion=2.346.3
+jenkinsPluginBomVersion=4.47
 assetPipelineVersion=2.11.6
 githubUser=jenkinsci
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=1.82-SNAPSHOT
 groovyVersion=2.4.12
-jenkinsVersion=2.200.0
+jenkinsVersion=2.240
 jenkinsPluginBomVersion=4.47
 assetPipelineVersion=2.11.6
 githubUser=jenkinsci

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=1.82-SNAPSHOT
 groovyVersion=2.4.12
-jenkinsVersion=2.346.3
+jenkinsVersion=2.200.0
 jenkinsPluginBomVersion=4.47
 assetPipelineVersion=2.11.6
 githubUser=jenkinsci


### PR DESCRIPTION
- Bump minimum Jenkins version to v2.332.3
- Add release notes
