### PR TITLE
[JENKINS-73759] Remove deprecated usage of Spring Framework class

### DIFF
--- a/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/EmbeddedApiDocGenerator.groovy
+++ b/job-dsl-plugin/src/main/groovy/javaposse/jobdsl/plugin/EmbeddedApiDocGenerator.groovy
@@ -16,8 +16,8 @@ import org.jenkinsci.plugins.structs.describable.EnumType
 import org.jenkinsci.plugins.structs.describable.HeterogeneousObjectType
 import org.jenkinsci.plugins.structs.describable.HomogeneousObjectType
 import org.jenkinsci.plugins.structs.describable.ParameterType
-import org.springframework.core.LocalVariableTableParameterNameDiscoverer
 import org.springframework.core.ParameterNameDiscoverer
+import org.springframework.core.StandardReflectionParameterNameDiscoverer
 
 import java.lang.reflect.Method
 import java.text.BreakIterator
@@ -33,7 +33,7 @@ import static org.apache.commons.lang.StringEscapeUtils.unescapeHtml
 
 class EmbeddedApiDocGenerator {
     private static final ParameterNameDiscoverer PARAMETER_NAME_DISCOVERER =
-            new LocalVariableTableParameterNameDiscoverer()
+            new StandardReflectionParameterNameDiscoverer()
 
     private final List<DescribableModel> newContexts = []
     private final List<ParameterType> newListContexts = []


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

See [JENKINS-73759](https://issues.jenkins.io/browse/JENKINS-73759).

`LocalVariableTableParameterNameDiscoverer` was marked as deprecated in favour of `StandardReflectionParameterNameDiscoverer`. Since Spring Framework 6.1.0-M1, the class was removed from the framework. See https://github.com/spring-projects/spring-framework/commit/4d15b58ca421488d02f92e882c4a4b52c20328f6
Because of this, the plugin faces a bug in Jenkins 2.475+. 

As `StandardReflectionParameterNameDiscoverer` class is present in Spring Framework since version 4.0, this shouldn't be a problem to use the plugin with Jenkins prior or more recent than 2.475.

### Testing done

I just compiled the plugin

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
