### PR TITLE
chore: Remove deprecated LESS calls

### DIFF
--- a/job-dsl-plugin/src/main/less/main.less
+++ b/job-dsl-plugin/src/main/less/main.less
@@ -241,7 +241,7 @@ body {
 }
 
 .intro {
-  .method-doc;
+  .method-doc();
   margin-bottom: 30px;
 
   .info {
@@ -289,7 +289,7 @@ body {
     }
   }
   .signature {
-    .code-block;
+    .code-block();
     padding: 5px;
     margin-bottom: 10px;
     text-align: left;
@@ -321,7 +321,7 @@ body {
 }
 
 pre.highlight {
-  .code-block;
+  .code-block();
 }
 
 .highlight.inline {
@@ -332,7 +332,7 @@ pre.highlight {
 
 .context-methods-section {
   padding: 5px 10px;
-  .code-block;
+  .code-block();
   pre {
     background-color: transparent;
     border: none;
@@ -354,7 +354,7 @@ ul.context-methods {
     list-style-type: none;
   }
   .method-name {
-    .text-ellipsis;
+    .text-ellipsis();
     .method-link-wrapper {
       min-width: 250px;
       display: inline-block;


### PR DESCRIPTION
Mixins should use parentheses.

Reference: https://lesscss.org/features/#mixins-feature

### Testing done

- Validated mixins still are represented in the [API [Viewer](http://localhost:8080/jenkins/plugin/job-dsl/api-viewer/index.html)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
