### PR TITLE
Add a job to sync docs with GitHub Wiki

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,36 @@
+name: Push to the GitHub Wiki
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "docs/**"
+
+permissions:
+  contents: write
+
+jobs:
+  push-to-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          path: repo
+      - name: Checkout wiki
+        uses: actions/checkout@v3
+        with:
+          repository: ${{github.repository}}.wiki
+          path: wiki
+      - name: Push to wiki
+        continue-on-error: true
+        run: |
+          git config --global user.email "actions@users.noreply.github.com"
+          git config --global user.name "wiki[bot]"
+
+          cd wiki
+          cp ../docs/* -r .
+          git add .
+          git commit -m "Automagic update"
+          git push


### PR DESCRIPTION
Right now, it's a manual step I perform when I'm doing a release, which
leads to this being out-of-sync.

We can fortunately automate it following comments in [0] to do this more
easily.

[0]: https://github.com/orgs/community/discussions/25929
