### PR TITLE
Disable AbstractFolder when item gets unreferenced

### DIFF
--- a/job-dsl-plugin/src/main/java/javaposse/jobdsl/plugin/ExecuteDslScripts.java
+++ b/job-dsl-plugin/src/main/java/javaposse/jobdsl/plugin/ExecuteDslScripts.java
@@ -4,6 +4,7 @@ import static hudson.Util.fixEmptyAndTrim;
 import static java.lang.String.format;
 import static javaposse.jobdsl.plugin.actions.GeneratedObjectsAction.extractGeneratedObjects;
 
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Collections2;
@@ -505,9 +506,20 @@ public class ExecuteDslScripts extends Builder implements SimpleBuildStep {
                 } else {
                     if (removedItem instanceof ParameterizedJob) {
                         ParameterizedJob project = (ParameterizedJob) removedItem;
-                        project.checkPermission(Item.CONFIGURE);
-                        project.makeDisabled(true);
-                        disabled.add(unreferencedJob);
+                        if (project.supportsMakeDisabled()) {
+                            project.checkPermission(Item.CONFIGURE);
+                            project.makeDisabled(true);
+                            disabled.add(unreferencedJob);
+                        }
+                    }
+
+                    if (removedItem instanceof AbstractFolder) {
+                        AbstractFolder project = (AbstractFolder) removedItem;
+                        if (project.supportsMakeDisabled()) {
+                            project.checkPermission(Item.CONFIGURE);
+                            project.makeDisabled(true);
+                            disabled.add(unreferencedJob);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Disables MultibranchWorkflow jobs and other folders when the type supports being disabled

### Testing done

Manually using `mvn hpi:run`

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

https://issues.jenkins.io/browse/JENKINS-64058?focusedCommentId=435419&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel