### PR TITLE
Restore automated wiki updates

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,41 @@
+name: Push to the GitHub Wiki
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  push-to-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          path: job-dsl-plugin
+      - name: Checkout wiki
+        uses: actions/checkout@v3
+        with:
+          repository: ${{github.repository}}.wiki
+          path: job-dsl-plugin.wiki
+      - name: Push to wiki
+        run: |
+          git config --global user.email "actions@users.noreply.github.com"
+          git config --global user.name "wiki[bot]"
+
+          pushd job-dsl-plugin
+          ./build-wiki.sh
+          popd
+
+          pushd job-dsl-plugin.wiki
+          cp -r ../job-dsl-plugin/target/docs/* .
+          git add .
+          git commit -m "Automagic update"
+          git push
+          popd

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,6 +5,7 @@ These are the steps to release the Maven-based Job DSL plugin.
 * Set `compatibleSinceVersion` to the new version if deprecated features have been removed
 * Prepare and perform the release: `mvn release:prepare release:perform`
 * Edit the [draft release notes](https://github.com/jenkinsci/job-dsl-plugin/releases) and publish them
+* Run the [Push to the GitHub Wiki](https://github.com/jenkinsci/job-dsl-plugin/actions/workflows/wiki.yml) workflow to update the wiki with the new version
 * File a pull request to add the newly-released version to the API viewer in `job-dsl-plugin/pom.xml` and `job-dsl-plugin/src/main/hbs/root.hbs`
 * Close all resolved issues in [JIRA](https://issues.jenkins-ci.org/secure/Dashboard.jspa?selectPageId=15341)
 * Open a pull request to update the [Job DSL Playground](https://github.com/sheehan/job-dsl-playground)

--- a/build-wiki.sh
+++ b/build-wiki.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -eux
+
+mkdir -p target/docs
+
+mvn -B -e -ntp -q -Dexpression=jenkins.version -Doutput=jenkins.version help:evaluate
+JENKINS_VERSION=`cat jenkins.version`
+
+curl -sSO https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/job-dsl/maven-metadata.xml
+VERSION=$(grep '<latest>.*</latest>' maven-metadata.xml | cut -d'>' -f2 | cut -d'<' -f1)
+
+cp -r docs target
+sed -i -e "s/@jenkinsVersion@/${JENKINS_VERSION}/g" target/docs/*.md
+sed -i -e "s/@version@/${VERSION}/g" target/docs/*.md
+
+exit 0

--- a/job-dsl-plugin/pom.xml
+++ b/job-dsl-plugin/pom.xml
@@ -45,11 +45,12 @@
     </developers>
     <distributionManagement>
         <site>
-            <id>github</id>
+            <id>github.com</id>
             <url>scm:git:git@github.com:${gitHubUser}/job-dsl-plugin.git</url>
         </site>
     </distributionManagement>
     <properties>
+        <gitHubUser>jenkinsci</gitHubUser>
         <!-- TODO GMavenPlus does not support Javadoc -->
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <node.version>18.14.2</node.version>
@@ -476,6 +477,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-scm-publish-plugin</artifactId>
+                <version>3.1.0</version>
                 <configuration>
                     <checkinComment>updated gh-pages for ${project.version}</checkinComment>
                     <scmBranch>gh-pages</scmBranch>

--- a/pom.xml
+++ b/pom.xml
@@ -29,16 +29,9 @@
         <tag>${scmTag}</tag>
         <url>https://github.com/${gitHubRepo}</url>
     </scm>
-    <distributionManagement>
-        <site>
-            <id>github</id>
-            <url>scm:git:git@github.com:${gitHubUser}/job-dsl-plugin.wiki.git</url>
-        </site>
-    </distributionManagement>
     <properties>
         <revision>1.82</revision>
         <changelist>-SNAPSHOT</changelist>
-        <gitHubUser>jenkinsci</gitHubUser>
         <gitHubRepo>jenkinsci/job-dsl-plugin</gitHubRepo>
         <jenkins.version>2.361.4</jenkins.version>
         <!-- TODO fix violations -->
@@ -101,11 +94,6 @@
                         </dependency>
                     </dependencies>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-scm-publish-plugin</artifactId>
-                    <version>3.1.0</version>
-                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -115,15 +103,6 @@
                 <configuration>
                     <!-- Keep the tag names aligned with previous releases -->
                     <tagNameFormat>job-dsl-@{project.version}</tagNameFormat>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-scm-publish-plugin</artifactId>
-                <configuration>
-                    <checkinComment>updated wiki for ${project.version}</checkinComment>
-                    <scmBranch>master</scmBranch>
-                    <!-- TODO generate the wiki from docs/*.md replacing version with project.version and jenkinsVersion with jenkins.version -->
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This had been temporarily ripped out in https://github.com/jenkinsci/job-dsl-plugin/pull/1265 to facilitate ease of development. The work has now been completed.