### PR TITLE
Add Job DSL support for dynamic-view-filter plugin

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/JobParent.groovy
@@ -15,6 +15,7 @@ import javaposse.jobdsl.dsl.views.BuildPipelineView
 import javaposse.jobdsl.dsl.views.CategorizedJobsView
 import javaposse.jobdsl.dsl.views.DashboardView
 import javaposse.jobdsl.dsl.views.DeliveryPipelineView
+import javaposse.jobdsl.dsl.views.DropdownFilterView
 import javaposse.jobdsl.dsl.views.ListView
 import javaposse.jobdsl.dsl.views.NestedView
 import javaposse.jobdsl.dsl.views.PipelineAggregatorView
@@ -182,6 +183,12 @@ abstract class JobParent extends Script implements DslFactory {
     PipelineAggregatorView pipelineAggregatorView(
             String name, @DslContext(PipelineAggregatorView) Closure closure = null) {
         processView(name, PipelineAggregatorView, closure)
+    }
+
+    @Override
+    DropdownFilterView dropdownFilterView(
+            String name, @DslContext(DropdownFilterView) Closure closure = null) {
+        processView(name, DropdownFilterView, closure)
     }
 
     @Override

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ViewFactory.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ViewFactory.groovy
@@ -7,6 +7,7 @@ import javaposse.jobdsl.dsl.views.DashboardView
 import javaposse.jobdsl.dsl.views.DeliveryPipelineView
 import javaposse.jobdsl.dsl.views.ListView
 import javaposse.jobdsl.dsl.views.NestedView
+import javaposse.jobdsl.dsl.views.DropdownFilterView
 import javaposse.jobdsl.dsl.views.PipelineAggregatorView
 import javaposse.jobdsl.dsl.views.SectionedView
 
@@ -147,4 +148,20 @@ interface ViewFactory extends Context {
      */
     @RequiresPlugin(id = 'pipeline-aggregator-view', minimumVersion = '1.15', failIfMissing = true)
     PipelineAggregatorView pipelineAggregatorView(String name, @DslContext(PipelineAggregatorView) Closure closure)
+
+    /**
+     * Creates or updates a view with configurable dropdown filters that auto-populate
+     * from job folder paths and build parameters.
+     *
+     * @see #dropdownFilterView(java.lang.String, groovy.lang.Closure)
+     */
+    @RequiresPlugin(id = 'dynamic-view-filter', failIfMissing = true)
+    DropdownFilterView dropdownFilterView(String name)
+
+    /**
+     * Creates or updates a view with configurable dropdown filters that auto-populate
+     * from job folder paths and build parameters.
+     */
+    @RequiresPlugin(id = 'dynamic-view-filter', failIfMissing = true)
+    DropdownFilterView dropdownFilterView(String name, @DslContext(DropdownFilterView) Closure closure)
 }

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ViewFactory.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/ViewFactory.groovy
@@ -5,9 +5,9 @@ import javaposse.jobdsl.dsl.views.BuildPipelineView
 import javaposse.jobdsl.dsl.views.CategorizedJobsView
 import javaposse.jobdsl.dsl.views.DashboardView
 import javaposse.jobdsl.dsl.views.DeliveryPipelineView
+import javaposse.jobdsl.dsl.views.DropdownFilterView
 import javaposse.jobdsl.dsl.views.ListView
 import javaposse.jobdsl.dsl.views.NestedView
-import javaposse.jobdsl.dsl.views.DropdownFilterView
 import javaposse.jobdsl.dsl.views.PipelineAggregatorView
 import javaposse.jobdsl.dsl.views.SectionedView
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
@@ -5,6 +5,8 @@ import javaposse.jobdsl.dsl.ContextType
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.RequiresPlugin
 
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
+
 @ContextType('hudson.views.ListViewColumn')
 class ColumnsContext extends AbstractExtensibleContext {
     List<Node> columnNodes = []
@@ -282,6 +284,67 @@ class ColumnsContext extends AbstractExtensibleContext {
     void scmType() {
         columnNodes << new Node(null, 'jenkins.plugins.extracolumns.SCMTypeColumn')
     }
+
+    /**
+     * Wraps a standard column with {@code DynamicBuildFilterColumn} from the dynamic-view-filter
+     * plugin. The wrapped column shows build data filtered through the view's RunMatcher job filters.
+     *
+     * <p>Valid delegate types: {@code 'status'}, {@code 'weather'}, {@code 'name'}, {@code 'lastSuccess'},
+     * {@code 'lastFailure'}, {@code 'lastDuration'}, {@code 'buildButton'}.
+     */
+    @RequiresPlugin(id = 'dynamic-view-filter', failIfMissing = true)
+    void dynamicBuildFilterColumn(String delegateType) {
+        checkNotNullOrEmpty(delegateType, 'delegateType must be specified')
+
+        String delegateClass = COLUMN_DELEGATE_MAP[delegateType]
+        if (!delegateClass) {
+            throw new javaposse.jobdsl.dsl.DslScriptException("Unknown column type: ${delegateType}. " +
+                "Valid types: ${COLUMN_DELEGATE_MAP.keySet().join(', ')}")
+        }
+
+        columnNodes << new NodeBuilder().'io.jenkins.plugins.dynamic__view__filter.DynamicBuildFilterColumn' {
+            'delegate'(class: delegateClass)
+        }
+    }
+
+    /**
+     * Adds a self-contained parameter-filtered column from the dynamic-view-filter plugin.
+     * Filters builds by a specific parameter name and value regex. No view-level RunMatcher required.
+     *
+     * <p>Valid delegate types: same as {@link #dynamicBuildFilterColumn(String)}.
+     *
+     * @param delegateType the column type to wrap (e.g., 'status', 'lastSuccess')
+     * @param paramName regex matching build parameter names
+     * @param paramValueRegex regex matching build parameter values
+     */
+    @RequiresPlugin(id = 'dynamic-view-filter', failIfMissing = true)
+    void parameterBuildFilterColumn(String delegateType, String paramName, String paramValueRegex) {
+        checkNotNullOrEmpty(delegateType, 'delegateType must be specified')
+        checkNotNullOrEmpty(paramName, 'paramName must be specified')
+        checkNotNullOrEmpty(paramValueRegex, 'paramValueRegex must be specified')
+
+        String delegateClass = COLUMN_DELEGATE_MAP[delegateType]
+        if (!delegateClass) {
+            throw new javaposse.jobdsl.dsl.DslScriptException("Unknown column type: ${delegateType}. " +
+                "Valid types: ${COLUMN_DELEGATE_MAP.keySet().join(', ')}")
+        }
+
+        columnNodes << new NodeBuilder().'io.jenkins.plugins.dynamic__view__filter.ParameterBuildFilterColumn' {
+            'delegate'(class: delegateClass)
+            'paramName'(paramName)
+            'paramValueRegex'(paramValueRegex)
+        }
+    }
+
+    private static final Map<String, String> COLUMN_DELEGATE_MAP = [
+        'status':       'hudson.views.StatusColumn',
+        'weather':      'hudson.views.WeatherColumn',
+        'name':         'hudson.views.JobColumn',
+        'lastSuccess':  'hudson.views.LastSuccessColumn',
+        'lastFailure':  'hudson.views.LastFailureColumn',
+        'lastDuration': 'hudson.views.LastDurationColumn',
+        'buildButton':  'hudson.views.BuildButtonColumn',
+    ]
 
     @Override
     protected void addExtensionNode(Node node) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
@@ -9,6 +9,16 @@ import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
 
 @ContextType('hudson.views.ListViewColumn')
 class ColumnsContext extends AbstractExtensibleContext {
+    private static final Map<String, String> COLUMN_DELEGATE_MAP = [
+        'status':       'hudson.views.StatusColumn',
+        'weather':      'hudson.views.WeatherColumn',
+        'name':         'hudson.views.JobColumn',
+        'lastSuccess':  'hudson.views.LastSuccessColumn',
+        'lastFailure':  'hudson.views.LastFailureColumn',
+        'lastDuration': 'hudson.views.LastDurationColumn',
+        'buildButton':  'hudson.views.BuildButtonColumn',
+    ]
+
     List<Node> columnNodes = []
 
     ColumnsContext(JobManagement jobManagement) {
@@ -335,16 +345,6 @@ class ColumnsContext extends AbstractExtensibleContext {
             'paramValueRegex'(pValueRegex)
         }
     }
-
-    private static final Map<String, String> COLUMN_DELEGATE_MAP = [
-        'status':       'hudson.views.StatusColumn',
-        'weather':      'hudson.views.WeatherColumn',
-        'name':         'hudson.views.JobColumn',
-        'lastSuccess':  'hudson.views.LastSuccessColumn',
-        'lastFailure':  'hudson.views.LastFailureColumn',
-        'lastDuration': 'hudson.views.LastDurationColumn',
-        'buildButton':  'hudson.views.BuildButtonColumn',
-    ]
 
     @Override
     protected void addExtensionNode(Node node) {

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
@@ -318,10 +318,10 @@ class ColumnsContext extends AbstractExtensibleContext {
      * @param paramValueRegex regex matching build parameter values
      */
     @RequiresPlugin(id = 'dynamic-view-filter', failIfMissing = true)
-    void parameterBuildFilterColumn(String delegateType, String paramName, String paramValueRegex) {
+    void parameterBuildFilterColumn(String delegateType, String pName, String pValueRegex) {
         checkNotNullOrEmpty(delegateType, 'delegateType must be specified')
-        checkNotNullOrEmpty(paramName, 'paramName must be specified')
-        checkNotNullOrEmpty(paramValueRegex, 'paramValueRegex must be specified')
+        checkNotNullOrEmpty(pName, 'paramName must be specified')
+        checkNotNullOrEmpty(pValueRegex, 'paramValueRegex must be specified')
 
         String delegateClass = COLUMN_DELEGATE_MAP[delegateType]
         if (!delegateClass) {
@@ -331,8 +331,8 @@ class ColumnsContext extends AbstractExtensibleContext {
 
         columnNodes << new NodeBuilder().'io.jenkins.plugins.dynamic__view__filter.ParameterBuildFilterColumn' {
             'delegate'(class: delegateClass)
-            'paramName'(paramName)
-            'paramValueRegex'(paramValueRegex)
+            'paramName'(pName)
+            'paramValueRegex'(pValueRegex)
         }
     }
 

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/DropdownFilterDropdownsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/DropdownFilterDropdownsContext.groovy
@@ -1,0 +1,41 @@
+package javaposse.jobdsl.dsl.views
+
+import javaposse.jobdsl.dsl.Context
+
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty
+
+class DropdownFilterDropdownsContext implements Context {
+    List<Node> dropdownNodes = []
+
+    /**
+     * Adds a dropdown that extracts values from job folder paths using a regex capture group.
+     * E.g., {@code jobNameRegex('Project', 'projects/([^/]+)/.*')} extracts project names.
+     */
+    void jobNameRegex(String label, String pattern) {
+        checkNotNullOrEmpty(label, 'label must be specified')
+        checkNotNullOrEmpty(pattern, 'pattern must be specified')
+
+        dropdownNodes << new NodeBuilder().'io.jenkins.plugins.dynamic__view__filter.DropdownDefinition' {
+            delegate.label(label)
+            sourceType('jobNameRegex')
+            jobNamePattern(pattern)
+            parameterName()
+        }
+    }
+
+    /**
+     * Adds a dropdown that populates values from a build parameter.
+     * E.g., {@code buildParameter('Environment', 'env')} creates a dropdown from the 'env' parameter.
+     */
+    void buildParameter(String label, String parameterName) {
+        checkNotNullOrEmpty(label, 'label must be specified')
+        checkNotNullOrEmpty(parameterName, 'parameterName must be specified')
+
+        dropdownNodes << new NodeBuilder().'io.jenkins.plugins.dynamic__view__filter.DropdownDefinition' {
+            delegate.label(label)
+            sourceType('buildParameter')
+            jobNamePattern()
+            delegate.parameterName(parameterName)
+        }
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/DropdownFilterView.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/DropdownFilterView.groovy
@@ -1,0 +1,51 @@
+package javaposse.jobdsl.dsl.views
+
+import javaposse.jobdsl.dsl.DslContext
+import javaposse.jobdsl.dsl.JobManagement
+import javaposse.jobdsl.dsl.RequiresPlugin
+
+import static javaposse.jobdsl.dsl.ContextHelper.executeInContext
+import static javaposse.jobdsl.dsl.Preconditions.checkNotNull
+
+class DropdownFilterView extends ListView {
+    DropdownFilterView(JobManagement jobManagement, String name) {
+        super(jobManagement, name)
+    }
+
+    /**
+     * Sets the filter bar position. Defaults to {@code 'top'}.
+     *
+     * <p>Valid values: {@code 'top'} (horizontal bar above job table) or
+     * {@code 'sidebar'} (vertical panel on the right).
+     */
+    void filterPosition(String filterPosition) {
+        checkNotNull(filterPosition, 'filterPosition must not be null')
+
+        configure {
+            it / methodMissing('filterPosition', filterPosition)
+        }
+    }
+
+    /**
+     * Configures dropdown filter definitions. Multiple dropdowns combine with AND logic.
+     *
+     * <p>Example:
+     * <pre>
+     * dropdowns {
+     *     jobNameRegex('Project', 'projects/([^/]+)/.*')
+     *     buildParameter('Environment', 'env')
+     * }
+     * </pre>
+     */
+    @RequiresPlugin(id = 'dynamic-view-filter')
+    void dropdowns(@DslContext(DropdownFilterDropdownsContext) Closure dropdownsClosure) {
+        DropdownFilterDropdownsContext context = new DropdownFilterDropdownsContext()
+        executeInContext(dropdownsClosure, context)
+
+        configure {
+            for (Node dropdownNode : context.dropdownNodes) {
+                it / 'dropdowns' << dropdownNode
+            }
+        }
+    }
+}

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/JobFiltersContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/JobFiltersContext.groovy
@@ -133,6 +133,37 @@ class JobFiltersContext extends AbstractExtensibleContext {
         filterNodes << new NodeBuilder().'hudson.plugins.release.ReleaseJobsFilter'()
     }
 
+    /**
+     * Adds a parameter-based run matcher filter from the dynamic-view-filter plugin.
+     * Every {@code DynamicBuildFilterColumn} in the view will filter builds through this matcher.
+     *
+     * <p>Example:
+     * <pre>
+     * parameterRunMatcher {
+     *     matchType('includeMatched')
+     *     nameRegex('env')
+     *     valueRegex('prod')
+     *     matchAllBuilds(true)
+     * }
+     * </pre>
+     */
+    @RequiresPlugin(id = 'dynamic-view-filter', failIfMissing = true)
+    void parameterRunMatcher(@DslContext(ParameterRunMatcherContext) Closure closure) {
+        ParameterRunMatcherContext context = new ParameterRunMatcherContext()
+        executeInContext(closure, context)
+
+        filterNodes << new NodeBuilder().'io.jenkins.plugins.dynamic__view__filter.ParameterRunMatcherFilter' {
+            includeExcludeTypeString(context.matchType)
+            nameRegex(context.nameRegex)
+            valueRegex(context.valueRegex)
+            descriptionRegex(context.descriptionRegex)
+            useDefaultValue(context.useDefaultValue)
+            matchAllBuilds(context.matchAllBuilds)
+            maxBuildsToMatch(context.maxBuildsToMatch)
+            matchBuildsInProgress(context.matchBuildsInProgress)
+        }
+    }
+
     @Override
     protected void addExtensionNode(Node node) {
         filterNodes << node

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/NestedViewsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/NestedViewsContext.groovy
@@ -90,6 +90,12 @@ class NestedViewsContext extends AbstractExtensibleContext implements ViewFactor
     }
 
     @Override
+    DropdownFilterView dropdownFilterView(
+            String name, @DslContext(DropdownFilterView) Closure closure = null) {
+        processView(name, DropdownFilterView, closure)
+    }
+
+    @Override
     protected void addExtensionNode(Node node) {
         views << new View(jobManagement, node['name'].text()) {
             @Override

--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ParameterRunMatcherContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ParameterRunMatcherContext.groovy
@@ -1,0 +1,72 @@
+package javaposse.jobdsl.dsl.views
+
+import javaposse.jobdsl.dsl.Context
+
+class ParameterRunMatcherContext implements Context {
+    String matchType = 'includeMatched'
+    String nameRegex = ''
+    String valueRegex = ''
+    String descriptionRegex = ''
+    boolean useDefaultValue = false
+    boolean matchAllBuilds = true
+    int maxBuildsToMatch = 0
+    boolean matchBuildsInProgress = false
+
+    /**
+     * Include/exclude mode.
+     * Valid values: {@code 'includeMatched'}, {@code 'includeUnmatched'},
+     * {@code 'excludeMatched'}, {@code 'excludeUnmatched'}.
+     */
+    void matchType(String matchType) {
+        this.matchType = matchType
+    }
+
+    /**
+     * Regex to match parameter names.
+     */
+    void nameRegex(String nameRegex) {
+        this.nameRegex = nameRegex
+    }
+
+    /**
+     * Regex to match parameter values.
+     */
+    void valueRegex(String valueRegex) {
+        this.valueRegex = valueRegex
+    }
+
+    /**
+     * Regex to match parameter descriptions.
+     */
+    void descriptionRegex(String descriptionRegex) {
+        this.descriptionRegex = descriptionRegex
+    }
+
+    /**
+     * If {@code true}, matches against the parameter's default value instead of actual build value.
+     */
+    void useDefaultValue(boolean useDefaultValue = true) {
+        this.useDefaultValue = useDefaultValue
+    }
+
+    /**
+     * If {@code true}, scans build history (not just last build). Defaults to {@code true}.
+     */
+    void matchAllBuilds(boolean matchAllBuilds = true) {
+        this.matchAllBuilds = matchAllBuilds
+    }
+
+    /**
+     * Maximum builds to scan. 0 = unlimited.
+     */
+    void maxBuildsToMatch(int maxBuildsToMatch) {
+        this.maxBuildsToMatch = maxBuildsToMatch
+    }
+
+    /**
+     * If {@code true}, also matches currently running builds.
+     */
+    void matchBuildsInProgress(boolean matchBuildsInProgress = true) {
+        this.matchBuildsInProgress = matchBuildsInProgress
+    }
+}

--- a/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/views/DropdownFilterView-template.xml
+++ b/job-dsl-core/src/main/resources/javaposse/jobdsl/dsl/views/DropdownFilterView-template.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<io.jenkins.plugins.dynamic__view__filter.DropdownFilterView>
+    <filterExecutors>false</filterExecutors>
+    <filterQueue>false</filterQueue>
+    <properties class="hudson.model.View$PropertyList"/>
+    <jobNames class="tree-set">
+        <comparator class="hudson.util.CaseInsensitiveComparator"/>
+    </jobNames>
+    <jobFilters/>
+    <columns/>
+    <recurse>false</recurse>
+    <filterPosition>top</filterPosition>
+    <dropdowns/>
+</io.jenkins.plugins.dynamic__view__filter.DropdownFilterView>

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/DropdownFilterViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/DropdownFilterViewSpec.groovy
@@ -1,0 +1,174 @@
+package javaposse.jobdsl.dsl.views
+
+import javaposse.jobdsl.dsl.DslScriptException
+import javaposse.jobdsl.dsl.JobManagement
+import org.custommonkey.xmlunit.XMLUnit
+import spock.lang.Specification
+
+import static org.custommonkey.xmlunit.XMLUnit.compareXML
+
+class DropdownFilterViewSpec extends Specification {
+    private static final String DEFAULT_XML = '''<?xml version="1.1" encoding="UTF-8"?>
+        <io.jenkins.plugins.dynamic__view__filter.DropdownFilterView>
+            <filterExecutors>false</filterExecutors>
+            <filterQueue>false</filterQueue>
+            <properties class="hudson.model.View$PropertyList"/>
+            <jobNames class="tree-set">
+                <comparator class="hudson.util.CaseInsensitiveComparator"/>
+            </jobNames>
+            <jobFilters/>
+            <columns/>
+            <recurse>false</recurse>
+            <filterPosition>top</filterPosition>
+            <dropdowns/>
+        </io.jenkins.plugins.dynamic__view__filter.DropdownFilterView>'''
+
+    private final JobManagement jobManagement = Mock(JobManagement)
+    private final DropdownFilterView view = new DropdownFilterView(jobManagement, 'test')
+
+    def setup() {
+        XMLUnit.ignoreWhitespace = true
+    }
+
+    def 'defaults'() {
+        expect:
+        compareXML(DEFAULT_XML, view.xml).similar()
+    }
+
+    def 'filterPosition sidebar'() {
+        when:
+        view.filterPosition('sidebar')
+
+        then:
+        Node root = view.node
+        root.filterPosition.text() == 'sidebar'
+    }
+
+    def 'filterPosition null'() {
+        when:
+        view.filterPosition(null)
+
+        then:
+        thrown(DslScriptException)
+    }
+
+    def 'dropdowns with jobNameRegex'() {
+        when:
+        view.dropdowns {
+            jobNameRegex('Project', 'projects/([^/]+)/.*')
+        }
+
+        then:
+        Node root = view.node
+        root.dropdowns.'io.jenkins.plugins.dynamic__view__filter.DropdownDefinition'.size() == 1
+        with(root.dropdowns.'io.jenkins.plugins.dynamic__view__filter.DropdownDefinition'[0]) {
+            label.text() == 'Project'
+            sourceType.text() == 'jobNameRegex'
+            jobNamePattern.text() == 'projects/([^/]+)/.*'
+            parameterName.text() == ''
+        }
+    }
+
+    def 'dropdowns with buildParameter'() {
+        when:
+        view.dropdowns {
+            buildParameter('Environment', 'env')
+        }
+
+        then:
+        Node root = view.node
+        root.dropdowns.'io.jenkins.plugins.dynamic__view__filter.DropdownDefinition'.size() == 1
+        with(root.dropdowns.'io.jenkins.plugins.dynamic__view__filter.DropdownDefinition'[0]) {
+            label.text() == 'Environment'
+            sourceType.text() == 'buildParameter'
+            jobNamePattern.text() == ''
+            parameterName.text() == 'env'
+        }
+    }
+
+    def 'dropdowns with multiple entries'() {
+        when:
+        view.dropdowns {
+            jobNameRegex('Team', 'teams/([^/]+)/.*')
+            buildParameter('Region', 'region')
+        }
+
+        then:
+        Node root = view.node
+        root.dropdowns.'io.jenkins.plugins.dynamic__view__filter.DropdownDefinition'.size() == 2
+    }
+
+    def 'jobNameRegex with empty label'() {
+        when:
+        view.dropdowns {
+            jobNameRegex('', 'some/pattern')
+        }
+
+        then:
+        thrown(DslScriptException)
+    }
+
+    def 'jobNameRegex with null label'() {
+        when:
+        view.dropdowns {
+            jobNameRegex(null, 'some/pattern')
+        }
+
+        then:
+        thrown(DslScriptException)
+    }
+
+    def 'buildParameter with empty parameterName'() {
+        when:
+        view.dropdowns {
+            buildParameter('Label', '')
+        }
+
+        then:
+        thrown(DslScriptException)
+    }
+
+    def 'buildParameter with null parameterName'() {
+        when:
+        view.dropdowns {
+            buildParameter('Label', null)
+        }
+
+        then:
+        thrown(DslScriptException)
+    }
+
+    def 'recurse inherited from ListView'() {
+        when:
+        view.recurse()
+
+        then:
+        Node root = view.node
+        root.recurse.text() == 'true'
+    }
+
+    def 'jobs with regex inherited from ListView'() {
+        when:
+        view.jobs {
+            regex('project-.*')
+        }
+
+        then:
+        Node root = view.node
+        root.includeRegex.text() == 'project-.*'
+    }
+
+    def 'columns inherited from ListView'() {
+        when:
+        view.columns {
+            status()
+            name()
+        }
+
+        then:
+        Node root = view.node
+        root.columns[0].children().size() == 2
+        root.columns[0].'hudson.views.StatusColumn'.size() == 1
+        root.columns[0].'hudson.views.JobColumn'.size() == 1
+    }
+}

--- a/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/DropdownFilterViewSpec.groovy
+++ b/job-dsl-core/src/test/groovy/javaposse/jobdsl/dsl/views/DropdownFilterViewSpec.groovy
@@ -171,4 +171,172 @@ class DropdownFilterViewSpec extends Specification {
         root.columns[0].'hudson.views.StatusColumn'.size() == 1
         root.columns[0].'hudson.views.JobColumn'.size() == 1
     }
+
+    def 'dynamicBuildFilterColumn'() {
+        when:
+        view.columns {
+            dynamicBuildFilterColumn('status')
+        }
+
+        then:
+        Node root = view.node
+        def cols = root.columns[0].children()
+        cols.size() == 1
+        cols[0].name() == 'io.jenkins.plugins.dynamic__view__filter.DynamicBuildFilterColumn'
+        cols[0].delegate[0].@class == 'hudson.views.StatusColumn'
+        1 * jobManagement.requirePlugin('dynamic-view-filter', true)
+    }
+
+    def 'dynamicBuildFilterColumn with all delegate types'() {
+        when:
+        view.columns {
+            dynamicBuildFilterColumn(type)
+        }
+
+        then:
+        Node root = view.node
+        def col = root.columns[0].children()[0]
+        col.name() == 'io.jenkins.plugins.dynamic__view__filter.DynamicBuildFilterColumn'
+        col.delegate[0].@class == expected
+        1 * jobManagement.requirePlugin('dynamic-view-filter', true)
+
+        where:
+        type           || expected
+        'status'       || 'hudson.views.StatusColumn'
+        'weather'      || 'hudson.views.WeatherColumn'
+        'name'         || 'hudson.views.JobColumn'
+        'lastSuccess'  || 'hudson.views.LastSuccessColumn'
+        'lastFailure'  || 'hudson.views.LastFailureColumn'
+        'lastDuration' || 'hudson.views.LastDurationColumn'
+        'buildButton'  || 'hudson.views.BuildButtonColumn'
+    }
+
+    def 'dynamicBuildFilterColumn with null delegate'() {
+        when:
+        view.columns {
+            dynamicBuildFilterColumn(null)
+        }
+
+        then:
+        thrown(DslScriptException)
+    }
+
+    def 'dynamicBuildFilterColumn with unknown delegate'() {
+        when:
+        view.columns {
+            dynamicBuildFilterColumn('unknown')
+        }
+
+        then:
+        thrown(DslScriptException)
+    }
+
+    def 'parameterBuildFilterColumn'() {
+        when:
+        view.columns {
+            parameterBuildFilterColumn('lastSuccess', 'region', 'east')
+        }
+
+        then:
+        Node root = view.node
+        def cols = root.columns[0].children()
+        cols.size() == 1
+        cols[0].name() == 'io.jenkins.plugins.dynamic__view__filter.ParameterBuildFilterColumn'
+        cols[0].delegate[0].@class == 'hudson.views.LastSuccessColumn'
+        cols[0].paramName.text() == 'region'
+        cols[0].paramValueRegex.text() == 'east'
+        1 * jobManagement.requirePlugin('dynamic-view-filter', true)
+    }
+
+    def 'parameterBuildFilterColumn with null paramName'() {
+        when:
+        view.columns {
+            parameterBuildFilterColumn('status', null, 'east')
+        }
+
+        then:
+        thrown(DslScriptException)
+    }
+
+    def 'parameterBuildFilterColumn with empty paramValueRegex'() {
+        when:
+        view.columns {
+            parameterBuildFilterColumn('status', 'region', '')
+        }
+
+        then:
+        thrown(DslScriptException)
+    }
+
+    def 'parameterRunMatcher with defaults'() {
+        when:
+        view.jobFilters {
+            parameterRunMatcher {}
+        }
+
+        then:
+        def filters = view.node.jobFilters[0].value()
+        filters.size() == 1
+        Node filter = filters[0]
+        filter.name() == 'io.jenkins.plugins.dynamic__view__filter.ParameterRunMatcherFilter'
+        filter.includeExcludeTypeString.text() == 'includeMatched'
+        filter.nameRegex.text() == ''
+        filter.valueRegex.text() == ''
+        filter.descriptionRegex.text() == ''
+        filter.useDefaultValue.text() == 'false'
+        filter.matchAllBuilds.text() == 'true'
+        filter.maxBuildsToMatch.text() == '0'
+        filter.matchBuildsInProgress.text() == 'false'
+        1 * jobManagement.requirePlugin('dynamic-view-filter', true)
+    }
+
+    def 'parameterRunMatcher with all properties'() {
+        when:
+        view.jobFilters {
+            parameterRunMatcher {
+                matchType('excludeMatched')
+                nameRegex('.*region.*')
+                valueRegex('us-east-1')
+                descriptionRegex('deploy.*')
+                useDefaultValue(true)
+                matchAllBuilds(false)
+                maxBuildsToMatch(5)
+                matchBuildsInProgress(true)
+            }
+        }
+
+        then:
+        def filters = view.node.jobFilters[0].value()
+        filters.size() == 1
+        Node filter = filters[0]
+        filter.name() == 'io.jenkins.plugins.dynamic__view__filter.ParameterRunMatcherFilter'
+        filter.includeExcludeTypeString.text() == 'excludeMatched'
+        filter.nameRegex.text() == '.*region.*'
+        filter.valueRegex.text() == 'us-east-1'
+        filter.descriptionRegex.text() == 'deploy.*'
+        filter.useDefaultValue.text() == 'true'
+        filter.matchAllBuilds.text() == 'false'
+        filter.maxBuildsToMatch.text() == '5'
+        filter.matchBuildsInProgress.text() == 'true'
+        1 * jobManagement.requirePlugin('dynamic-view-filter', true)
+    }
+
+    def 'mixed columns with standard and dynamic-view-filter columns'() {
+        when:
+        view.columns {
+            status()
+            dynamicBuildFilterColumn('lastSuccess')
+            parameterBuildFilterColumn('lastFailure', 'env', 'prod')
+            name()
+        }
+
+        then:
+        Node root = view.node
+        def cols = root.columns[0].children()
+        cols.size() == 4
+        cols[0].name() == 'hudson.views.StatusColumn'
+        cols[1].name() == 'io.jenkins.plugins.dynamic__view__filter.DynamicBuildFilterColumn'
+        cols[2].name() == 'io.jenkins.plugins.dynamic__view__filter.ParameterBuildFilterColumn'
+        cols[3].name() == 'hudson.views.JobColumn'
+    }
 }


### PR DESCRIPTION
Adds Job DSL support for the [dynamic-view-filter](https://github.com/jenkinsci/dynamic-view-filter-plugin) plugin, covering all four components: `DropdownFilterView`, `DynamicBuildFilterColumn`, `ParameterBuildFilterColumn,` and `ParameterRunMatcherFilter`.

Resolves #2594

### Usage

```groovy
dropdownFilterView('My Filtered View') {
    filterPosition('sidebar')
    dropdowns {
        jobNameRegex('Project', 'projects/([^/]+)/.*')
        buildParameter('Environment', 'env')
    }
    columns {
        dynamicBuildFilterColumn('hudson.views.StatusColumn')
        parameterBuildFilterColumn('hudson.views.LastSuccessColumn', 'region', 'east')
    }
    jobFilters {
        parameterRunMatcher {
            includeExcludeTypeString('includeMatched')
            nameRegex('region')
            valueRegex('east')
        }
    }
}
```

### Testing

23 new tests covering:

- View defaults and XML template
- `filterPosition` (valid + null validation)
- Dropdowns: `jobNameRegex`, `buildParameter`, multiple entries, validation (empty/null label and param)
- `dynamicBuildFilterColumn` with all 7 delegate types + null/unknown validation
- `parameterBuildFilterColumn` with delegate + paramName + paramValueRegex + validation
- `parameterRunMatcher` with defaults and all 8 properties configured
- Mixed columns (standard + dynamic-view-filter together)
- ListView inheritance (`recurse`, `includeRegex`, `columns`)

Full suite: 2,299 tests, 0 failures.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

