### PR TITLE
Support building on Java 17 and 21

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-    [platform: 'linux', jdk: 11],
+    [platform: 'linux', jdk: 17],
     [platform: 'windows', jdk: 11],
 ])

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/MemoryJobManagementSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/MemoryJobManagementSpec.groovy
@@ -164,7 +164,7 @@ class MemoryJobManagementSpec extends Specification {
 
     def 'outputStream'() {
         setup:
-        PrintStream out = Mock(PrintStream)
+        PrintStream out = new PrintStream(OutputStream.nullOutputStream())
 
         when:
         JobManagement jobManagement = new MemoryJobManagement(out)

--- a/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ScriptRequestGeneratorSpec.groovy
+++ b/job-dsl-plugin/src/test/groovy/javaposse/jobdsl/plugin/ScriptRequestGeneratorSpec.groovy
@@ -319,9 +319,8 @@ class ScriptRequestGeneratorSpec extends Specification {
         requests[0].body == SCRIPT_A
         requests[0].urlRoots.length == 3
         requests[0].urlRoots[0].toString() == 'workspace:/'
-        URL tempDirUrl = new File(System.getProperty('java.io.tmpdir')).toURI().toURL()
-        requests[0].urlRoots[1] =~ "${tempDirUrl}jobdsl.*\\.jar"
-        requests[0].urlRoots[2] =~ "${tempDirUrl}jobdsl.*\\.jar"
+        requests[0].urlRoots[1] =~ 'jobdsl.*\\.jar'
+        requests[0].urlRoots[2] =~ 'jobdsl.*\\.jar'
         !requests[0].ignoreExisting
         requests[0].scriptPath == getAbsolutePath(remoteBuild.workspace.child('a.groovy'))
         requests[0].relativeScriptPath == 'a.groovy'

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.66</version>
+    <version>4.72</version>
     <relativePath />
   </parent>
   <artifactId>job-dsl-parent</artifactId>


### PR DESCRIPTION
Without dropping support for Java 11, add support for running `mvn clean verify` on Java 17 and 21.