### PR TITLE
Enable configuration for icons in folders

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractFolder.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractFolder.groovy
@@ -1,6 +1,7 @@
 package javaposse.jobdsl.dsl
 
 import javaposse.jobdsl.dsl.helpers.AuthorizationContext
+import javaposse.jobdsl.dsl.helpers.icon.FolderIconContext
 import javaposse.jobdsl.dsl.helpers.properties.FolderPropertiesContext
 
 abstract class AbstractFolder extends Item {
@@ -52,6 +53,24 @@ abstract class AbstractFolder extends Item {
             context.propertiesNodes.each {
                 project / 'properties' << it
             }
+        }
+    }
+
+    /**
+     * Sets the icon of the folder.
+     *
+     * @since 1.82
+     */
+    void icon(@DslContext(FolderIconContext) Closure closure) {
+        FolderIconContext context = new FolderIconContext(jobManagement, this)
+        ContextHelper.executeInContext(closure, context)
+
+        configure { Node folder ->
+            Node icon = folder / icon
+            if (icon) {
+                folder.remove(icon)
+            }
+            folder << context.icon
         }
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/icon/FolderIconContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/icon/FolderIconContext.groovy
@@ -1,0 +1,17 @@
+package javaposse.jobdsl.dsl.helpers.icon
+
+import javaposse.jobdsl.dsl.*
+
+@ContextType('com.cloudbees.hudson.plugins.folder.FolderIcon')
+class FolderIconContext extends AbstractExtensibleContext {
+    Node icon
+
+    FolderIconContext(JobManagement jobManagement, Item item) {
+        super(jobManagement, item)
+    }
+
+    @Override
+    protected void addExtensionNode(Node node) {
+        icon = ContextHelper.toNamedNode('icon', node)
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/FolderSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/FolderSpec.groovy
@@ -127,6 +127,23 @@ class FolderSpec extends Specification {
         folder.node.properties[0].children()[0].name() == 'hack'
     }
 
+    def 'call icon'() {
+        when:
+        folder.icon {
+            icon = new Node(null,
+                    'icon', ['class': 'jenkins.plugins.foldericon.CustomFolderIcon', 'plugin': 'custom-folder-icon'],
+                    new Node(null,
+                            'customFolderIcon', 'test.png'))
+        }
+
+        then:
+        folder.node.icon[0].name() == 'icon'
+        folder.node.icon[0].attribute('class') == 'jenkins.plugins.foldericon.CustomFolderIcon'
+        folder.node.icon[0].attribute('plugin') == 'custom-folder-icon'
+        folder.node.icon[0].children()[0].name() == 'customFolderIcon'
+        folder.node.icon[0].children()[0].value() == 'test.png'
+    }
+
     def 'configure'() {
         when:
         folder.configure {


### PR DESCRIPTION
This PR enables the `icon` configuration on folders, multi-branch projects and organization folders to be accessible. This way one can customize the folder icon via jenkinsci/[custom-folder-icon-plugin](https://github.com/jenkinsci/custom-folder-icon-plugin).
See https://github.com/jenkinsci/custom-folder-icon-plugin/issues/92 as well for details and use case.

![image](https://user-images.githubusercontent.com/49242855/194561205-69bf7bd4-aaff-446b-841a-c380801af02e.png)

Here the [jenkinsci/custom-folder-icon-plugin](https://github.com/jenkinsci/custom-folder-icon-plugin) is installed, by default there is only `stockFolderIcon` and `metaDataActionFolderIcon` available.

Example configuration:
```
folder('stock')

userContent('customFolderIcons/custom.png', streamFileFromWorkspace('custom.png'))
folder('custom') {
  icon {
    customFolderIcon {
      foldericon('custom.png')
    } 
  }
}
folder('ionicon') {
  icon {
    ioniconFolderIcon {
      ionicon('jenkins')
    } 
  }
}
folder('build-status') {
  icon {
      buildStatusFolderIcon()
  }
}
```