### PR TITLE
Add ability to set network for Docker Custom Build Environment plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/BuildInDockerContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/BuildInDockerContext.groovy
@@ -14,6 +14,7 @@ class BuildInDockerContext extends AbstractContext {
     boolean forcePull
     String userGroup
     String startCommand = '/bin/cat'
+    String network = 'bridge'
 
     BuildInDockerContext(JobManagement jobManagement) {
         super(jobManagement)
@@ -77,5 +78,9 @@ class BuildInDockerContext extends AbstractContext {
 
     void startCommand(String startCommand) {
         this.startCommand = startCommand
+    }
+
+    void network(String network) {
+        this.network = network
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy
@@ -605,6 +605,7 @@ class WrapperContext extends AbstractExtensibleContext {
             forcePull(context.forcePull)
             group(context.userGroup ?: '')
             command(context.startCommand ?: '')
+            net(context.network)
         }
         node.append(context.selector)
         wrapperNodes << node

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContextSpec.groovy
@@ -1391,7 +1391,7 @@ class WrapperContextSpec extends Specification {
         then:
         with(context.wrapperNodes[0]) {
             name() == 'com.cloudbees.jenkins.plugins.okidocki.DockerBuildWrapper'
-            children().size() == 9
+            children().size() == 10
             selector[0].children().size() == 2
             selector[0].attribute('class') == 'com.cloudbees.jenkins.plugins.okidocki.DockerfileImageSelector'
             selector[0].contextPath[0].value() == '.'
@@ -1404,6 +1404,7 @@ class WrapperContextSpec extends Specification {
             forcePull[0].value() == false
             group[0].value().empty
             command[0].value() == '/bin/cat'
+            net[0].value() == 'bridge'
         }
         1 * mockJobManagement.requireMinimumPluginVersion('docker-custom-build-environment', '1.6.2')
     }
@@ -1422,12 +1423,13 @@ class WrapperContextSpec extends Specification {
             verbose()
             userGroup('test10')
             startCommand('test11')
+            network('test12')
         }
 
         then:
         with(context.wrapperNodes[0]) {
             name() == 'com.cloudbees.jenkins.plugins.okidocki.DockerBuildWrapper'
-            children().size() == 9
+            children().size() == 10
             selector[0].children().size() == 2
             selector[0].attribute('class') == 'com.cloudbees.jenkins.plugins.okidocki.DockerfileImageSelector'
             selector[0].contextPath[0].value() == 'test1'
@@ -1448,6 +1450,7 @@ class WrapperContextSpec extends Specification {
             forcePull[0].value() == true
             group[0].value() == 'test10'
             command[0].value() == 'test11'
+            net[0].value() == 'test12'
         }
         1 * mockJobManagement.requireMinimumPluginVersion('docker-custom-build-environment', '1.6.2')
     }
@@ -1466,12 +1469,13 @@ class WrapperContextSpec extends Specification {
             verbose()
             userGroup('test10')
             startCommand('test11')
+            network('test12')
         }
 
         then:
         with(context.wrapperNodes[0]) {
             name() == 'com.cloudbees.jenkins.plugins.okidocki.DockerBuildWrapper'
-            children().size() == 9
+            children().size() == 10
             selector[0].children().size() == 1
             selector[0].attribute('class') == 'com.cloudbees.jenkins.plugins.okidocki.PullDockerImageSelector'
             selector[0].image[0].value() == 'test1'
@@ -1491,6 +1495,7 @@ class WrapperContextSpec extends Specification {
             forcePull[0].value() == true
             group[0].value() == 'test10'
             command[0].value() == 'test11'
+            net[0].value() == 'test12'
         }
         1 * mockJobManagement.requireMinimumPluginVersion('docker-custom-build-environment', '1.6.2')
     }


### PR DESCRIPTION
This PR is for adding the ability to configure the network parameter of docker when running inside a container.
When configuring the "build inside docker" section of a job - under advanced options - you have the ability to configure manually the network and change it from "bridge" (the default) to "host"
in the job-dsl-plugin it was not exposed so I added it.
I added a new function "network" in docker context and exposed it in the wrapper.

Picture of the Maven clean install (after I added some tests for the new ability):

![image](https://github.com/jenkinsci/job-dsl-plugin/assets/9662017/e063dce8-44a6-42c4-a999-1263043ff81f)


Picture of the actual use of the plugin after installing it on testing Jenkins:

![image](https://github.com/jenkinsci/job-dsl-plugin/assets/9662017/1bca7e1b-48b4-43dd-a249-ea8c822fae42)

![image](https://github.com/jenkinsci/job-dsl-plugin/assets/9662017/84254b31-73b7-4424-ac56-ea0c01d33a0f)

https://issues.jenkins.io/browse/JENKINS-70542

-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
