### PR TITLE
Use the Jenkins plugin BOM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,10 @@ configure(subprojects - project(':job-dsl-api-viewer')) {
     targetCompatibility = 1.8
 
     dependencies {
+        implementation platform("org.jenkins-ci.plugins:plugin:${jenkinsPluginBomVersion}")
         compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
         testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
-        testCompile 'junit:junit:4.12'
+        testCompile 'junit:junit'
         testCompile 'cglib:cglib-nodep:3.2.5' // used by Spock
         testCompile 'org.objenesis:objenesis:2.5.1' // used by Spock
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 version=1.82-SNAPSHOT
 groovyVersion=2.4.12
 jenkinsVersion=2.176
+jenkinsPluginBomVersion=3.57
 assetPipelineVersion=2.11.6
 githubUser=jenkinsci
 org.gradle.parallel=true


### PR DESCRIPTION
To better manage dependencies of various libraries, we can use the
Parent POM for Jenkins Plugins, which we can import as a Platform, and
then manage our dependencies more appropriately.

We can use 3.57 as the closest plugin version that maps to our version
of Jenkins core.

As a step towards JENKINS-68275.
