### PR TITLE
JENKINS-75956: Add charset support to `readFileFromWorkspace` function

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/DslFactory/readFileFromWorkspace.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/DslFactory/readFileFromWorkspace.groovy
@@ -1,3 +1,5 @@
+import java.nio.charset.Charset
+
 // read the file release.groovy from the seed job's workspace
 // and configure a Groovy build step using that script
 def releaseScript = readFileFromWorkspace('release.groovy')
@@ -13,5 +15,12 @@ def runScript = readFileFromWorkspace('project-a', 'run.bat')
 job('example-2') {
     steps {
         batchFile(runScript)
+    }
+}
+
+def winScript = readFileFromWorkspace('build.bat', Charset.forName("windows-31j"))
+job('example-3') {
+    steps {
+        batchFile(winScript)
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/DslFactory.groovy
@@ -1,14 +1,9 @@
 package javaposse.jobdsl.dsl
 
 import javaposse.jobdsl.dsl.helpers.ConfigFilesContext
-import javaposse.jobdsl.dsl.jobs.FreeStyleJob
-import javaposse.jobdsl.dsl.jobs.IvyJob
-import javaposse.jobdsl.dsl.jobs.MatrixJob
-import javaposse.jobdsl.dsl.jobs.MavenJob
-import javaposse.jobdsl.dsl.jobs.MultiJob
-import javaposse.jobdsl.dsl.jobs.OrganizationFolderJob
-import javaposse.jobdsl.dsl.jobs.WorkflowJob
-import javaposse.jobdsl.dsl.jobs.MultibranchWorkflowJob
+import javaposse.jobdsl.dsl.jobs.*
+
+import java.nio.charset.Charset
 
 interface DslFactory extends ViewFactory {
     /**
@@ -236,4 +231,12 @@ interface DslFactory extends ViewFactory {
      * @param filePath path of the file relative to the workspace root
      */
     String readFileFromWorkspace(String jobName, String filePath)
+
+    /**
+     * Streams a file from the workspace of the seed job.
+     *
+     * @param filePath path of the file relative to the workspace root
+     * @param charset
+     */
+    String readFileFromWorkspace(String filePath, Charset charset)
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/FileJobManagement.groovy
@@ -1,5 +1,7 @@
 package javaposse.jobdsl.dsl
 
+import java.nio.charset.Charset
+
 class FileJobManagement extends MockJobManagement {
     /**
      * Root of where to look for and write out job and view config files
@@ -61,6 +63,11 @@ class FileJobManagement extends MockJobManagement {
 
     @Override
     String readFileInWorkspace(String filePath) {
-        new File(root, filePath).text
+        readFileInWorkspace(filePath, Charset.defaultCharset())
+    }
+
+    @Override
+    String readFileInWorkspace(String filePath, Charset charset) {
+        new File(root, filePath).getText(charset.name())
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobManagement.groovy
@@ -1,12 +1,14 @@
 package javaposse.jobdsl.dsl
 
+import java.nio.charset.Charset
+
 /**
  * Interface to manage jobs, which the DSL needs to do.
  */
 interface JobManagement {
     /**
      * Marker value returned by
-     * {@link #callExtension(java.lang.String, javaposse.jobdsl.dsl.Item, java.lang.Class, java.lang.Object[])} to
+     * {@link #callExtension(java.lang.String, javaposse.jobdsl.dsl.Item, java.lang.Class, java.lang.Object [ ])} to
      * indicate that an extension method does not produce a node.
      */
     Node NO_VALUE = new Node(null, 'no-value')
@@ -105,6 +107,17 @@ interface JobManagement {
      * @since 1.25
      */
     String readFileInWorkspace(String jobName, String filePath) throws IOException, InterruptedException
+
+    /**
+     * Reads a file from the workspace of a job.
+     *
+     * @param filePath path of the file relative to the workspace root
+     * @param charset charset to use when reading the file
+     * @return content of the file
+     * @throws IOException if the file could not be read
+     * @since 1.xx
+     */
+    String readFileInWorkspace(String filePath, Charset charset) throws IOException, InterruptedException
 
     /**
      * Stream to write to, for stdout.

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
@@ -2,23 +2,10 @@ package javaposse.jobdsl.dsl
 
 import groovy.transform.ThreadInterrupt
 import javaposse.jobdsl.dsl.helpers.ConfigFilesContext
-import javaposse.jobdsl.dsl.jobs.FreeStyleJob
-import javaposse.jobdsl.dsl.jobs.IvyJob
-import javaposse.jobdsl.dsl.jobs.MatrixJob
-import javaposse.jobdsl.dsl.jobs.MavenJob
-import javaposse.jobdsl.dsl.jobs.MultiJob
-import javaposse.jobdsl.dsl.jobs.OrganizationFolderJob
-import javaposse.jobdsl.dsl.jobs.WorkflowJob
-import javaposse.jobdsl.dsl.jobs.MultibranchWorkflowJob
-import javaposse.jobdsl.dsl.views.BuildMonitorView
-import javaposse.jobdsl.dsl.views.BuildPipelineView
-import javaposse.jobdsl.dsl.views.CategorizedJobsView
-import javaposse.jobdsl.dsl.views.DashboardView
-import javaposse.jobdsl.dsl.views.DeliveryPipelineView
-import javaposse.jobdsl.dsl.views.ListView
-import javaposse.jobdsl.dsl.views.NestedView
-import javaposse.jobdsl.dsl.views.PipelineAggregatorView
-import javaposse.jobdsl.dsl.views.SectionedView
+import javaposse.jobdsl.dsl.jobs.*
+import javaposse.jobdsl.dsl.views.*
+
+import java.nio.charset.Charset
 
 import static javaposse.jobdsl.dsl.Preconditions.checkNotNull
 import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
@@ -237,6 +224,16 @@ abstract class JobParent extends Script implements DslFactory {
         checkNotNullOrEmpty(jobName, 'jobName must not be null or empty')
         checkNotNullOrEmpty(filePath, 'filePath must not be null or empty')
         jm.readFileInWorkspace(jobName, filePath)
+    }
+
+    /**
+     * @since 1.xx
+     */
+    @Override
+    String readFileFromWorkspace(String filePath, Charset charset) {
+        checkNotNullOrEmpty(filePath, 'filePath must not be null or empty')
+        checkNotNull(charset, 'charset must not be null')
+        jm.readFileInWorkspace(filePath, charset)
     }
 
     // this method cannot be private due to http://jira.codehaus.org/browse/GROOVY-6263

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/MemoryJobManagement.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/MemoryJobManagement.groovy
@@ -1,5 +1,7 @@
 package javaposse.jobdsl.dsl
 
+import java.nio.charset.Charset
+
 /**
  * In-memory JobManagement for testing.
  */
@@ -56,6 +58,11 @@ class MemoryJobManagement extends MockJobManagement {
 
     @Override
     String readFileInWorkspace(String filePath) {
+        readFileInWorkspace(filePath, Charset.defaultCharset())
+    }
+
+    @Override
+    String readFileInWorkspace(String filePath, Charset charset) {
         String body = availableFiles[filePath]
         if (body == null) {
             throw new FileNotFoundException(filePath)

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/AbstractJobManagementSpec.groovy
@@ -2,6 +2,8 @@ package javaposse.jobdsl.dsl
 
 import spock.lang.Specification
 
+import java.nio.charset.Charset
+
 import static org.codehaus.groovy.runtime.InvokerHelper.createScript
 
 class AbstractJobManagementSpec extends Specification {
@@ -148,6 +150,11 @@ class AbstractJobManagementSpec extends Specification {
 
         @Override
         String readFileInWorkspace(String filePath) throws IOException {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        String readFileInWorkspace(String filePath, Charset charset) throws IOException {
             throw new UnsupportedOperationException()
         }
 

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobParentSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/JobParentSpec.groovy
@@ -1,23 +1,10 @@
 package javaposse.jobdsl.dsl
 
-import javaposse.jobdsl.dsl.jobs.FreeStyleJob
-import javaposse.jobdsl.dsl.jobs.IvyJob
-import javaposse.jobdsl.dsl.jobs.MatrixJob
-import javaposse.jobdsl.dsl.jobs.MavenJob
-import javaposse.jobdsl.dsl.jobs.MultiJob
-import javaposse.jobdsl.dsl.jobs.OrganizationFolderJob
-import javaposse.jobdsl.dsl.jobs.WorkflowJob
-import javaposse.jobdsl.dsl.jobs.MultibranchWorkflowJob
-import javaposse.jobdsl.dsl.views.BuildMonitorView
-import javaposse.jobdsl.dsl.views.BuildPipelineView
-import javaposse.jobdsl.dsl.views.CategorizedJobsView
-import javaposse.jobdsl.dsl.views.DashboardView
-import javaposse.jobdsl.dsl.views.DeliveryPipelineView
-import javaposse.jobdsl.dsl.views.ListView
-import javaposse.jobdsl.dsl.views.NestedView
-import javaposse.jobdsl.dsl.views.PipelineAggregatorView
-import javaposse.jobdsl.dsl.views.SectionedView
+import javaposse.jobdsl.dsl.jobs.*
+import javaposse.jobdsl.dsl.views.*
 import spock.lang.Specification
+
+import java.nio.charset.Charset
 
 class JobParentSpec extends Specification {
     private final JobParent parent = Spy(JobParent)
@@ -328,7 +315,7 @@ class JobParentSpec extends Specification {
         result == 'hello'
 
         when:
-        parent.readFileFromWorkspace('my-job', null)
+        parent.readFileFromWorkspace('my-job', (String) null)
 
         then:
         thrown(DslScriptException)
@@ -347,6 +334,28 @@ class JobParentSpec extends Specification {
 
         when:
         parent.readFileFromWorkspace('', 'foo.txt')
+
+        then:
+        thrown(DslScriptException)
+    }
+
+    def 'readFileInWorkspace with charset parameter'() {
+        jobManagement.readFileInWorkspace('foo.txt', Charset.forName('windows-31j')) >> 'hello'
+
+        when:
+        String result = parent.readFileFromWorkspace('foo.txt', Charset.forName('windows-31j'))
+
+        then:
+        result == 'hello'
+
+        when:
+        parent.readFileFromWorkspace('foo.txt', (Charset) null)
+
+        then:
+        thrown(DslScriptException)
+
+        when:
+        parent.readFileFromWorkspace(null, Charset.forName('windows-31j'))
 
         then:
         thrown(DslScriptException)


### PR DESCRIPTION
When I tried to upgrade Jenkins using Java from 17 to 21 at Windows, I got an error due to 'JEP 400: UTF-8 by Default'.　To work around this issue, we can use '-Dfile.encoding=COMPAT' or convert all files you load to UTF-8, but I would like to be able to solve this problem just with this plugin.  
The bug is the belief that when processing text files in Java, I should specify the character encoding.

JENKINS-75956: https://issues.jenkins.io/browse/JENKINS-75956

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
