### PR TITLE
Use core default driver for XStream

### DIFF
--- a/job-dsl-plugin/src/main/java/javaposse/jobdsl/plugin/JenkinsJobManagement.java
+++ b/job-dsl-plugin/src/main/java/javaposse/jobdsl/plugin/JenkinsJobManagement.java
@@ -10,7 +10,6 @@ import com.cloudbees.hudson.plugins.folder.Folder;
 import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider.FolderCredentialsProperty;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
-import com.thoughtworks.xstream.io.xml.XppDriver;
 import groovy.util.Node;
 import groovy.util.XmlParser;
 import hudson.FilePath;
@@ -31,6 +30,7 @@ import hudson.model.View;
 import hudson.model.ViewGroup;
 import hudson.slaves.Cloud;
 import hudson.util.VersionNumber;
+import hudson.util.XStream2;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -507,7 +507,7 @@ public class JenkinsJobManagement extends AbstractJobManagement {
     private boolean viewTypeChanged(View view, InputStream config) throws IOException {
         Class viewType = Jenkins.XSTREAM2
                 .getMapper()
-                .realClass(new XppDriver().createReader(config).getNodeName());
+                .realClass(XStream2.getDefaultDriver().createReader(config).getNodeName());
         config.reset();
         return !viewType.equals(view.getClass());
     }


### PR DESCRIPTION
The XStream default driver (based on XML Pull Parser 3rd edition) is one that core no longer prefers or uses for various reasons, including bugs parsing emoji in modern XML files. Instead core now uses the Streaming API for XML (StAX) that is built into modern versions of the Java Platform runtime environment. I have been working to slowly remove the old XPP3 parser from core, but I discovered that this plugin still had a hard-coded reference to it in one place and was broken when I removed the old driver from core. To avoid this problem I am instead having this plugin use core's default driver, which in newer versions is StAX.

### Testing done

I ran this plugin's tests against a core with XPP3 removed and observed they started failing. After this PR and https://github.com/jenkinsci/nested-view-plugin/pull/43 they now pass.

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
