### PR TITLE
Enable Release Drafter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jenkinsci/job-dsl-plugin-developers 
+* @jenkinsci/job-dsl-plugin-developers

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,3 @@
+# https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+_extends: .github
+tag-template: job-dsl-$NEXT_MINOR_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+# Automates creation of Release Drafts using Release Drafter
+# More Info: https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,14 +1,12 @@
 These are the steps to release the Maven-based Job DSL plugin.
 
 * Ensure you have the latest code from origin: `git pull origin`
-* Make sure tests still run: `mvn clean verify`
 * Run locally to perform sanity check: `mvn hpi:run`
 * Set `compatibleSinceVersion` to the new version if deprecated features have been removed
-* File a pull request to update the release notes, setting the release date: `* 1.14 (Mar 31 2013)`
 * Prepare and perform the release: `mvn release:prepare release:perform`
-* File a pull request to update the release notes, adding the next version: `* 1.15 (unreleased)`
+* Edit the [draft release notes](https://github.com/jenkinsci/job-dsl-plugin/releases) and publish them
 * Close all resolved issues in [JIRA](https://issues.jenkins-ci.org/secure/Dashboard.jspa?selectPageId=15341)
-* Open a pull request to update the [Job DSL Playground](https://github.com/sheehan/job-dsl-playground) 
+* Open a pull request to update the [Job DSL Playground](https://github.com/sheehan/job-dsl-playground)
 * Open a pull request to update the [Job DSL Gradle Example](https://github.com/sheehan/job-dsl-gradle-example)
 * Open a pull request to update the [Job DSL Sample](https://github.com/unguiculus/job-dsl-sample)
 * Wait up to twelve hours for it show up in the Update Center

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -32,7 +32,7 @@ scripts, including [[tests for DSL scripts|Testing DSL Scripts]] and [[IDE Suppo
 Browse the Jenkins issue tracker to see any [open issues](https://issues.jenkins-ci.org/issues/?filter=15140).
 
 ## Release Notes
-* 1.82 (Unreleased)
+* Release notes for versions >= 1.82 can be found on the [GitHub releases page](https://github.com/jenkinsci/job-dsl-plugin/releases).
 * 1.81.1 (March 13 2023)
   * Internal dependency management updates
   * Fix concurrent modification exception in ExecuteDslScripts ([GH-1253](https://github.com/jenkinsci/job-dsl-plugin/pull/1253) [JENKINS-69064](https://issues.jenkins.io/browse/JENKINS-69064)).

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,14 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <!-- Keep the tag names aligned with previous releases -->
+                    <tagNameFormat>job-dsl-@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-scm-publish-plugin</artifactId>
                 <configuration>
                     <checkinComment>updated wiki for ${project.version}</checkinComment>


### PR DESCRIPTION
Align this plugin with other Jenkins plugins to allow for the release notes to be displayed on https://plugins.jenkins.io/job-dsl/releases/