### PR TITLE
Use Apache Maven 3.9.12 in actions

### DIFF
--- a/.github/workflows/api-viewer.yml
+++ b/.github/workflows/api-viewer.yml
@@ -43,9 +43,9 @@ jobs:
           sudo ln -s /opt/maven/bin/mvn /usr/bin/mvn
           mvn --version
         env:
-          MAVEN_VERSION: 3.9.11
-          # https://downloads.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz.sha512
-          CHECKSUM: bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978
+          MAVEN_VERSION: 3.9.12
+          # https://downloads.apache.org/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz.sha512
+          CHECKSUM: 0a1be79f02466533fc1a80abbef8796e4f737c46c6574ede5658b110899942a94db634477dfd3745501c80aef9aac0d4f841d38574373f7e2d24cce89d694f70
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Build API viewer

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -42,9 +42,9 @@ jobs:
           sudo ln -s /opt/maven/bin/mvn /usr/bin/mvn
           mvn --version
         env:
-          MAVEN_VERSION: 3.9.11
-          # https://downloads.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz.sha512
-          CHECKSUM: bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978
+          MAVEN_VERSION: 3.9.12
+          # https://downloads.apache.org/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz.sha512
+          CHECKSUM: 0a1be79f02466533fc1a80abbef8796e4f737c46c6574ede5658b110899942a94db634477dfd3745501c80aef9aac0d4f841d38574373f7e2d24cce89d694f70
       - name: Push to wiki
         run: |
           git config --global user.email "actions@users.noreply.github.com"


### PR DESCRIPTION
## Use Apache Maven 3.9.12 in actions

The Apache Maven project has wisely chosen to only provide binary downloads for the most recent release of Apache Maven 3.  That is a good way to reduce overuse and abuse of their download server and assure that consumers are regularly updating to the most recent release.

### Testing done

Confirmed that the new SHA-512 matches the download site.  Rely on GitHub actions to test the rest of the change.

Apache Maven 3.9.12 has already been adopted in Jenkins core and Jenkins plugins with no known regressions.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
