### PR TITLE
Simplify release process

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - "docs/**"
+      - "pom.xml"
   workflow_dispatch:
 
 permissions:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,8 +5,7 @@ These are the steps to release the Maven-based Job DSL plugin.
 * Set `compatibleSinceVersion` to the new version if deprecated features have been removed
 * Prepare and perform the release: `mvn release:prepare release:perform`
 * Edit the [draft release notes](https://github.com/jenkinsci/job-dsl-plugin/releases) and publish them
-* Run the [Push to the GitHub Wiki](https://github.com/jenkinsci/job-dsl-plugin/actions/workflows/wiki.yml) workflow to update the wiki with the new version
-* File a pull request to add the newly-released version to the API viewer in `job-dsl-plugin/pom.xml` and `job-dsl-plugin/src/main/hbs/root.hbs`
+* Open a pull request to add the newly-released version to the API viewer in `job-dsl-plugin/pom.xml` and `job-dsl-plugin/src/main/hbs/root.hbs`
 * Close all resolved issues in [JIRA](https://issues.jenkins-ci.org/secure/Dashboard.jspa?selectPageId=15341)
 * Open a pull request to update the [Job DSL Playground](https://github.com/sheehan/job-dsl-playground)
 * Open a pull request to update the [Job DSL Gradle Example](https://github.com/sheehan/job-dsl-gradle-example)


### PR DESCRIPTION
By automatically deploying the wiki on any push to `pom.xml`, we can take one step out of the release process.