### PR TITLE
Upgrade to the latest JPI plugin

### DIFF
--- a/job-dsl-plugin/build.gradle
+++ b/job-dsl-plugin/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.jenkins-ci.jpi' version '0.43.0'
+    id 'org.jenkins-ci.jpi' version '0.46.0'
 }
 
 java {


### PR DESCRIPTION
As a step towards JENKINS-68275, and to generally keep up to date.
