### PR TITLE
Allow up to 45 minutes for deploy

### DIFF
--- a/.github/workflows/api-viewer.yml
+++ b/.github/workflows/api-viewer.yml
@@ -66,3 +66,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+        with:
+          timeout: 2700000   # 45 min in ms


### PR DESCRIPTION
## Allow up to 45 minutes for deploy to GitHub pages

GitHub Copilot suggested:

Root cause: the failure is in the Pages deployment step, not in your build/test logic.

From the failing job logs:

> Current status: deployment_queued (repeated)
> Timeout reached, aborting!
> Canceling Pages deployment...

That means actions/deploy-pages waited in the GitHub Pages queue too long and timed out.

Targeted fix

Update .github/workflows/api-viewer.yml so the deploy step can wait longer
for queue delays, and prevent old queued runs from blocking newer ones.

### Testing done

None.  Rely on GitHub action to test it

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
