### PR TITLE
Disable Dependabot PRs for Bootstrap 4 and later

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
     directory: "job-dsl-plugin"
     schedule:
       interval: "weekly"
+    ignore:
+      # Breaks the appearance of the API viewer. See:
+      # https://github.com/jenkinsci/job-dsl-plugin/pull/1270
+      - dependency-name: "bootstrap"
+        versions: [">=4.0.0"]


### PR DESCRIPTION
This should prevent noisy Dependabot PRs for a dependency we know cannot be upgraded without additional effort. If and when we decide to upgrade this dependency, the API viewer will need to be adapted and manual testing done to verify the API viewer displays correctly with the new version of Bootstrap.