### PR TITLE
Gerrit Event Trigger - Add Private & WIP State changed

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GerritEventContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/triggers/GerritEventContext.groovy
@@ -67,4 +67,22 @@ class GerritEventContext implements Context {
     void refUpdated() {
         eventShortNames << 'RefUpdated'
     }
+
+    /**
+     * Trigger when the private state is updated.
+     *
+     * @since 2.15
+     */
+    void privateStateChanged() {
+        eventShortNames << 'PrivateStateChanged'
+    }
+
+    /**
+     * Trigger when the Work In Progress state is updated.
+     *
+     * @since 2.15
+     */
+    void wipStateChanged() {
+        eventShortNames << 'WipStateChanged'
+    }
 }

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/triggers/TriggerContextSpec.groovy
@@ -146,7 +146,7 @@ class TriggerContextSpec extends Specification {
         where:
         event << [
                 'changeAbandoned', 'changeMerged', 'changeRestored', 'commentAdded', 'draftPublished',
-                'patchsetCreated', 'refUpdated'
+                'patchsetCreated', 'refUpdated', 'PrivateStateChanged', 'WipStateChanged'
         ]
     }
 


### PR DESCRIPTION
Since Gerrit 2.15, new events hooks have been introduced which can be used to trigger new Builds:
- Private state changed
- Work In Progress state changed
- Draft Publication removed

Ref: https://www.gerritcodereview.com/2.15.html#new-workflows

In this PR, we add support for the new events and keep the removed one for compatibility with Gerrit < 2.15.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

