### PR TITLE
Remove <optional> from config-file-provider dependency

### DIFF
--- a/job-dsl-plugin/pom.xml
+++ b/job-dsl-plugin/pom.xml
@@ -100,7 +100,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>config-file-provider</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Remove the `optional` flag from the `config-file-provider` dependency.
To my understanding this dependency is directly referenced in `ExecuteDslScripts` as well as `JenkinsDslScriptLoader` and for that reason should *not* be optional.

Resolves https://github.com/jenkinsci/custom-folder-icon-plugin/issues/280

### Testing done

Ran existing tests without any errors.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
