### PR TITLE
Fix: add missing sshUserPrivateKey options of CredentialsBinding Plugin for wrapper

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/CredentialsBindingContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/CredentialsBindingContext.groovy
@@ -56,7 +56,20 @@ class CredentialsBindingContext extends AbstractExtensibleContext {
         addSimpleBinding('ZipFile', variable, credentials)
     }
 
-    private void addSimpleBinding(String type, String variableName, String credentials) {
+    /**
+     * Sets a variable to the given SSH User Private Key in the credentials.
+     */
+    @RequiresPlugin(id = 'credentials-binding', minimumVersion = '1.3')
+    void sshUserPrivateKey(String keyFileVariable, String passPhraseVariable, String usernameVariable, String credentials) {
+        nodes << new NodeBuilder().'org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding' {
+            credentialsId(credentials)
+            usernameVariable(userVariableName)
+            passPhraseVariable(passphraseVariable)
+            keyFileVariable(keyFileVariable)
+        }
+    }
+
+    private void addSimpleBinding(String type, String passphraseVariable, String usernameVariable, String variableName, String credentials) {
         nodes << new NodeBuilder()."org.jenkinsci.plugins.credentialsbinding.impl.${type}Binding" {
             variable(variableName)
             credentialsId(credentials)


### PR DESCRIPTION
Added the options for SSHUserPrivateKey to the DSL plugin.

Problem:

- SSHUserPrivateKey is missing at the API reference of the job dsl plugin which is essentially required to automate to setup of this option in a secret file or key at the configuration of Jenkins jobs/pipeline.

<img width="897" alt="Screenshot 2023-09-08 at 12 08 22 AM" src="https://github.com/jenkinsci/job-dsl-plugin/assets/29862610/b4dc6b8a-0082-4be1-a3d2-8fd14005724d">


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```