### PR TITLE
Fix concurrent modification exception in ExecuteDslScripts

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/ExecuteDslScripts.java
@@ -409,7 +409,7 @@ public class ExecuteDslScripts extends Builder implements SimpleBuildStep {
             Collection<SeedReference> seedJobReferences = descriptor.getTemplateJobMap().get(templateName);
             Collection<SeedReference> matching = Collections2.filter(seedJobReferences, new SeedNamePredicate(seedJobName));
             if (!matching.isEmpty()) {
-                seedJobReferences.removeAll(matching);
+                seedJobReferences.removeAll(Sets.newHashSet(matching));
                 descriptorMutated = true;
             }
         }
@@ -432,7 +432,7 @@ public class ExecuteDslScripts extends Builder implements SimpleBuildStep {
             } else {
                 if (matching.size() > 1) {
                     // Not sure how there could be more one, throw it all away and start over
-                    seedJobReferences.removeAll(matching);
+                    seedJobReferences.removeAll(Sets.newHashSet(matching));
                 }
                 seedJobReferences.add(new SeedReference(templateName, seedJobName, digest));
                 descriptorMutated = true;

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ExecuteDslScriptsSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ExecuteDslScriptsSpec.groovy
@@ -784,7 +784,7 @@ folder('folder-a/folder-b') {
         jenkinsRule.instance.getDescriptorByType(DescriptorImpl).generatedJobMap.size() == 0
     }
 
-    def "Deleted jobs with different seeds but same templates are removed from GeneratedJobMap"() {
+    def "JENKINS-69064 Deleted jobs with different seeds but same templates are removed from GeneratedJobMap"() {
         setup:
         FreeStyleProject seedJob = jenkinsRule.createFreeStyleProject('seed')
         FreeStyleProject seedJob2 = jenkinsRule.createFreeStyleProject('seed2')

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ExecuteDslScriptsSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ExecuteDslScriptsSpec.groovy
@@ -784,6 +784,24 @@ folder('folder-a/folder-b') {
         jenkinsRule.instance.getDescriptorByType(DescriptorImpl).generatedJobMap.size() == 0
     }
 
+    def "Deleted jobs with different seeds but same templates are removed from GeneratedJobMap"() {
+        setup:
+        FreeStyleProject seedJob = jenkinsRule.createFreeStyleProject('seed')
+        FreeStyleProject seedJob2 = jenkinsRule.createFreeStyleProject('seed2')
+        jenkinsRule.createFreeStyleProject('template')
+        runBuild(seedJob, new ExecuteDslScripts('job("test-job") {\n using("template")\n}'))
+        runBuild(seedJob2, new ExecuteDslScripts('job("test-job-2") {\n using("template")\n}'))
+
+        when:
+        ExecuteDslScripts builder = new ExecuteDslScripts('// do nothing')
+        builder.removedJobAction = RemovedJobAction.DELETE
+        runBuild(seedJob, builder)
+        runBuild(seedJob2, builder)
+
+        then:
+        jenkinsRule.instance.getDescriptorByType(DescriptorImpl).generatedJobMap.size() == 0
+    }
+
     def "Manually deleted job is removed from GeneratedJobMap"() {
         setup:
         FreeStyleProject seedJob = jenkinsRule.createFreeStyleProject('seed')


### PR DESCRIPTION
This PR fixes an intermittant problem we've been seeing on our builds, where alternate builds fail because of `ConcurrentModificationException` in `ExecuteDslScripts`. This was raised as [JENKINS-69064](https://issues.jenkins.io/browse/JENKINS-69064).

**Explanation**
As part of the cleanup of removed templates in the `updateTemplates()` method, all seed job references are read for the removed template. These references are then filtered to those matching the seed job name. These matches are then removed from the seed job references.

However, the filtered references are a 'live' view (from `Collections2.filter`) based on the original seed job references, so attempting to remove them results in a `ConcurrentModificationException`.

**Fix**
The fix simply first converts the 'live' matches collection to a hash set before passing it to `removeAll()`, which allows the original collection to be modified. A unit test has been added to confirm this.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
