### PR TITLE
[JENKINS-69849] Add support for additional classpath with seed config

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractDslScriptLoader.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractDslScriptLoader.groovy
@@ -83,9 +83,13 @@ abstract class AbstractDslScriptLoader<S extends JobParent, G extends GeneratedI
      *
      * @since 1.47
      */
+    G runScript(String script) throws IOException {
+        runScript(script, [])
+    }
+
     G runScript(String script, List<URL> additionalClasspath) throws IOException {
         List<URL> classpath = new ArrayList<URL>(additionalClasspath)
-        classpath.add(new File('.').toURI().toURL())
+        //classpath.add(new File('.').toURI().toURL())
 
         ScriptRequest scriptRequest = new ScriptRequest(script, classpath as URL[])
         runScripts([scriptRequest])

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractDslScriptLoader.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/AbstractDslScriptLoader.groovy
@@ -83,8 +83,12 @@ abstract class AbstractDslScriptLoader<S extends JobParent, G extends GeneratedI
      *
      * @since 1.47
      */
-    G runScript(String script) throws IOException {
-        runScripts([new ScriptRequest(script)])
+    G runScript(String script, List<URL> additionalClasspath) throws IOException {
+        List<URL> classpath = new ArrayList<URL>(additionalClasspath)
+        classpath.add(new File('.').toURI().toURL())
+
+        ScriptRequest scriptRequest = new ScriptRequest(script, classpath as URL[])
+        runScripts([scriptRequest])
     }
 
     @SuppressWarnings('UnnecessarySetter') // must use JobParent.setJm() for some reason

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.java
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.java
@@ -18,5 +18,6 @@ public class ConfigurationAsCodeTest {
         assertNotNull(j.jenkins.getItem("testJob1"));
         assertNotNull(j.jenkins.getItem("testJob2"));
         assertNotNull(j.jenkins.getItem("testJob3"));
+        assertNotNull(j.jenkins.getItem("advancedJob"));
     }
 }

--- a/job-dsl-plugin/src/test/resources/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.yaml
+++ b/job-dsl-plugin/src/test/resources/javaposse/jobdsl/plugin/ConfigurationAsCodeTest.yaml
@@ -1,4 +1,5 @@
 jobs:
+  - additionalClasspath: ['src/test/resources/lib/', 'abc/', 'def/']
   - script: >
       job('testJob1') {
           scm {
@@ -13,6 +14,7 @@ jobs:
       }
 
   - file: ./src/test/resources/javaposse/jobdsl/plugin/testjob.groovy
+  - file: ./src/test/resources/javaposse/jobdsl/plugin/advancedJob.groovy
 
   - providedEnv:
       JOB_NAME_FROM_ENV: testJob3

--- a/job-dsl-plugin/src/test/resources/javaposse/jobdsl/plugin/advancedJob.groovy
+++ b/job-dsl-plugin/src/test/resources/javaposse/jobdsl/plugin/advancedJob.groovy
@@ -1,0 +1,15 @@
+import support.Helper;
+
+aJob = job('advancedJob') {
+    scm {
+        git('git://github.com/quidryan/aws-sdk-test.git')
+    }
+    triggers {
+        scm('H/15 * * * *')
+    }
+    steps {
+        maven('-e clean test')
+    }
+}
+
+Helper.extend(aJob)

--- a/job-dsl-plugin/src/test/resources/lib/support/Helper.groovy
+++ b/job-dsl-plugin/src/test/resources/lib/support/Helper.groovy
@@ -1,0 +1,18 @@
+package support;
+
+class Helper {
+    static void extend(def job) {
+        job.with {
+            wrappers {
+                release {
+                    preBuildSteps {
+                        shell 'echo 1'
+                    }
+                    postBuildSteps {
+                        shell 'echo 2'
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Given that CasC have no ways to configure classpath and jenkins bootstrap classpath is isolated from plugins there is no way to actually deliver a shared library to jobdsl beyond pipeline. As described in https://issues.jenkins.io/browse/JENKINS-69849 this approach may double amount of configurations needed to be maintained and complicate basic scenarios.

Provided pull request introduces a new "additionalClasspath" option accepted by seed job configurator which is processed in similar fashion as providedEnv - it is accumulated and passed to lower layers which generate script request and in effect also compile it.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


