### PR TITLE
Add support for "Failure -> Unstable (Test Failures)" trigger

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/ExtendedEmailTriggersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/publisher/ExtendedEmailTriggersContext.groovy
@@ -22,6 +22,14 @@ class ExtendedEmailTriggersContext implements Context {
     }
 
     /**
+     * Triggers an email when the build goes from failing (compilation or build step failures) to
+     * unstable (unit test failures).
+     */
+    void building(@DslContext(ExtendedEmailTriggerContext) Closure closure = null) {
+        addTrigger('Building', closure)
+    }
+
+    /**
      * Triggers an email when the build begins, but after SCM polling has completed.
      */
     void beforeBuild(@DslContext(ExtendedEmailTriggerContext) Closure closure = null) {

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/publisher/PublisherContextSpec.groovy
@@ -217,6 +217,7 @@ class PublisherContextSpec extends Specification {
         'aborted'        || 'AbortedTrigger'
         'always'         || 'AlwaysTrigger'
         'beforeBuild'    || 'PreBuildTrigger'
+        'building'       || 'BuildingTrigger'
         'firstFailure'   || 'FirstFailureTrigger'
         'secondFailure'  || 'SecondFailureTrigger'
         'failure'        || 'FailureTrigger'


### PR DESCRIPTION
While reviewing #1297 I noticed that we were lacking support for `BuildTrigger` and that it was trivial to add it.