### PR TITLE
Add support for toggling sandbox for active choice plugin parameter scripts

### DIFF
--- a/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/BuildParametersContext/activeChoiceParam.groovy
+++ b/job-dsl-core/src/main/docs/examples/javaposse/jobdsl/dsl/helpers/BuildParametersContext/activeChoiceParam.groovy
@@ -9,5 +9,20 @@ job('example') {
                 fallbackScript('"fallback choice"')
             }
         }
+        activeChoiceParam('CHOICE-2') {
+            description('Allows user choose from multiple choices with sandbox enabled')
+            filterable()
+            choiceType('SINGLE_SELECT')
+            groovyScript {
+                secureScript {
+                    script('["choice1", "choice2"]')
+                    sandbox(true)
+                }
+                secureFallbackScript {
+                    script('"fallback choice"')
+                    sandbox(true)
+                }
+            }
+        }
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContext.groovy
@@ -238,7 +238,7 @@ class BuildParametersContext extends AbstractExtensibleContext {
      *
      * @since 1.36
      */
-    @RequiresPlugin(id = 'uno-choice', minimumVersion = '1.2')
+    @RequiresPlugin(id = 'uno-choice', minimumVersion = '2.0')
     void activeChoiceParam(String parameterName, @DslContext(ActiveChoiceContext) Closure closure) {
         ActiveChoiceContext context = new ActiveChoiceContext()
         ContextHelper.executeInContext(closure, context)
@@ -255,7 +255,7 @@ class BuildParametersContext extends AbstractExtensibleContext {
      *
      * @since 1.38
      */
-    @RequiresPlugin(id = 'uno-choice', minimumVersion = '1.2')
+    @RequiresPlugin(id = 'uno-choice', minimumVersion = '2.0')
     void activeChoiceReactiveParam(String parameterName,
                                    @DslContext(ActiveChoiceReactiveContext) Closure closure = null) {
         ActiveChoiceReactiveContext context = new ActiveChoiceReactiveContext()
@@ -275,7 +275,7 @@ class BuildParametersContext extends AbstractExtensibleContext {
      *
      * @since 1.38
      */
-    @RequiresPlugin(id = 'uno-choice', minimumVersion = '1.2')
+    @RequiresPlugin(id = 'uno-choice', minimumVersion = '2.0')
     void activeChoiceReactiveReferenceParam(String parameterName,
                                             @DslContext(ActiveChoiceReactiveReferenceContext) Closure closure = null) {
         ActiveChoiceReactiveReferenceContext context = new ActiveChoiceReactiveReferenceContext()

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/AbstractActiveChoiceContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/AbstractActiveChoiceContext.groovy
@@ -23,9 +23,14 @@ abstract class AbstractActiveChoiceContext implements Context {
         ActiveChoiceGroovyScriptContext context = new ActiveChoiceGroovyScriptContext()
         executeInContext(closure, context)
 
-        script = new NodeBuilder().script(class: 'org.biouno.unochoice.model.GroovyScript') {
-            delegate.script(context.script ?: '')
-            delegate.fallbackScript(context.fallbackScript ?: '')
+        if (context.secureScriptNode || context.secureFallbackScriptNode) {
+            script = new NodeBuilder().script(class: 'org.biouno.unochoice.model.GroovyScript')
+            script.children().addAll(context.secureScriptNode, context.secureFallbackScriptNode)
+        } else {
+            script = new NodeBuilder().script(class: 'org.biouno.unochoice.model.GroovyScript') {
+                delegate.script(context.script ?: '')
+                delegate.fallbackScript(context.fallbackScript ?: '')
+            }
         }
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/ActiveChoiceGroovyScriptContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/ActiveChoiceGroovyScriptContext.groovy
@@ -1,22 +1,56 @@
 package javaposse.jobdsl.dsl.helpers.parameter
 
 import javaposse.jobdsl.dsl.Context
+import javaposse.jobdsl.dsl.DslContext
+
+import static javaposse.jobdsl.dsl.ContextHelper.executeInContext
 
 class ActiveChoiceGroovyScriptContext implements Context {
     String script
     String fallbackScript
 
+    Node secureScriptNode
+    Node secureFallbackScriptNode
+
     /**
-     * Sets the script that will dynamically generate the parameter value options.
+     * Sets the script that will dynamically generate the parameter value options, sandbox is turned off,
+     * won't be used if secureScript or secureFallbackScript is specified.
      */
     void script(String script) {
         this.script = script
     }
 
     /**
-     * Provides alternate parameter value options in case the main script fails.
+     * Provides alternate parameter value options in case the main script fails, sandbox is turned off,
+     * won't be used if secureScript or secureFallbackScript is specified.
      */
     void fallbackScript(String fallbackScript) {
         this.fallbackScript = fallbackScript
+    }
+
+    /**
+     * Configure the script that will dynamically generate the parameter value options.
+     */
+    void secureScript(@DslContext(ActiveChoiceSecureGroovyScriptContext) Closure closure) {
+        ActiveChoiceSecureGroovyScriptContext context = new ActiveChoiceSecureGroovyScriptContext()
+        executeInContext(closure, context)
+
+        secureScriptNode = new NodeBuilder().secureScript {
+            delegate.script(context.script ?: '')
+            delegate.sandbox(context.sandbox ?: false)
+        }
+    }
+
+    /**
+     * Configure the fallback script in case the main script fails.
+     */
+    void secureFallbackScript(@DslContext(ActiveChoiceSecureGroovyScriptContext) Closure closure) {
+        ActiveChoiceSecureGroovyScriptContext context = new ActiveChoiceSecureGroovyScriptContext()
+        executeInContext(closure, context)
+
+        secureFallbackScriptNode = new NodeBuilder().secureFallbackScript {
+            delegate.script(context.script ?: '')
+            delegate.sandbox(context.sandbox ?: false)
+        }
     }
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/ActiveChoiceSecureGroovyScriptContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/parameter/ActiveChoiceSecureGroovyScriptContext.groovy
@@ -1,0 +1,22 @@
+package javaposse.jobdsl.dsl.helpers.parameter
+
+import javaposse.jobdsl.dsl.Context
+
+class ActiveChoiceSecureGroovyScriptContext implements Context {
+    String script
+    boolean sandbox
+
+    /**
+     * Sets the script to dynamically generate the value options.
+     */
+    void script(String script) {
+        this.script = script
+    }
+
+    /**
+     * Enables or disables the Groovy sandbox for the provided script. Will default to false when omitted.
+     */
+    void sandbox(boolean sandbox) {
+        this.sandbox = sandbox
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy
@@ -1004,7 +1004,7 @@ class BuildParametersContextSpec extends Specification {
             choiceType.text() == 'PT_SINGLE_SELECT'
             filterable.text() == 'false'
         }
-        1 * jobManagement.requireMinimumPluginVersion('uno-choice', '1.2')
+        1 * jobManagement.requireMinimumPluginVersion('uno-choice', '2.0')
     }
 
     def 'active choice param with all options and groovy script'() {
@@ -1036,7 +1036,52 @@ class BuildParametersContextSpec extends Specification {
                 fallbackScript.text() == 'x2'
             }
         }
-        1 * jobManagement.requireMinimumPluginVersion('uno-choice', '1.2')
+        1 * jobManagement.requireMinimumPluginVersion('uno-choice', '2.0')
+    }
+
+    def 'active choice param with all options and groovy secure script'() {
+        when:
+        context.activeChoiceParam('activeChoiceGroovyParam') {
+            description('Active choice param test/groovy secure script')
+            filterable()
+            choiceType('MULTI_SELECT')
+            groovyScript {
+                secureScript {
+                    script('x1')
+                    sandbox(true)
+                }
+                secureFallbackScript {
+                    script('x2')
+                }
+            }
+        }
+
+        then:
+        with(context.buildParameterNodes['activeChoiceGroovyParam']) {
+            name() == 'org.biouno.unochoice.ChoiceParameter'
+            children().size() == 7
+            name.text() == 'activeChoiceGroovyParam'
+            description.text() == 'Active choice param test/groovy secure script'
+            randomName.text() =~ /choice-parameter-\d+/
+            visibleItemCount.text() == '1'
+            choiceType.text() == 'PT_MULTI_SELECT'
+            filterable.text() == 'true'
+            with(script[0]) {
+                attributes()['class'] == 'org.biouno.unochoice.model.GroovyScript'
+                children().size() == 2
+                with(secureScript) {
+                    children().size() == 2
+                    script.text() == 'x1'
+                    sandbox.text() == 'true'
+                }
+                with(secureFallbackScript) {
+                    children().size() == 2
+                    script.text() == 'x2'
+                    sandbox.text() == 'false'
+                }
+            }
+        }
+        1 * jobManagement.requireMinimumPluginVersion('uno-choice', '2.0')
     }
 
     def 'active choice reactive param without options'() {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

A new test for the changes is present in the `job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/helpers/BuildParametersContextSpec.groovy` file.

The new example in this PR generates the following config.xml:
```xml
<?xml version="1.0" encoding="UTF-8"?><project>
    <actions/>
    <description/>
    <keepDependencies>false</keepDependencies>
    <properties>
        <hudson.model.ParametersDefinitionProperty>
            <parameterDefinitions>
                <org.biouno.unochoice.ChoiceParameter>
                    <name>CHOICE-1</name>
                    <description>Allows user choose from multiple choices</description>
                    <randomName>choice-parameter-594689523327784</randomName>
                    <visibleItemCount>1</visibleItemCount>
                    <script class="org.biouno.unochoice.model.GroovyScript">
                        <script>["choice1", "choice2"]</script>
                        <fallbackScript>"fallback choice"</fallbackScript>
                    </script>
                    <filterable>true</filterable>
                    <choiceType>PT_SINGLE_SELECT</choiceType>
                </org.biouno.unochoice.ChoiceParameter>
                <org.biouno.unochoice.ChoiceParameter>
                    <name>CHOICE-2</name>
                    <description>Allows user choose from multiple choices with sandbox enabled</description>
                    <randomName>choice-parameter-594689525631250</randomName>
                    <visibleItemCount>1</visibleItemCount>
                    <script class="org.biouno.unochoice.model.GroovyScript">
                        <secureScript>
                            <script>["choice1", "choice2"]</script>
                            <sandbox>true</sandbox>
                        </secureScript>
                        <secureFallbackScript>
                            <script>"fallback choice"</script>
                            <sandbox>true</sandbox>
                        </secureFallbackScript>
                    </script>
                    <filterable>true</filterable>
                    <choiceType>PT_SINGLE_SELECT</choiceType>
                </org.biouno.unochoice.ChoiceParameter>
            </parameterDefinitions>
        </hudson.model.ParametersDefinitionProperty>
    </properties>
    <scm class="hudson.scm.NullSCM"/>
    <canRoam>true</canRoam>
    <disabled>false</disabled>
    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
    <triggers/>
    <concurrentBuild>false</concurrentBuild>
    <builders/>
    <publishers/>
    <buildWrappers/>
</project>
```
(tested with Jenkins 2.541.1)

The result looks like this:
<img width="2032" height="820" alt="image" src="https://github.com/user-attachments/assets/5d00961d-bb6a-4dd8-ae18-11c4733fa9e5" />
- The first parameter is empty because the sandbox is off by default - I did not approve the script - this might be desired by some people and is how it worked before the changes in this PR
- The second parameter is populated by default (because the script ran in a Groovy sandbox)

I have also bumped the minimum version to 2.0 as I cannot see older version in the [update center](https://updates.jenkins.io/download/plugins/uno-choice/)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
